### PR TITLE
Add downstream upstream audit tooling

### DIFF
--- a/app/api/urlsource/route.js
+++ b/app/api/urlsource/route.js
@@ -1,9 +1,4 @@
 import { NextResponse } from "next/server";
-import {
-    AJE,
-    AJA,
-    getAxisUrl,
-} from "../../../app.config/config/transcribe/TranscribeUrlConstants";
 
 export const dynamic = "force-dynamic";
 
@@ -22,113 +17,77 @@ export async function GET(req) {
             );
         }
 
-        let searchQuery = urlInput;
-        let accountId = AJE; // AJE, AJA, etc.
-
-        //check if url is a valid youtube url
-        const youtubeRegex =
-            // eslint-disable-next-line no-useless-escape
-            /^(https?\:\/\/)?(www\.)?(youtube\.com|youtu\.?be)\/.+$/;
-        if (youtubeRegex.test(urlInput)) {
-            const oEmbedUrl = `https://www.youtube.com/oembed?url=${encodeURIComponent(urlInput)}&format=json`;
-            const response = await fetch(oEmbedUrl);
-            const data = await response.json();
-            searchQuery = data.title;
-
-            const channelId = data.author_url.split("@").pop();
-
-            if (channelId === "aljazeeraenglish") {
-                accountId = AJE;
-            } else if (channelId === "aljazeera") {
-                accountId = AJA;
-            } else {
-                return NextResponse.json(
-                    { error: "Unsupported YouTube channel" },
-                    { status: 400 },
-                );
-            }
-        } else {
-            //check if searchQuery has arabic characters
-            const arabicRegex = /[\u0600-\u06FF]/;
-            if (arabicRegex.test(searchQuery)) {
-                accountId = AJA;
-            }
+        if (isYoutubeUrl(urlInput)) {
+            return NextResponse.json(await getYoutubeResult(urlInput));
         }
 
-        const axisUrl = getAxisUrl(accountId, searchQuery);
-        const axisResponse = await fetch(axisUrl);
-        const axisData = await axisResponse.json();
-
-        const SIMILARITY_THRESHOLD = 0.1;
-        const MAX_RESULTS = 5; // Return up to 5 similar videos
-
-        // Find multiple similar items instead of just one
-        const similarItems = axisData.items
-            .map((item) => ({
-                item,
-                similarity: calculateSimilarity(searchQuery, item.name),
-            }))
-            .filter((result) => result.similarity > SIMILARITY_THRESHOLD)
-            .sort((a, b) => b.similarity - a.similarity)
-            .slice(0, MAX_RESULTS);
-
-        if (similarItems.length > 0) {
-            const results = similarItems.map(({ item }) => ({
-                title: searchQuery,
-                name: item.name,
-                url: getBestRenditionForTranscription(item),
-                videoUrl: getBestQualityRendition(item),
-                similarity: calculateSimilarity(searchQuery, item.name),
-            }));
-
-            return NextResponse.json({ results });
-        } else {
-            return NextResponse.json(
-                { error: "No matching videos found" },
-                // { status: 404 },
-            );
-        }
+        return NextResponse.json({
+            results: [
+                {
+                    name: urlInput,
+                    url: urlInput,
+                    videoUrl: urlInput,
+                    similarity: 1,
+                },
+            ],
+        });
     } catch (error) {
         console.error(error);
         return NextResponse.json({ error: error.message }, { status: 500 });
     }
 }
 
-// function findMostSimilarTitle(items, targetTitle) {
-//     return items.reduce(
-//         (best, current) => {
-//             const similarity = calculateSimilarity(targetTitle, current.name);
-//             return similarity > best.similarity
-//                 ? { item: current, similarity }
-//                 : best;
-//         },
-//         { item: null, similarity: 0 },
-//     );
-// }
+async function getYoutubeResult(urlInput) {
+    const videoId = extractYoutubeVideoId(urlInput);
+    const videoUrl = videoId
+        ? `https://www.youtube.com/embed/${videoId}`
+        : urlInput;
 
-function calculateSimilarity(str1, str2) {
-    const set1 = new Set(str1.toLowerCase().split(" "));
-    const set2 = new Set(str2.toLowerCase().split(" "));
-    const intersection = new Set([...set1].filter((x) => set2.has(x)));
-    return intersection.size / Math.max(set1.size, set2.size);
-}
-
-function getBestRenditionForTranscription(videoData) {
-    const audioRendition = videoData.renditions.find((r) => r.audioOnly);
-    if (audioRendition) return audioRendition.url;
-
-    const videoRenditions = videoData.renditions.filter((r) => !r.audioOnly);
-    if (videoRenditions.length > 0) {
-        return videoRenditions.reduce((best, current) =>
-            current.encodingRate < best.encodingRate ? current : best,
-        ).url;
+    let name = "YouTube video";
+    try {
+        const oEmbedUrl = `https://www.youtube.com/oembed?url=${encodeURIComponent(urlInput)}&format=json`;
+        const response = await fetch(oEmbedUrl);
+        if (response.ok) {
+            const data = await response.json();
+            name = data.title || name;
+        }
+    } catch {
+        // Best-effort title lookup only; the source URL is still usable.
     }
 
-    return videoData.FLVURL || null;
+    return {
+        results: [
+            {
+                name,
+                url: urlInput,
+                videoUrl,
+                similarity: 1,
+                isYouTube: true,
+                fromExternalChannel: true,
+            },
+        ],
+    };
 }
 
-function getBestQualityRendition(videoData) {
-    return videoData.renditions.reduce((best, current) =>
-        current.encodingRate > best.encodingRate ? current : best,
-    ).url;
+function isYoutubeUrl(urlInput) {
+    try {
+        const url = new URL(urlInput);
+        return ["youtube.com", "www.youtube.com", "youtu.be"].includes(
+            url.hostname,
+        );
+    } catch {
+        return false;
+    }
+}
+
+function extractYoutubeVideoId(urlInput) {
+    try {
+        const url = new URL(urlInput);
+        if (url.hostname === "youtu.be") {
+            return url.pathname.slice(1) || null;
+        }
+        return url.searchParams.get("v");
+    } catch {
+        return null;
+    }
 }

--- a/docs/upstream-audit.md
+++ b/docs/upstream-audit.md
@@ -1,0 +1,70 @@
+# Upstream Audit
+
+Use the upstream audit command before porting changes from a downstream fork or
+private distribution back into Concierge. The command is intentionally read-only:
+it does not merge, commit, push, open a browser, or create a pull request.
+
+## Basic Use
+
+```sh
+npm run upstream:audit -- --source-url ../my-downstream-fork --source-branch main
+```
+
+The command compares the downstream source with the current Concierge checkout,
+then reports:
+
+- commit divergence
+- diff size and directory spread
+- changed files grouped by feature area
+- optional forbidden-pattern scan results
+
+## Forbidden Pattern Scans
+
+Keep organization-specific terms, internal hostnames, tenant IDs, and private
+deployment names outside this repository. For private audits, pass those checks
+in a local JSON file:
+
+```sh
+npm run upstream:audit -- \
+  --source-url ../my-downstream-fork \
+  --pattern-file ../private-upstream-patterns.json
+```
+
+Pattern file format:
+
+```json
+[
+    {
+        "id": "product-brand",
+        "severity": "blocker",
+        "pattern": "\\bExample Product\\b",
+        "flags": "i"
+    },
+    {
+        "id": "internal-secret-env",
+        "severity": "review",
+        "pattern": "\\b[A-Z0-9_]*SECRET\\b"
+    }
+]
+```
+
+Use `blocker` for findings that must be removed before a public pull request.
+Use `review` for findings that may be acceptable only after human inspection.
+
+## Staged Porting
+
+Do not port a large downstream diff as one pull request. Use the clusters in the
+audit report to create small, reviewable branches:
+
+- app shell, chat, and canvas architecture
+- file manager, storage, and scoped file access
+- applets, SDK, and shared data
+- media generation UI and worker plumbing
+- automations, connectors, and MCP
+- help, release notes, and user-facing docs
+- configuration, auth, and deployment cleanup
+
+For each branch, sanitize product names, sample content, environment variables,
+deployment configuration, and optional connector credentials as part of the same
+change. Validate with Concierge's own tests and build before opening the public
+pull request.

--- a/package-lock.json
+++ b/package-lock.json
@@ -4265,6 +4265,71 @@
                 "darwin"
             ]
         },
+        "node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.3.tgz",
+            "integrity": "sha512-mdzd3AVzYKuUmiWOQ8GNhl64/IoFGol569zNRdkLReh6LRLHOXxU4U8eq0JwaD8iFHdVGqSy4IjFL4reoWCDFw==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.3.tgz",
+            "integrity": "sha512-fg0uy/dG/nZEXfYilKoRe7yALaNmHoYeIoJuJ7KJ+YyU2bvY8vPv27f7UKhGRpY6euFYqEVhxCFZgAUNQBM3nw==",
+            "cpu": [
+                "arm"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.3.tgz",
+            "integrity": "sha512-YxQL+ax0XqBJDZiKimS2XQaf+2wDGVa1enVRGzEvLLVFeqa5kx2bWbtcSXgsxjQB7nRqqIGFIcLteF/sHeVtQg==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.3.tgz",
+            "integrity": "sha512-cvwNfbP07pKUfq1uH+S6KJ7dT9K8WOE4ZiAcsrSes+UY55E/0jLYc+vq+DO7jlmqRb5zAggExKm0H7O/CBaesg==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.3.tgz",
+            "integrity": "sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
         "node_modules/@next/env": {
             "version": "14.2.35",
             "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.35.tgz",
@@ -4518,6 +4583,27 @@
                 "@parcel/watcher-win32-x64": "2.5.1"
             }
         },
+        "node_modules/@parcel/watcher-android-arm64": {
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.1.tgz",
+            "integrity": "sha512-KF8+j9nNbUN8vzOFDpRMsaKBHZ/mcjEjMToVMJOhTozkDonQFFrRcfdLWn6yWKCmJKmdVxSgHiYvTCef4/qcBA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
         "node_modules/@parcel/watcher-darwin-arm64": {
             "version": "2.5.1",
             "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.1.tgz",
@@ -4530,6 +4616,255 @@
             "optional": true,
             "os": [
                 "darwin"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-darwin-x64": {
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.1.tgz",
+            "integrity": "sha512-1ZXDthrnNmwv10A0/3AJNZ9JGlzrF82i3gNQcWOzd7nJ8aj+ILyW1MTxVk35Db0u91oD5Nlk9MBiujMlwmeXZg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-freebsd-x64": {
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.1.tgz",
+            "integrity": "sha512-SI4eljM7Flp9yPuKi8W0ird8TI/JK6CSxju3NojVI6BjHsTyK7zxA9urjVjEKJ5MBYC+bLmMcbAWlZ+rFkLpJQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-linux-arm-glibc": {
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.1.tgz",
+            "integrity": "sha512-RCdZlEyTs8geyBkkcnPWvtXLY44BCeZKmGYRtSgtwwnHR4dxfHRG3gR99XdMEdQ7KeiDdasJwwvNSF5jKtDwdA==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-linux-arm-musl": {
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.1.tgz",
+            "integrity": "sha512-6E+m/Mm1t1yhB8X412stiKFG3XykmgdIOqhjWj+VL8oHkKABfu/gjFj8DvLrYVHSBNC+/u5PeNrujiSQ1zwd1Q==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-linux-arm64-glibc": {
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.1.tgz",
+            "integrity": "sha512-LrGp+f02yU3BN9A+DGuY3v3bmnFUggAITBGriZHUREfNEzZh/GO06FF5u2kx8x+GBEUYfyTGamol4j3m9ANe8w==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-linux-arm64-musl": {
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.1.tgz",
+            "integrity": "sha512-cFOjABi92pMYRXS7AcQv9/M1YuKRw8SZniCDw0ssQb/noPkRzA+HBDkwmyOJYp5wXcsTrhxO0zq1U11cK9jsFg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-linux-x64-glibc": {
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.1.tgz",
+            "integrity": "sha512-GcESn8NZySmfwlTsIur+49yDqSny2IhPeZfXunQi48DMugKeZ7uy1FX83pO0X22sHntJ4Ub+9k34XQCX+oHt2A==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-linux-x64-musl": {
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.1.tgz",
+            "integrity": "sha512-n0E2EQbatQ3bXhcH2D1XIAANAcTZkQICBPVaxMeaCVBtOpBZpWJuf7LwyWPSBDITb7In8mqQgJ7gH8CILCURXg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-win32-arm64": {
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.1.tgz",
+            "integrity": "sha512-RFzklRvmc3PkjKjry3hLF9wD7ppR4AKcWNzH7kXR7GUe0Igb3Nz8fyPwtZCSquGrhU5HhUNDr/mKBqj7tqA2Vw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-win32-ia32": {
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.1.tgz",
+            "integrity": "sha512-c2KkcVN+NJmuA7CGlaGD1qJh1cLfDnQsHjE89E60vUEMlqduHGCdCLJCID5geFVM0dOtA3ZiIO8BoEQmzQVfpQ==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-win32-x64": {
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.1.tgz",
+            "integrity": "sha512-9lHBdJITeNR++EvSQVUcaZoWupyHfXe1jZvGZ06O/5MflPcuPLtEphScIBL+AiCWBO46tDSHzWyD0uDmmZqsgA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
             ],
             "engines": {
                 "node": ">= 10.0.0"

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
         "dev:multiworker": "concurrently \"npm run next:dev\" \"npm run worker:dev\" \"npm run worker:dev\"",
         "next:dev": "npm run prebuild && next dev",
         "prebuild": "node ./scripts/prebuild.js",
+        "upstream:audit": "node ./scripts/upstream-audit.mjs",
         "build": "next build",
         "start": "next start",
         "lint": "next lint && npx prettier --check .",

--- a/scripts/upstream-audit.mjs
+++ b/scripts/upstream-audit.mjs
@@ -1,0 +1,562 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const ROOT_DIR = path.resolve(path.dirname(__filename), "..");
+
+const DEFAULT_SOURCE_REF = "refs/remotes/downstream/main";
+const DEFAULT_TARGET_REF = "HEAD";
+
+const DEFAULT_CLUSTERS = [
+    {
+        id: "app-shell-chat-canvas",
+        label: "App shell, chat, and canvas architecture",
+        prefixes: [
+            "app/chat/",
+            "app/home/",
+            "app/queries/",
+            "app/workspaces/",
+            "app/write/",
+            "app/api/chats/",
+            "app/api/workspaces/",
+            "src/components/chat/",
+            "src/components/canvas/",
+            "src/hooks/",
+            "src/layout/",
+        ],
+        includes: ["middleware.js", "next.config.js"],
+    },
+    {
+        id: "file-manager-storage",
+        label: "File manager, storage, and scoped file access",
+        prefixes: [
+            "app/api/files/",
+            "app/api/storage/",
+            "app/api/workspaces/[id]/files/",
+            "src/components/common/UnifiedFileManager/",
+            "src/components/files/",
+            "src/lib/files/",
+            "src/lib/storage/",
+        ],
+    },
+    {
+        id: "applets-sdk",
+        label: "Applets, SDK, and shared data",
+        prefixes: [
+            "app/applets/",
+            "app/api/applet/",
+            "app/api/applets/",
+            "app/api/canvas-applets/",
+            "app/api/generate-applet/",
+            "app/api/published/applets/",
+            "app/api/published/workspaces/",
+            "app/api/workspaces/[id]/applet/",
+            "src/applets/",
+            "src/components/applets/",
+            "src/lib/applets/",
+            "public/applets/",
+            "public/applet-sdk.js",
+        ],
+    },
+    {
+        id: "media-generation",
+        label: "Media generation UI and worker plumbing",
+        prefixes: [
+            "app/api/image-proxy/",
+            "app/api/media/",
+            "app/api/media-items/",
+            "app/api/media-proxy/",
+            "app/api/text-proxy/",
+            "jobs/",
+            "src/components/images/",
+            "src/components/media/",
+            "src/components/transcribe/",
+            "src/components/translate/",
+            "src/lib/media/",
+        ],
+    },
+    {
+        id: "automations-connectors-mcp",
+        label: "Automations, connectors, and MCP",
+        prefixes: [
+            "app/api/automations/",
+            "app/api/connectors/",
+            "app/api/mcp/",
+            "src/components/automations/",
+            "src/components/connectors/",
+            "src/lib/automations/",
+            "src/lib/connectors/",
+            "src/lib/mcp/",
+        ],
+    },
+    {
+        id: "docs-help-release-notes",
+        label: "Help, release notes, and user-facing docs",
+        prefixes: [
+            "docs/",
+            "src/content/help-guides/",
+            "src/content/release-notes/",
+            "README",
+        ],
+    },
+    {
+        id: "config-auth-deploy",
+        label: "Configuration, auth, and deployment",
+        prefixes: [
+            ".github/workflows/",
+            "app.config/",
+            "app/auth/",
+            "config/",
+            "__mocks__/config/",
+            "Dockerfile",
+            "infra/",
+        ],
+    },
+    {
+        id: "tests",
+        label: "Tests and fixtures",
+        prefixes: ["__tests__/", "tests/", "playwright/", "test/", "e2e/"],
+        includes: [".test.", ".spec.", "__tests__/"],
+    },
+];
+
+const SCAN_EXCLUDED_PATHS = new Set([
+    "package-lock.json",
+    "yarn.lock",
+    "pnpm-lock.yaml",
+]);
+const SCAN_EXCLUDED_EXTENSIONS = new Set([
+    ".gif",
+    ".ico",
+    ".jpeg",
+    ".jpg",
+    ".lock",
+    ".mp3",
+    ".mp4",
+    ".pdf",
+    ".png",
+    ".svg",
+    ".webp",
+]);
+
+const args = process.argv.slice(2);
+
+const options = {
+    allowDirty: false,
+    failOnReview: false,
+    fetch: true,
+    json: false,
+    out: null,
+    patternFile: null,
+    sourceBranch: "main",
+    sourceRef: DEFAULT_SOURCE_REF,
+    sourceUrl: null,
+    targetRef: DEFAULT_TARGET_REF,
+};
+
+const usage = () => {
+    console.log(`Usage: npm run upstream:audit -- [options]
+
+Compares a downstream source ref with this repository and reports divergence,
+file clusters, and optional forbidden-pattern findings. This command never
+merges, commits, pushes, opens a browser, or creates a pull request.
+
+Options:
+  --source-url <url>       Fetch source branch from this repository URL or path
+  --source-branch <name>   Source branch to fetch when --source-url is set
+  --source-ref <ref>       Source git ref to compare from
+  --target-ref <ref>       Target git ref to compare to
+  --pattern-file <path>    JSON file containing scan patterns
+  --no-fetch               Do not fetch the source ref before auditing
+  --allow-dirty            Continue when this worktree has local changes
+  --fail-on-review         Exit non-zero on review findings as well as blockers
+  --json                   Print JSON instead of a text report
+  --out <path>             Write the report to a file
+  -h, --help               Show this help
+
+Pattern file shape:
+[
+  { "id": "product-brand", "severity": "blocker", "pattern": "\\\\bExample\\\\b", "flags": "i" }
+]
+`);
+};
+
+for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "--source-url") {
+        options.sourceUrl = args[index + 1];
+        index += 1;
+    } else if (arg === "--source-branch") {
+        options.sourceBranch = args[index + 1];
+        index += 1;
+    } else if (arg === "--source-ref") {
+        options.sourceRef = args[index + 1];
+        index += 1;
+    } else if (arg === "--target-ref") {
+        options.targetRef = args[index + 1];
+        index += 1;
+    } else if (arg === "--pattern-file") {
+        options.patternFile = args[index + 1];
+        index += 1;
+    } else if (arg === "--no-fetch") {
+        options.fetch = false;
+    } else if (arg === "--allow-dirty") {
+        options.allowDirty = true;
+    } else if (arg === "--fail-on-review") {
+        options.failOnReview = true;
+    } else if (arg === "--json") {
+        options.json = true;
+    } else if (arg === "--out") {
+        options.out = args[index + 1];
+        index += 1;
+    } else if (arg === "-h" || arg === "--help") {
+        usage();
+        process.exit(0);
+    } else {
+        console.error(`Unknown option: ${arg}`);
+        usage();
+        process.exit(2);
+    }
+}
+
+const run = (command, commandArgs, { allowFailure = false } = {}) => {
+    const result = spawnSync(command, commandArgs, {
+        cwd: ROOT_DIR,
+        encoding: "utf8",
+        maxBuffer: 100 * 1024 * 1024,
+    });
+
+    if (result.error) throw result.error;
+    if (result.status !== 0 && !allowFailure) {
+        const output = [result.stdout, result.stderr]
+            .filter(Boolean)
+            .join("\n")
+            .trim();
+        throw new Error(
+            `${command} ${commandArgs.join(" ")} failed with status ${result.status}${output ? `:\n${output}` : ""}`,
+        );
+    }
+
+    return {
+        status: result.status,
+        stdout: result.stdout || "",
+        stderr: result.stderr || "",
+    };
+};
+
+const git = (gitArgs, optionsForRun) =>
+    run("git", gitArgs, optionsForRun).stdout.trim();
+
+const lines = (value) =>
+    value
+        .split("\n")
+        .map((line) => line.trim())
+        .filter(Boolean);
+
+const quotePath = (filePath) =>
+    filePath.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+
+const changedPathFromStatus = (line) => {
+    const parts = line.split("\t");
+    const status = parts[0];
+    const filePath =
+        status.startsWith("R") || status.startsWith("C") ? parts[2] : parts[1];
+    return { status, path: filePath };
+};
+
+const loadPatterns = () => {
+    if (!options.patternFile) return [];
+
+    const patternPath = path.resolve(ROOT_DIR, options.patternFile);
+    if (!existsSync(patternPath)) {
+        throw new Error(`Pattern file not found: ${options.patternFile}`);
+    }
+
+    const rawPatterns = JSON.parse(readFileSync(patternPath, "utf8"));
+    if (!Array.isArray(rawPatterns)) {
+        throw new Error("Pattern file must contain a JSON array.");
+    }
+
+    return rawPatterns.map((pattern) => {
+        if (!pattern.id || !pattern.pattern) {
+            throw new Error(
+                "Each scan pattern requires id and pattern fields.",
+            );
+        }
+        return {
+            id: pattern.id,
+            severity: pattern.severity || "review",
+            regex: new RegExp(pattern.pattern, pattern.flags || ""),
+        };
+    });
+};
+
+const classifyPath = (filePath) => {
+    const matches = DEFAULT_CLUSTERS.filter((cluster) => {
+        const byPrefix = cluster.prefixes.some((prefix) =>
+            filePath.startsWith(prefix),
+        );
+        const byInclude = (cluster.includes || []).some((needle) =>
+            filePath.includes(needle),
+        );
+        return byPrefix || byInclude;
+    });
+
+    return matches.length
+        ? matches.map((cluster) => cluster.id)
+        : ["uncategorized"];
+};
+
+const fileContentsAtRef = (ref, filePath) => {
+    if (SCAN_EXCLUDED_PATHS.has(filePath)) return null;
+    if (SCAN_EXCLUDED_EXTENSIONS.has(path.extname(filePath).toLowerCase())) {
+        return null;
+    }
+
+    const result = run("git", ["show", `${ref}:${filePath}`], {
+        allowFailure: true,
+    });
+
+    if (result.status !== 0) return null;
+    if (result.stdout.includes("\u0000")) return null;
+    return result.stdout;
+};
+
+const scanFiles = (filePaths, ref, patterns) => {
+    const findings = [];
+    if (!patterns.length) return findings;
+
+    for (const filePath of filePaths) {
+        const contents = fileContentsAtRef(ref, filePath);
+        if (!contents) continue;
+
+        contents.split("\n").forEach((line, index) => {
+            patterns.forEach((pattern) => {
+                if (pattern.regex.test(line)) {
+                    findings.push({
+                        id: pattern.id,
+                        severity: pattern.severity,
+                        path: filePath,
+                        line: index + 1,
+                        sample: line.trim().slice(0, 220),
+                    });
+                }
+            });
+        });
+    }
+
+    return findings;
+};
+
+const buildReport = () => {
+    const status = git(["status", "-sb"]);
+    const dirty = lines(git(["status", "--porcelain"]));
+
+    if (dirty.length && !options.allowDirty) {
+        throw new Error(
+            [
+                "Worktree has local changes. Re-run with --allow-dirty for an exploratory audit.",
+                status,
+            ].join("\n"),
+        );
+    }
+
+    if (options.fetch) {
+        if (!options.sourceUrl) {
+            throw new Error(
+                "--source-url is required unless --no-fetch or --source-ref is already available locally.",
+            );
+        }
+        git([
+            "fetch",
+            options.sourceUrl,
+            `+${options.sourceBranch}:${options.sourceRef}`,
+        ]);
+    }
+
+    git(["rev-parse", "--verify", options.sourceRef]);
+    git(["rev-parse", "--verify", options.targetRef]);
+
+    const patterns = loadPatterns();
+    const mergeBase = git(["merge-base", options.targetRef, options.sourceRef]);
+    const [targetOnly, sourceOnly] = git([
+        "rev-list",
+        "--left-right",
+        "--count",
+        `${options.targetRef}...${options.sourceRef}`,
+    ])
+        .split(/\s+/)
+        .map(Number);
+    const shortstat = git([
+        "diff",
+        "--shortstat",
+        `${options.targetRef}...${options.sourceRef}`,
+    ]);
+    const dirstat = lines(
+        git([
+            "diff",
+            "--dirstat=files,0",
+            `${options.targetRef}...${options.sourceRef}`,
+        ]),
+    );
+    const nameStatus = lines(
+        git([
+            "diff",
+            "--name-status",
+            `${options.targetRef}...${options.sourceRef}`,
+        ]),
+    ).map(changedPathFromStatus);
+
+    const clusters = new Map([
+        ...DEFAULT_CLUSTERS.map((cluster) => [
+            cluster.id,
+            {
+                id: cluster.id,
+                label: cluster.label,
+                files: [],
+                count: 0,
+            },
+        ]),
+        [
+            "uncategorized",
+            {
+                id: "uncategorized",
+                label: "Uncategorized",
+                files: [],
+                count: 0,
+            },
+        ],
+    ]);
+
+    nameStatus.forEach((entry) => {
+        classifyPath(entry.path).forEach((clusterId) => {
+            const cluster = clusters.get(clusterId);
+            cluster.count += 1;
+            if (cluster.files.length < 25) {
+                cluster.files.push(`${entry.status}\t${entry.path}`);
+            }
+        });
+    });
+
+    const changedFiles = nameStatus
+        .filter((entry) => !entry.status.startsWith("D"))
+        .map((entry) => entry.path);
+    const findings = scanFiles(changedFiles, options.sourceRef, patterns);
+    const findingCounts = findings.reduce((counts, finding) => {
+        counts[finding.severity] = (counts[finding.severity] || 0) + 1;
+        return counts;
+    }, {});
+
+    return {
+        generatedAt: new Date().toISOString(),
+        root: ROOT_DIR,
+        status,
+        dirtyFiles: dirty,
+        refs: {
+            sourceBranch: options.sourceBranch,
+            sourceRef: options.sourceRef,
+            sourceHead: git(["rev-parse", options.sourceRef]),
+            targetRef: options.targetRef,
+            targetHead: git(["rev-parse", options.targetRef]),
+            mergeBase,
+        },
+        divergence: {
+            targetOnly,
+            sourceOnly,
+            shortstat,
+            dirstat,
+        },
+        clusters: [...clusters.values()].filter((cluster) => cluster.count > 0),
+        scan: {
+            patternCount: patterns.length,
+            counts: findingCounts,
+            findings,
+        },
+        recommendation: [
+            "Use this report to choose one feature cluster for a focused branch.",
+            "Sanitize product names, sample content, deployment configuration, and credentials in the same branch as the port.",
+            "Resolve blocker findings before opening a public pull request.",
+            "Validate the final branch with this repository's own tests and build.",
+        ],
+    };
+};
+
+const renderText = (report) => {
+    const clusterLines = report.clusters.flatMap((cluster) => [
+        `- ${cluster.label}: ${cluster.count} files`,
+        ...cluster.files.map((file) => `  ${file}`),
+    ]);
+
+    const findingLines = report.scan.findings.slice(0, 80).map((finding) => {
+        const location = `${finding.path}:${finding.line}`;
+        return `- [${finding.severity}] ${finding.id} ${location} :: ${finding.sample}`;
+    });
+
+    return `# Upstream Audit
+
+Generated: ${report.generatedAt}
+Worktree: ${report.status}
+
+## Refs
+
+- Target: ${report.refs.targetRef} (${report.refs.targetHead})
+- Source: ${report.refs.sourceRef} (${report.refs.sourceHead})
+- Merge base: ${report.refs.mergeBase}
+
+## Divergence
+
+- Target-only commits: ${report.divergence.targetOnly}
+- Source-only commits: ${report.divergence.sourceOnly}
+- Diff: ${report.divergence.shortstat || "no file diff"}
+
+Directory spread:
+${report.divergence.dirstat.length ? report.divergence.dirstat.map((line) => `- ${line}`).join("\n") : "- none"}
+
+## File Clusters
+
+${clusterLines.length ? clusterLines.join("\n") : "- No changed files"}
+
+## Forbidden Pattern Scan
+
+- Patterns loaded: ${report.scan.patternCount}
+- Blocker findings: ${report.scan.counts.blocker || 0}
+- Review findings: ${report.scan.counts.review || 0}
+
+${findingLines.length ? findingLines.join("\n") : "No findings."}
+${report.scan.findings.length > findingLines.length ? `\n\n... ${report.scan.findings.length - findingLines.length} additional findings omitted from text output. Use --json for the full set.` : ""}
+
+## Recommendation
+
+${report.recommendation.map((line) => `- ${line}`).join("\n")}
+`;
+};
+
+try {
+    const report = buildReport();
+    const output = options.json
+        ? `${JSON.stringify(report, null, 2)}\n`
+        : renderText(report);
+
+    if (options.out) {
+        const outPath = path.resolve(ROOT_DIR, options.out);
+        mkdirSync(path.dirname(outPath), { recursive: true });
+        writeFileSync(outPath, output);
+        console.log(`Wrote ${quotePath(path.relative(ROOT_DIR, outPath))}`);
+    } else {
+        process.stdout.write(output);
+    }
+
+    if (
+        (report.scan.counts.blocker || 0) > 0 ||
+        (options.failOnReview && (report.scan.counts.review || 0) > 0)
+    ) {
+        process.exitCode = 1;
+    }
+} catch (error) {
+    console.error(error.message);
+    process.exit(1);
+}


### PR DESCRIPTION
## Summary

Adds a read-only upstream audit workflow for comparing Concierge with downstream/private distributions before porting features back upstream. The tool reports commit divergence, directory spread, changed-file clusters, and optional forbidden-pattern scan results loaded from a caller-provided private JSON file.

This also removes a legacy branded URL source dependency from the Concierge build path and refreshes missing lockfile entries so clean installs can resolve the declared dependency tree.

## Validation

- node --check scripts/upstream-audit.mjs
- npm run upstream:audit -- --help
- npm run upstream:audit -- --allow-dirty --no-fetch --source-ref refs/remotes/downstream/main --pattern-file /Users/jmac/software/ml/labeeb/scripts/concierge-upstream-patterns.json --out /private/tmp/concierge-public-upstream-audit-final.md
- npm test -- --runInBand --silent --openHandlesTimeout=1000
- npm run build

Notes: build exits successfully, but Concierge currently logs Redis connection refusals during static page generation when no local Redis is running. The upstream audit against Labeeb still reports blocker/review findings in the downstream source, which is expected and is the reason for this staged workflow.