### PR TITLE
Add unified file manager and scoped storage routing

### DIFF
--- a/app/api/__tests__/checkUrl.test.js
+++ b/app/api/__tests__/checkUrl.test.js
@@ -1,0 +1,361 @@
+/**
+ * @jest-environment node
+ */
+
+import { POST } from "../files/check-url/route";
+
+jest.mock("../utils/auth.js", () => ({
+    getCurrentUser: jest.fn(),
+}));
+
+jest.mock("../utils/file-route-utils.js", () => ({
+    resolveAuthorizedMediaRouting: jest.fn(),
+}));
+
+jest.mock("../utils/media-service-utils.js", () => ({
+    checkMediaFile: jest.fn(),
+}));
+
+global.fetch = jest.fn();
+
+describe("check-url API", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    test("rejects unauthenticated requests", async () => {
+        const { getCurrentUser } = require("../utils/auth.js");
+        getCurrentUser.mockResolvedValue(null);
+
+        const response = await POST(createMockRequest({ url: "https://x" }));
+        const data = await response.json();
+
+        expect(response.status).toBe(401);
+        expect(data.error).toBe("Authentication required");
+    });
+
+    test("resolves a canonical file by hash without requiring the stale URL", async () => {
+        const { getCurrentUser } = require("../utils/auth.js");
+        const {
+            resolveAuthorizedMediaRouting,
+        } = require("../utils/file-route-utils.js");
+        const { checkMediaFile } = require("../utils/media-service-utils.js");
+
+        getCurrentUser.mockResolvedValue({
+            _id: "mongo-user-1",
+            contextId: "user-context-1",
+        });
+        resolveAuthorizedMediaRouting.mockResolvedValue({
+            storageTarget: {
+                kind: "chat",
+                contextId: "user-context-1",
+                userContextId: "user-context-1",
+                chatId: "chat-123",
+                fileScope: "chat",
+            },
+            routingParams: {
+                contextId: "user-context-1",
+                userId: "user-context-1",
+                chatId: "chat-123",
+                fileScope: "chat",
+            },
+        });
+        checkMediaFile.mockResolvedValue({
+            url: "https://example.com/fresh.pdf",
+            blobPath: "chats/chat-123/hash123_file.pdf",
+            hash: "hash123",
+        });
+
+        const response = await POST(
+            createMockRequest({
+                hash: "hash123",
+                chatId: "chat-123",
+                fileScope: "chat",
+            }),
+        );
+        const data = await response.json();
+
+        expect(response.status).toBe(200);
+        expect(resolveAuthorizedMediaRouting).toHaveBeenCalledWith({
+            user: {
+                _id: "mongo-user-1",
+                contextId: "user-context-1",
+            },
+            routingInput: {
+                contextId: undefined,
+                userId: undefined,
+                workspaceId: undefined,
+                chatId: "chat-123",
+                fileScope: "chat",
+            },
+        });
+        expect(checkMediaFile).toHaveBeenCalledWith({
+            blobPath: null,
+            hash: "hash123",
+            storageTarget: {
+                kind: "chat",
+                contextId: "user-context-1",
+                userContextId: "user-context-1",
+                chatId: "chat-123",
+                fileScope: "chat",
+            },
+        });
+        expect(data).toEqual({
+            exists: true,
+            source: "canonical",
+            file: {
+                url: "https://example.com/fresh.pdf",
+                blobPath: "chats/chat-123/hash123_file.pdf",
+                hash: "hash123",
+            },
+        });
+        expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    test("falls back to probing the raw URL when canonical lookup misses", async () => {
+        const { getCurrentUser } = require("../utils/auth.js");
+        const {
+            resolveAuthorizedMediaRouting,
+        } = require("../utils/file-route-utils.js");
+        const { checkMediaFile } = require("../utils/media-service-utils.js");
+
+        getCurrentUser.mockResolvedValue({
+            _id: "mongo-user-1",
+            contextId: "user-context-1",
+        });
+        resolveAuthorizedMediaRouting.mockResolvedValue({
+            storageTarget: {
+                kind: "chat",
+                contextId: "user-context-1",
+            },
+            routingParams: {
+                contextId: "user-context-1",
+                fileScope: "chat",
+            },
+        });
+        checkMediaFile.mockResolvedValue(null);
+        global.fetch.mockResolvedValueOnce({
+            ok: true,
+            status: 200,
+        });
+
+        const response = await POST(
+            createMockRequest({
+                url: "https://storage.example.blob.core.windows.net/files/test.pdf",
+                hash: "hash123",
+                chatId: "chat-123",
+                fileScope: "chat",
+            }),
+        );
+        const data = await response.json();
+
+        expect(response.status).toBe(200);
+        expect(checkMediaFile).toHaveBeenCalledTimes(2);
+        expect(checkMediaFile).toHaveBeenNthCalledWith(2, {
+            hash: "hash123",
+        });
+        expect(data).toEqual({
+            exists: true,
+            source: "url",
+        });
+        expect(global.fetch).toHaveBeenCalledWith(
+            "https://storage.example.blob.core.windows.net/files/test.pdf",
+            expect.objectContaining({
+                method: "HEAD",
+                redirect: "follow",
+            }),
+        );
+    });
+
+    test("derives blobPath and hash from old URL-only payloads before probing raw URL", async () => {
+        const { getCurrentUser } = require("../utils/auth.js");
+        const {
+            resolveAuthorizedMediaRouting,
+        } = require("../utils/file-route-utils.js");
+        const { checkMediaFile } = require("../utils/media-service-utils.js");
+
+        getCurrentUser.mockResolvedValue({
+            _id: "mongo-user-1",
+            contextId: "user-context-1",
+        });
+        resolveAuthorizedMediaRouting.mockResolvedValue({
+            storageTarget: {
+                kind: "chat",
+                contextId: "user-context-1",
+                userContextId: "user-context-1",
+                chatId: "chat-123",
+                fileScope: "chat",
+            },
+        });
+        checkMediaFile.mockResolvedValue({
+            url: "https://example.com/fresh.pdf",
+            blobPath: "chats/chat-123/abc123_file.pdf",
+            hash: "abc123",
+        });
+
+        const response = await POST(
+            createMockRequest({
+                url: "https://storage.example.blob.core.windows.net/cortexfiles-user-context-1/chats/chat-123/abc123_file.pdf?sv=old&sig=expired",
+                chatId: "chat-123",
+                fileScope: "chat",
+            }),
+        );
+        const data = await response.json();
+
+        expect(response.status).toBe(200);
+        expect(checkMediaFile).toHaveBeenCalledWith({
+            blobPath: "chats/chat-123/abc123_file.pdf",
+            hash: "abc123",
+            storageTarget: expect.objectContaining({
+                kind: "chat",
+                chatId: "chat-123",
+            }),
+        });
+        expect(data).toEqual({
+            exists: true,
+            source: "canonical",
+            file: {
+                url: "https://example.com/fresh.pdf",
+                blobPath: "chats/chat-123/abc123_file.pdf",
+                hash: "abc123",
+            },
+        });
+        expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    test("resolves legacy hash-map files before probing stale URL", async () => {
+        const { getCurrentUser } = require("../utils/auth.js");
+        const {
+            resolveAuthorizedMediaRouting,
+        } = require("../utils/file-route-utils.js");
+        const { checkMediaFile } = require("../utils/media-service-utils.js");
+
+        getCurrentUser.mockResolvedValue({
+            _id: "mongo-user-1",
+            contextId: "user-context-1",
+        });
+        resolveAuthorizedMediaRouting.mockResolvedValue({
+            storageTarget: {
+                kind: "chat",
+                contextId: "user-context-1",
+                userContextId: "user-context-1",
+                chatId: "chat-123",
+                fileScope: "chat",
+            },
+        });
+        checkMediaFile.mockResolvedValueOnce(null).mockResolvedValueOnce({
+            url: "https://example.com/legacy-fresh.pdf",
+            shortLivedUrl: "https://example.com/legacy-short.pdf",
+            blobPath: "abc123_old.pdf",
+            hash: "abc123",
+        });
+
+        const response = await POST(
+            createMockRequest({
+                url: "https://storage.example.blob.core.windows.net/cortexfiles-user-context-1/chats/chat-123/abc123_old.pdf?sv=old&sig=expired",
+                chatId: "chat-123",
+                fileScope: "chat",
+            }),
+        );
+        const data = await response.json();
+
+        expect(response.status).toBe(200);
+        expect(checkMediaFile).toHaveBeenNthCalledWith(1, {
+            blobPath: "chats/chat-123/abc123_old.pdf",
+            hash: "abc123",
+            storageTarget: expect.objectContaining({
+                kind: "chat",
+                chatId: "chat-123",
+            }),
+        });
+        expect(checkMediaFile).toHaveBeenNthCalledWith(2, {
+            hash: "abc123",
+        });
+        expect(data).toEqual({
+            exists: true,
+            source: "legacy-hash",
+            file: {
+                url: "https://example.com/legacy-fresh.pdf",
+                shortLivedUrl: "https://example.com/legacy-short.pdf",
+                blobPath: "abc123_old.pdf",
+                hash: "abc123",
+            },
+        });
+        expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    test("normalizes stale CFH blobPath from the resolved file URL", async () => {
+        const { getCurrentUser } = require("../utils/auth.js");
+        const {
+            resolveAuthorizedMediaRouting,
+        } = require("../utils/file-route-utils.js");
+        const { checkMediaFile } = require("../utils/media-service-utils.js");
+
+        getCurrentUser.mockResolvedValue({
+            _id: "mongo-user-1",
+            contextId: "user-context-1",
+        });
+        resolveAuthorizedMediaRouting.mockResolvedValue({
+            storageTarget: {
+                kind: "chat",
+                contextId: "user-context-1",
+                userContextId: "user-context-1",
+                chatId: "chat-123",
+                fileScope: "chat",
+            },
+        });
+        checkMediaFile.mockResolvedValue({
+            url: "https://storage.example.blob.core.windows.net/cortexfiles/chats/chat-123/mod63eq7-act.jpeg?sv=fresh&sig=token",
+            shortLivedUrl:
+                "https://storage.example.blob.core.windows.net/cortexfiles/chats/chat-123/mod63eq7-act.jpeg?sv=short&sig=token",
+            blobPath: "mod63eq7-act.jpeg",
+            hash: "af67fc86281c4eb0",
+        });
+
+        const response = await POST(
+            createMockRequest({
+                hash: "af67fc86281c4eb0",
+                blobPath: "mod63eq7-act.jpeg",
+                chatId: "chat-123",
+                fileScope: "chat",
+            }),
+        );
+        const data = await response.json();
+
+        expect(response.status).toBe(200);
+        expect(data).toEqual({
+            exists: true,
+            source: "canonical",
+            file: {
+                url: "https://storage.example.blob.core.windows.net/cortexfiles/chats/chat-123/mod63eq7-act.jpeg?sv=fresh&sig=token",
+                shortLivedUrl:
+                    "https://storage.example.blob.core.windows.net/cortexfiles/chats/chat-123/mod63eq7-act.jpeg?sv=short&sig=token",
+                blobPath: "chats/chat-123/mod63eq7-act.jpeg",
+                hash: "af67fc86281c4eb0",
+            },
+        });
+        expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    test("requires at least one identifier", async () => {
+        const { getCurrentUser } = require("../utils/auth.js");
+        getCurrentUser.mockResolvedValue({
+            _id: "mongo-user-1",
+            contextId: "user-context-1",
+        });
+
+        const response = await POST(createMockRequest({}));
+        const data = await response.json();
+
+        expect(response.status).toBe(400);
+        expect(data.error).toBe(
+            "At least one of url, hash, or blobPath is required",
+        );
+    });
+});
+
+function createMockRequest(body) {
+    return {
+        json: async () => body,
+    };
+}

--- a/app/api/__tests__/renameFile.test.js
+++ b/app/api/__tests__/renameFile.test.js
@@ -1,0 +1,139 @@
+/**
+ * @jest-environment node
+ */
+
+import { POST } from "../files/rename/route";
+
+jest.mock("../../../config", () => ({
+    endpoints: {
+        mediaHelperDirect: jest.fn(() => "http://media-helper.test"),
+    },
+}));
+
+jest.mock("../utils/auth.js", () => ({
+    getCurrentUser: jest.fn(),
+}));
+
+jest.mock("../utils/file-route-utils.js", () => ({
+    resolveAuthorizedMediaRouting: jest.fn(),
+}));
+
+describe("rename file API", () => {
+    const originalFetch = global.fetch;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        global.fetch = jest.fn().mockResolvedValue({
+            ok: true,
+            json: async () => ({
+                blobPath: "media/Concierge Article Demo/demo.png",
+                url: "https://example.test/demo.png",
+            }),
+        });
+
+        const { getCurrentUser } = require("../utils/auth.js");
+        getCurrentUser.mockResolvedValue({
+            _id: "mongo-user-1",
+            contextId: "user-context-1",
+        });
+
+        const {
+            resolveAuthorizedMediaRouting,
+        } = require("../utils/file-route-utils.js");
+        resolveAuthorizedMediaRouting.mockResolvedValue({
+            routingParams: {
+                userId: "user-context-1",
+                fileScope: "media",
+            },
+        });
+    });
+
+    afterAll(() => {
+        global.fetch = originalFetch;
+    });
+
+    test("forwards targetBlobPath for folder moves", async () => {
+        const response = await POST(
+            createMockRequest({
+                blobPath: "users/user-context-1/media/demo.png",
+                newFilename: "Concierge Article Demo/demo.png",
+                targetBlobPath: "media/Concierge Article Demo/demo.png",
+                userId: "user-context-1",
+                fileScope: "media",
+            }),
+        );
+        const data = await response.json();
+
+        expect(response.status).toBe(200);
+        expect(data.success).toBe(true);
+        expect(global.fetch).toHaveBeenCalledTimes(1);
+
+        const helperUrl = new URL(global.fetch.mock.calls[0][0]);
+        expect(helperUrl.searchParams.get("rename")).toBe("true");
+        expect(helperUrl.searchParams.get("blobPath")).toBe(
+            "users/user-context-1/media/demo.png",
+        );
+        expect(helperUrl.searchParams.get("newFilename")).toBe(
+            "Concierge Article Demo/demo.png",
+        );
+        expect(helperUrl.searchParams.get("targetBlobPath")).toBe(
+            "media/Concierge Article Demo/demo.png",
+        );
+        expect(helperUrl.searchParams.get("userId")).toBe("user-context-1");
+        expect(helperUrl.searchParams.get("fileScope")).toBe("media");
+    });
+
+    test("does not fall back to hash rename for targetBlobPath folder moves", async () => {
+        global.fetch
+            .mockResolvedValueOnce({
+                ok: false,
+                status: 404,
+                statusText: "Not Found",
+                text: async () => "missing",
+            })
+            .mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({ blobPath: "wrong/path/demo.png" }),
+            });
+
+        const response = await POST(
+            createMockRequest({
+                blobPath: "users/user-context-1/media/demo.png",
+                hash: "hash-demo",
+                newFilename: "Concierge Article Demo/demo.png",
+                targetBlobPath: "media/Concierge Article Demo/demo.png",
+                userId: "user-context-1",
+                fileScope: "media",
+            }),
+        );
+
+        expect(response.status).toBe(404);
+        expect(global.fetch).toHaveBeenCalledTimes(1);
+        const helperUrl = new URL(global.fetch.mock.calls[0][0]);
+        expect(helperUrl.searchParams.get("blobPath")).toBe(
+            "users/user-context-1/media/demo.png",
+        );
+        expect(helperUrl.searchParams.get("hash")).toBeNull();
+    });
+
+    test("requires blobPath for targetBlobPath folder moves", async () => {
+        const response = await POST(
+            createMockRequest({
+                hash: "hash-demo",
+                newFilename: "Concierge Article Demo/demo.png",
+                targetBlobPath: "media/Concierge Article Demo/demo.png",
+                userId: "user-context-1",
+                fileScope: "media",
+            }),
+        );
+
+        expect(response.status).toBe(400);
+        expect(global.fetch).not.toHaveBeenCalled();
+    });
+});
+
+function createMockRequest(body) {
+    return {
+        json: async () => body,
+    };
+}

--- a/app/api/__tests__/streamingUploadIntegration.test.js
+++ b/app/api/__tests__/streamingUploadIntegration.test.js
@@ -56,6 +56,21 @@ jest.mock("../models/applet-file", () => ({
     }),
 }));
 
+jest.mock("../models/applet-shared-file", () => ({
+    findOne: jest.fn(),
+    findOneAndUpdate: jest.fn().mockReturnValue({
+        populate: jest.fn().mockResolvedValue({
+            files: [],
+        }),
+    }),
+}));
+
+jest.mock("../utils/applet-shared-file-utils", () => ({
+    ensureAppletSharedFileStore: jest.fn().mockResolvedValue({
+        files: [],
+    }),
+}));
+
 jest.mock("../workspaces/[id]/db", () => ({
     getWorkspace: jest.fn(),
 }));
@@ -173,6 +188,23 @@ describe("Streaming Upload Integration Tests", () => {
             populate: jest.fn().mockResolvedValue({
                 files: [],
             }),
+        });
+
+        const AppletSharedFile = require("../models/applet-shared-file");
+        AppletSharedFile.findOne.mockResolvedValue({
+            files: [],
+        });
+        AppletSharedFile.findOneAndUpdate.mockReturnValue({
+            populate: jest.fn().mockResolvedValue({
+                files: [{ _id: "file1", filename: "uploaded-file.jpg" }],
+            }),
+        });
+
+        const {
+            ensureAppletSharedFileStore,
+        } = require("../utils/applet-shared-file-utils");
+        ensureAppletSharedFileStore.mockResolvedValue({
+            files: [],
         });
 
         // Reset file validation mocks to default state

--- a/app/api/files/check-url/route.js
+++ b/app/api/files/check-url/route.js
@@ -1,5 +1,31 @@
 import { NextResponse } from "next/server";
 import { getCurrentUser } from "../../utils/auth.js";
+import { checkMediaFile } from "../../utils/media-service-utils.js";
+import { resolveAuthorizedMediaRouting } from "../../utils/file-route-utils.js";
+import {
+    extractBlobPathFromUrl,
+    extractHashFromBlobUrl,
+    isAllowedBlobDomain,
+} from "../../utils/llm-file-utils.js";
+
+function validateProbeUrl(rawUrl) {
+    let parsed;
+    try {
+        parsed = new URL(rawUrl);
+    } catch {
+        return { ok: false, reason: "Invalid URL format" };
+    }
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+        return { ok: false, reason: "Invalid URL format" };
+    }
+    if (parsed.username || parsed.password) {
+        return { ok: false, reason: "Invalid URL format" };
+    }
+    if (!isAllowedBlobDomain(parsed.hostname)) {
+        return { ok: false, reason: "URL is not from an allowed domain" };
+    }
+    return { ok: true };
+}
 
 /**
  * Redact sensitive query parameters from URL for logging
@@ -20,15 +46,120 @@ function redactUrl(url) {
     }
 }
 
+function normalizeResolvedMediaFile(file) {
+    if (!file?.url) {
+        return file;
+    }
+
+    try {
+        const parsedUrl = new URL(file.url);
+        if (!isAllowedBlobDomain(parsedUrl.hostname)) {
+            return file;
+        }
+    } catch {
+        return file;
+    }
+
+    const blobPathFromUrl = extractBlobPathFromUrl(file.url);
+    if (!blobPathFromUrl || blobPathFromUrl === file.blobPath) {
+        return file;
+    }
+
+    return {
+        ...file,
+        blobPath: blobPathFromUrl,
+    };
+}
+
 /**
- * POST /api/files/check-url
- * Check if a file URL exists by making a server-side request
- * This avoids CORS issues and doesn't rely on hash database
- * Uses POST to avoid logging sensitive URLs in server logs
+ * Check if a file URL exists by making a server-side request.
+ * Tries canonical CFH lookup first when hash/blobPath + routing are available,
+ * then falls back to probing the raw URL.
+ * Uses POST to avoid logging sensitive URLs in server logs.
  *
  * Body:
- * - url: File URL to check (required)
+ * - url: File URL to check (optional when hash/blobPath is provided)
+ * - hash: File hash for canonical lookup (optional)
+ * - blobPath: Blob path for canonical lookup (optional)
+ * - contextId/userId/workspaceId/chatId/fileScope: Optional routing hints
  */
+async function checkRawUrlExists(fileUrl) {
+    // Validate URL format
+    const url = new URL(fileUrl);
+
+    // Check if file exists by making a HEAD request
+    // If HEAD fails, try GET with range request (more efficient than full download)
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 5000); // 5 second timeout
+
+    try {
+        // Try HEAD first (most efficient)
+        const headResponse = await fetch(url.toString(), {
+            method: "HEAD",
+            redirect: "follow",
+            signal: controller.signal,
+        });
+
+        clearTimeout(timeoutId);
+
+        if (headResponse.ok) {
+            return true;
+        }
+
+        // If HEAD returns 404, file doesn't exist
+        if (headResponse.status === 404) {
+            return false;
+        }
+
+        // If HEAD fails for other reasons, try GET with range request
+        const getController = new AbortController();
+        const getTimeoutId = setTimeout(() => getController.abort(), 5000);
+
+        try {
+            const getResponse = await fetch(url.toString(), {
+                method: "GET",
+                headers: {
+                    // Request only first byte to check existence
+                    // Note: Some servers may ignore Range header and return full file (200 OK)
+                    // instead of partial content (206). The 5-second timeout limits impact.
+                    Range: "bytes=0-0",
+                },
+                redirect: "follow",
+                signal: getController.signal,
+            });
+
+            clearTimeout(getTimeoutId);
+
+            if (getResponse.ok || getResponse.status === 206) {
+                // 206 is Partial Content, which means file exists
+                return true;
+            }
+
+            if (getResponse.status === 404) {
+                return false;
+            }
+
+            // For other status codes, assume file doesn't exist to be safe
+            return false;
+        } catch (getError) {
+            clearTimeout(getTimeoutId);
+            throw getError;
+        }
+    } catch (error) {
+        clearTimeout(timeoutId);
+        // Network errors, timeouts, etc. - assume file doesn't exist
+        if (error.name === "AbortError") {
+            console.warn(`Timeout checking file URL: ${redactUrl(fileUrl)}`);
+        } else {
+            console.warn(
+                `Error checking file URL ${redactUrl(fileUrl)}:`,
+                error.message,
+            );
+        }
+        return false;
+    }
+}
+
 export async function POST(request) {
     try {
         // Get current user for authentication
@@ -41,99 +172,101 @@ export async function POST(request) {
         }
 
         const body = await request.json();
-        const fileUrl = body?.url;
+        const fileUrl = body?.url || null;
+        const hash = body?.hash || null;
+        const blobPath = body?.blobPath || null;
+        const resolvedBlobPath =
+            blobPath || (fileUrl ? extractBlobPathFromUrl(fileUrl) : null);
+        const resolvedHash =
+            hash || (fileUrl ? extractHashFromBlobUrl(fileUrl) : null);
+        const routingInput = {
+            contextId: body?.contextId,
+            userId: body?.userId,
+            workspaceId: body?.workspaceId,
+            chatId: body?.chatId,
+            fileScope: body?.fileScope,
+        };
 
-        if (!fileUrl) {
+        if (!fileUrl && !hash && !blobPath) {
             return NextResponse.json(
-                { error: "URL parameter is required" },
+                {
+                    error: "At least one of url, hash, or blobPath is required",
+                },
                 { status: 400 },
             );
         }
 
-        // Validate URL format
-        let url;
-        try {
-            url = new URL(fileUrl);
-        } catch (error) {
-            return NextResponse.json(
-                { error: "Invalid URL format" },
-                { status: 400 },
-            );
-        }
-
-        // Check if file exists by making a HEAD request
-        // If HEAD fails, try GET with range request (more efficient than full download)
-        const controller = new AbortController();
-        const timeoutId = setTimeout(() => controller.abort(), 5000); // 5 second timeout
-
-        try {
-            // Try HEAD first (most efficient)
-            const headResponse = await fetch(url.toString(), {
-                method: "HEAD",
-                redirect: "follow",
-                signal: controller.signal,
-            });
-
-            clearTimeout(timeoutId);
-
-            if (headResponse.ok) {
-                return NextResponse.json({ exists: true });
-            }
-
-            // If HEAD returns 404, file doesn't exist
-            if (headResponse.status === 404) {
-                return NextResponse.json({ exists: false });
-            }
-
-            // If HEAD fails for other reasons, try GET with range request
-            const getController = new AbortController();
-            const getTimeoutId = setTimeout(() => getController.abort(), 5000);
-
+        if (resolvedHash || resolvedBlobPath) {
             try {
-                const getResponse = await fetch(url.toString(), {
-                    method: "GET",
-                    headers: {
-                        // Request only first byte to check existence
-                        // Note: Some servers may ignore Range header and return full file (200 OK)
-                        // instead of partial content (206). The 5-second timeout limits impact.
-                        Range: "bytes=0-0",
-                    },
-                    redirect: "follow",
-                    signal: getController.signal,
+                const { storageTarget } = await resolveAuthorizedMediaRouting({
+                    user,
+                    routingInput,
+                });
+                const resolvedFile = await checkMediaFile({
+                    blobPath: resolvedBlobPath,
+                    hash: resolvedHash,
+                    storageTarget,
                 });
 
-                clearTimeout(getTimeoutId);
-
-                if (getResponse.ok || getResponse.status === 206) {
-                    // 206 is Partial Content, which means file exists
-                    return NextResponse.json({ exists: true });
+                if (resolvedFile?.url) {
+                    return NextResponse.json({
+                        exists: true,
+                        source: "canonical",
+                        file: normalizeResolvedMediaFile(resolvedFile),
+                    });
                 }
 
-                if (getResponse.status === 404) {
-                    return NextResponse.json({ exists: false });
+                // Some pre-rollout files exist only in CFH's legacy global
+                // Redis hash map. If scoped lookup misses, try the bare hash
+                // before falling back to a stale URL probe.
+                if (resolvedHash) {
+                    const legacyFile = await checkMediaFile({
+                        hash: resolvedHash,
+                    });
+
+                    if (legacyFile?.url) {
+                        return NextResponse.json({
+                            exists: true,
+                            source: "legacy-hash",
+                            file: normalizeResolvedMediaFile(legacyFile),
+                        });
+                    }
+                }
+            } catch (error) {
+                if (error?.status) {
+                    return NextResponse.json(
+                        { error: error.message },
+                        { status: error.status },
+                    );
                 }
 
-                // For other status codes, assume file doesn't exist to be safe
-                return NextResponse.json({ exists: false });
-            } catch (getError) {
-                clearTimeout(getTimeoutId);
-                throw getError;
-            }
-        } catch (error) {
-            clearTimeout(timeoutId);
-            // Network errors, timeouts, etc. - assume file doesn't exist
-            if (error.name === "AbortError") {
                 console.warn(
-                    `Timeout checking file URL: ${redactUrl(fileUrl)}`,
-                );
-            } else {
-                console.warn(
-                    `Error checking file URL ${redactUrl(fileUrl)}:`,
-                    error.message,
+                    "Canonical file lookup failed during check-url:",
+                    error?.message || error,
                 );
             }
-            return NextResponse.json({ exists: false });
         }
+
+        if (!fileUrl) {
+            return NextResponse.json({
+                exists: false,
+                source: null,
+            });
+        }
+
+        const urlCheck = validateProbeUrl(fileUrl);
+        if (!urlCheck.ok) {
+            return NextResponse.json(
+                { error: urlCheck.reason },
+                { status: 400 },
+            );
+        }
+
+        const exists = await checkRawUrlExists(fileUrl);
+        return NextResponse.json({
+            exists,
+            source: "url",
+        });
     } catch (error) {
         console.error("Error in check-url endpoint:", error);
         return NextResponse.json(
@@ -145,3 +278,5 @@ export async function POST(request) {
         );
     }
 }
+
+export const dynamic = "force-dynamic";

--- a/app/api/files/delete/route.js
+++ b/app/api/files/delete/route.js
@@ -1,15 +1,20 @@
 import { NextResponse } from "next/server";
 import { getCurrentUser } from "../../utils/auth.js";
 import config from "../../../../config/index.js";
+import { resolveAuthorizedMediaRouting } from "../../utils/file-route-utils.js";
+import { buildFileIdentifierAttempts } from "../../utils/media-service-utils.js";
 
 /**
  * DELETE /api/files/delete
  * Delete a file from cloud storage using CFH (cortex-file-handler)
  *
  * Query parameters:
- * - hash: File hash to delete (required)
+ * - blobPath: Blob path within the container (preferred identifier)
+ * - hash: File hash to delete (fallback identifier)
  * - contextId: Optional context ID for file scoping (e.g., user.contextId)
  *              If not provided, defaults to user.contextId
+ *
+ * At least one of blobPath or hash must be provided.
  */
 export async function DELETE(request) {
     try {
@@ -23,12 +28,21 @@ export async function DELETE(request) {
         }
 
         const { searchParams } = new URL(request.url);
+        const blobPath = searchParams.get("blobPath");
         const hash = searchParams.get("hash");
-        const contextIdParam = searchParams.get("contextId");
+        const routingInput = {
+            contextId: searchParams.get("contextId"),
+            userId: searchParams.get("userId"),
+            workspaceId: searchParams.get("workspaceId"),
+            chatId: searchParams.get("chatId"),
+            fileScope: searchParams.get("fileScope"),
+        };
 
-        if (!hash) {
+        if (!blobPath && !hash) {
             return NextResponse.json(
-                { error: "Hash parameter is required" },
+                {
+                    error: "At least one of blobPath or hash parameter is required",
+                },
                 { status: 400 },
             );
         }
@@ -46,47 +60,73 @@ export async function DELETE(request) {
             );
         }
 
-        // Use provided contextId or fall back to user.contextId
-        // This allows deletion of user files or other scoped files
-        const contextId = contextIdParam || user.contextId;
-
-        // Call CFH delete API
-        // According to CFH signature: DELETE with hash and contextId parameters
-        // Example: DELETE /file-handler?hash=xyz789&contextId=user-123
-        const deleteUrl = new URL(mediaHelperUrl);
-        deleteUrl.searchParams.set("hash", hash);
-        deleteUrl.searchParams.set("contextId", contextId);
-
-        const deleteResponse = await fetch(deleteUrl.toString(), {
-            method: "DELETE",
-            headers: {
-                "Content-Type": "application/json",
-            },
+        const { routingParams } = await resolveAuthorizedMediaRouting({
+            user,
+            routingInput,
         });
 
-        if (!deleteResponse.ok) {
-            const errorBody = await deleteResponse.text();
+        // Call CFH delete API — prefer blobPath and only fall back to hash on miss
+        let deleteResult = null;
+        let failedResponse = null;
+        for (const attempt of buildFileIdentifierAttempts({ blobPath, hash })) {
+            const deleteUrl = new URL(mediaHelperUrl);
+            if (attempt.blobPath) {
+                deleteUrl.searchParams.set("blobPath", attempt.blobPath);
+            } else if (attempt.hash) {
+                deleteUrl.searchParams.set("hash", attempt.hash);
+            }
+            for (const [key, value] of Object.entries(routingParams)) {
+                deleteUrl.searchParams.set(key, value);
+            }
+
+            const deleteResponse = await fetch(deleteUrl.toString(), {
+                method: "DELETE",
+                headers: {
+                    "Content-Type": "application/json",
+                },
+            });
+
+            if (deleteResponse.ok) {
+                deleteResult = await deleteResponse.json();
+                failedResponse = null;
+                break;
+            }
+
+            failedResponse = {
+                status: deleteResponse.status,
+                statusText: deleteResponse.statusText,
+                errorBody: await deleteResponse.text().catch(() => ""),
+            };
+        }
+
+        if (failedResponse) {
             console.warn(
-                `Failed to delete file: ${deleteResponse.statusText}. Response: ${errorBody}`,
+                `Failed to delete file: ${failedResponse.statusText}. Response: ${failedResponse.errorBody}`,
             );
             return NextResponse.json(
                 {
-                    error: `Failed to delete file: ${deleteResponse.statusText}`,
-                    details: errorBody,
+                    error: `Failed to delete file: ${failedResponse.statusText}`,
+                    details: failedResponse.errorBody,
                 },
-                { status: deleteResponse.status },
+                { status: failedResponse.status },
             );
         }
 
-        const deleteResult = await deleteResponse.json();
-        console.log(`Successfully deleted file ${hash}`);
+        const fileIdentifier = blobPath || hash;
+        console.log(`Successfully deleted file ${fileIdentifier}`);
 
         return NextResponse.json({
             success: true,
-            message: `File with hash ${hash} deleted successfully`,
+            message: `File ${fileIdentifier} deleted successfully`,
             deleted: deleteResult.deleted || deleteResult,
         });
     } catch (error) {
+        if (error.status) {
+            return NextResponse.json(
+                { error: error.message },
+                { status: error.status },
+            );
+        }
         console.error("Error deleting file:", error);
         return NextResponse.json(
             {
@@ -97,3 +137,5 @@ export async function DELETE(request) {
         );
     }
 }
+
+export const dynamic = "force-dynamic";

--- a/app/api/files/rename/route.js
+++ b/app/api/files/rename/route.js
@@ -1,0 +1,180 @@
+import { NextResponse } from "next/server";
+import { getCurrentUser } from "../../utils/auth.js";
+import config from "../../../../config/index.js";
+import { INVALID_FILENAME_CHARS } from "../../utils/llm-file-utils.js";
+import { resolveAuthorizedMediaRouting } from "../../utils/file-route-utils.js";
+import { buildFileIdentifierAttempts } from "../../utils/media-service-utils.js";
+
+/**
+ * POST /api/files/rename
+ * Rename a file in cloud storage (copy to new name, delete old blob, update Redis entry).
+ *
+ * Body parameters:
+ * - blobPath: Blob path within the container (preferred identifier)
+ * - hash: File hash (fallback identifier)
+ * - newFilename: New filename (required)
+ * - targetBlobPath: Optional full target blob path for folder moves
+ * - userId: User ID for file scoping (optional, falls back to user.contextId)
+ *
+ * At least one of blobPath or hash must be provided.
+ */
+export async function POST(request) {
+    try {
+        const user = await getCurrentUser();
+        if (!user) {
+            return NextResponse.json(
+                { error: "Authentication required" },
+                { status: 401 },
+            );
+        }
+
+        const body = await request.json();
+        const {
+            blobPath,
+            hash,
+            newFilename,
+            targetBlobPath,
+            contextId,
+            userId,
+            workspaceId,
+            chatId,
+            fileScope,
+        } = body;
+
+        if (!blobPath && !hash) {
+            return NextResponse.json(
+                {
+                    error: "At least one of blobPath or hash parameter is required",
+                },
+                { status: 400 },
+            );
+        }
+
+        if (targetBlobPath && !blobPath) {
+            return NextResponse.json(
+                { error: "blobPath is required for folder moves" },
+                { status: 400 },
+            );
+        }
+
+        if (!newFilename || !newFilename.trim()) {
+            return NextResponse.json(
+                { error: "newFilename parameter is required" },
+                { status: 400 },
+            );
+        }
+
+        INVALID_FILENAME_CHARS.lastIndex = 0;
+        if (INVALID_FILENAME_CHARS.test(newFilename)) {
+            return NextResponse.json(
+                { error: "Filename contains invalid characters" },
+                { status: 400 },
+            );
+        }
+        INVALID_FILENAME_CHARS.lastIndex = 0;
+        if (targetBlobPath && INVALID_FILENAME_CHARS.test(targetBlobPath)) {
+            return NextResponse.json(
+                { error: "Target path contains invalid characters" },
+                { status: 400 },
+            );
+        }
+
+        const mediaHelperUrl = config.endpoints.mediaHelperDirect();
+        if (!mediaHelperUrl) {
+            return NextResponse.json(
+                { error: "Media helper URL is not configured" },
+                { status: 500 },
+            );
+        }
+        const { routingParams } = await resolveAuthorizedMediaRouting({
+            user,
+            routingInput: {
+                contextId,
+                userId,
+                workspaceId,
+                chatId,
+                fileScope,
+            },
+        });
+
+        // Call CFH rename API — prefer blobPath and only fall back to hash on miss
+        let result = null;
+        let failedResponse = null;
+
+        for (const attempt of buildFileIdentifierAttempts({
+            blobPath,
+            hash,
+            fallbackToHash: !targetBlobPath,
+        })) {
+            const renameUrl = new URL(mediaHelperUrl);
+            if (attempt.blobPath) {
+                renameUrl.searchParams.set("blobPath", attempt.blobPath);
+            } else if (attempt.hash) {
+                renameUrl.searchParams.set("hash", attempt.hash);
+            }
+            renameUrl.searchParams.set("rename", "true");
+            renameUrl.searchParams.set("newFilename", newFilename.trim());
+            if (targetBlobPath?.trim()) {
+                renameUrl.searchParams.set(
+                    "targetBlobPath",
+                    targetBlobPath.trim(),
+                );
+            }
+            for (const [key, value] of Object.entries(routingParams)) {
+                renameUrl.searchParams.set(key, value);
+            }
+
+            const renameResponse = await fetch(renameUrl.toString(), {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                },
+            });
+
+            if (renameResponse.ok) {
+                result = await renameResponse.json();
+                failedResponse = null;
+                break;
+            }
+
+            failedResponse = {
+                status: renameResponse.status,
+                statusText: renameResponse.statusText,
+                errorBody: await renameResponse.text().catch(() => ""),
+            };
+        }
+
+        if (failedResponse) {
+            return NextResponse.json(
+                {
+                    error: `Failed to rename file: ${failedResponse.statusText}`,
+                    details: failedResponse.errorBody,
+                },
+                { status: failedResponse.status },
+            );
+        }
+
+        return NextResponse.json({
+            success: true,
+            message: `File renamed to ${newFilename}`,
+            result,
+        });
+    } catch (error) {
+        if (error.status) {
+            return NextResponse.json(
+                { error: error.message },
+                { status: error.status },
+            );
+        }
+        console.error("Error renaming file:", error);
+        return NextResponse.json(
+            {
+                error: "Internal server error while renaming file",
+                details: error.message,
+            },
+            { status: 500 },
+        );
+    }
+}
+
+export const dynamic = "force-dynamic";

--- a/app/api/models/applet-shared-file.js
+++ b/app/api/models/applet-shared-file.js
@@ -1,0 +1,35 @@
+import mongoose from "mongoose";
+import "./file";
+
+const ObjectIdType =
+    mongoose?.Schema?.Types?.ObjectId || mongoose?.Types?.ObjectId || String;
+
+export const appletSharedFileSchema = new mongoose.Schema(
+    {
+        appletId: {
+            type: ObjectIdType,
+            ref: "Applet",
+            required: true,
+        },
+        files: {
+            type: [
+                {
+                    type: ObjectIdType,
+                    ref: "File",
+                },
+            ],
+            default: [],
+        },
+    },
+    {
+        timestamps: true,
+    },
+);
+
+appletSharedFileSchema.index({ appletId: 1 }, { unique: true });
+
+const AppletSharedFile =
+    mongoose.models.AppletSharedFile ||
+    mongoose.model("AppletSharedFile", appletSharedFileSchema);
+
+export default AppletSharedFile;

--- a/app/api/utils/__tests__/file-resolution-utils.test.js
+++ b/app/api/utils/__tests__/file-resolution-utils.test.js
@@ -1,0 +1,200 @@
+/**
+ * @jest-environment node
+ */
+
+jest.mock("../media-service-utils.js", () => ({
+    checkMediaFile: jest.fn(),
+    hashBuffer: jest.fn(),
+    uploadBufferToMediaService: jest.fn(),
+}));
+
+const {
+    createAppletSharedStorageTarget,
+    createWorkspaceSharedStorageTarget,
+} = require("../../../../src/utils/storageTargets.js");
+const { resolveAndHealFile } = require("../file-resolution-utils.js");
+const {
+    checkMediaFile,
+    uploadBufferToMediaService,
+} = require("../media-service-utils.js");
+
+describe("resolveAndHealFile", () => {
+    const originalFetch = global.fetch;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        global.fetch = jest.fn();
+    });
+
+    afterAll(() => {
+        global.fetch = originalFetch;
+    });
+
+    it("falls back to a legacy storage target when the primary target misses", async () => {
+        checkMediaFile.mockResolvedValueOnce(null).mockResolvedValueOnce({
+            url: "https://legacy.example.com/file.pdf",
+            hash: "hash-123",
+            blobPath: "workspace/file.pdf",
+        });
+
+        const persistResolvedFile = jest.fn();
+        const result = await resolveAndHealFile(
+            {
+                hash: "hash-123",
+                url: "https://stale.example.com/file.pdf",
+                originalName: "file.pdf",
+            },
+            {
+                storageTarget: createAppletSharedStorageTarget("applet-123"),
+                fallbackStorageTargets: [
+                    createWorkspaceSharedStorageTarget("workspace-123"),
+                ],
+                persistResolvedFile,
+            },
+        );
+
+        expect(result.status).toBe("resolved");
+        expect(result.accessUrl).toBe("https://legacy.example.com/file.pdf");
+        expect(checkMediaFile).toHaveBeenNthCalledWith(
+            1,
+            expect.objectContaining({
+                hash: "hash-123",
+                storageTarget: expect.objectContaining({
+                    kind: "applet-shared",
+                    appletId: "applet-123",
+                }),
+            }),
+        );
+        expect(checkMediaFile).toHaveBeenNthCalledWith(
+            2,
+            expect.objectContaining({
+                hash: "hash-123",
+                storageTarget: expect.objectContaining({
+                    kind: "workspace-shared",
+                    workspaceId: "workspace-123",
+                }),
+            }),
+        );
+        expect(persistResolvedFile).toHaveBeenCalledWith(
+            expect.objectContaining({
+                url: "https://legacy.example.com/file.pdf",
+            }),
+            expect.objectContaining({
+                url: "https://legacy.example.com/file.pdf",
+            }),
+        );
+    });
+
+    it("heals a legacy fallback hit into the primary target when refresh is enabled", async () => {
+        checkMediaFile
+            .mockResolvedValueOnce(null)
+            .mockResolvedValueOnce({
+                url: "https://legacy.example.com/file.pdf",
+                hash: "hash-123",
+                blobPath: "workspace/file.pdf",
+            })
+            .mockResolvedValueOnce(null)
+            .mockResolvedValueOnce({
+                url: "https://primary.example.com/file.pdf",
+                hash: "hash-123",
+                blobPath: "applets/file.pdf",
+            });
+
+        global.fetch.mockResolvedValue({
+            ok: true,
+            arrayBuffer: async () => Uint8Array.from([1, 2, 3]).buffer,
+            headers: {
+                get: (name) =>
+                    name?.toLowerCase() === "content-type"
+                        ? "application/pdf"
+                        : null,
+            },
+        });
+
+        uploadBufferToMediaService.mockResolvedValue({
+            success: true,
+            data: {
+                url: "https://primary.example.com/file.pdf",
+                hash: "hash-123",
+                blobPath: "applets/file.pdf",
+            },
+        });
+
+        const result = await resolveAndHealFile(
+            {
+                hash: "hash-123",
+                url: "https://stale.example.com/file.pdf",
+                originalName: "file.pdf",
+            },
+            {
+                storageTarget: createAppletSharedStorageTarget("applet-123"),
+                fallbackStorageTargets: [
+                    createWorkspaceSharedStorageTarget("workspace-123"),
+                ],
+                allowUrlRefresh: true,
+            },
+        );
+
+        expect(result.status).toBe("refreshed");
+        expect(result.accessUrl).toBe("https://primary.example.com/file.pdf");
+        expect(global.fetch).toHaveBeenCalledWith(
+            "https://legacy.example.com/file.pdf",
+            {
+                redirect: "follow",
+            },
+        );
+        expect(uploadBufferToMediaService).toHaveBeenCalledWith(
+            expect.any(Buffer),
+            expect.objectContaining({
+                filename: "file.pdf",
+                mimeType: "application/pdf",
+                hash: "hash-123",
+            }),
+            expect.objectContaining({
+                storageTarget: expect.objectContaining({
+                    kind: "applet-shared",
+                    appletId: "applet-123",
+                }),
+            }),
+        );
+    });
+
+    it("drops stale gcs metadata when a fresh lookup no longer returns gcs", async () => {
+        checkMediaFile.mockResolvedValueOnce({
+            url: "https://primary.example.com/file.pdf",
+            hash: "hash-123",
+            blobPath: "workspace/file.pdf",
+        });
+
+        const persistResolvedFile = jest.fn();
+        const result = await resolveAndHealFile(
+            {
+                hash: "hash-123",
+                url: "https://stale.example.com/file.pdf",
+                gcsUrl: "gs://stale-bucket/file.pdf",
+                originalName: "file.pdf",
+            },
+            {
+                storageTarget:
+                    createWorkspaceSharedStorageTarget("workspace-123"),
+                persistResolvedFile,
+            },
+        );
+
+        expect(result.status).toBe("resolved");
+        expect(result.file.gcsUrl).toBeNull();
+        expect(persistResolvedFile).toHaveBeenCalledWith(
+            expect.objectContaining({
+                url: "https://primary.example.com/file.pdf",
+                $unset: expect.objectContaining({
+                    error: "",
+                    gcsUrl: "",
+                }),
+            }),
+            expect.objectContaining({
+                url: "https://primary.example.com/file.pdf",
+                gcsUrl: null,
+            }),
+        );
+    });
+});

--- a/app/api/utils/__tests__/file-route-utils.test.js
+++ b/app/api/utils/__tests__/file-route-utils.test.js
@@ -1,0 +1,83 @@
+/**
+ * @jest-environment node
+ */
+
+jest.mock("../../models/workspace.js", () => ({
+    __esModule: true,
+    default: {
+        findOne: jest.fn(),
+    },
+}));
+
+const Workspace = require("../../models/workspace.js").default;
+const { resolveAuthorizedMediaRouting } = require("../file-route-utils.js");
+
+const createSelectQuery = (value) => ({
+    select: jest.fn().mockResolvedValue(value),
+});
+
+describe("resolveAuthorizedMediaRouting", () => {
+    const user = {
+        _id: "mongo-user-1",
+        contextId: "user-context-1",
+    };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("returns user-scoped chat routing by default", async () => {
+        const result = await resolveAuthorizedMediaRouting({
+            user,
+            routingInput: {
+                chatId: "chat-123",
+                fileScope: "chat",
+            },
+        });
+
+        expect(result.routingParams).toEqual({
+            contextId: "user-context-1",
+            userId: "user-context-1",
+            chatId: "chat-123",
+            fileScope: "chat",
+        });
+    });
+
+    it("treats a foreign contextId-only request as workspace-shared routing", async () => {
+        Workspace.findOne.mockReturnValue(
+            createSelectQuery({ _id: "workspace-123" }),
+        );
+
+        const result = await resolveAuthorizedMediaRouting({
+            user,
+            routingInput: {
+                contextId: "workspace-123",
+            },
+        });
+
+        expect(Workspace.findOne).toHaveBeenCalledWith({
+            _id: "workspace-123",
+            owner: "mongo-user-1",
+        });
+        expect(result.routingParams).toEqual({
+            contextId: "workspace-123",
+            workspaceId: "workspace-123",
+            fileScope: "workspace-shared-legacy",
+        });
+    });
+
+    it("rejects attempts to route through another user's context", async () => {
+        await expect(
+            resolveAuthorizedMediaRouting({
+                user,
+                routingInput: {
+                    userId: "other-user-context",
+                    fileScope: "global",
+                },
+            }),
+        ).rejects.toMatchObject({
+            status: 403,
+            message: "Not authorized to access files in this context",
+        });
+    });
+});

--- a/app/api/utils/__tests__/llm-file-utils.test.js
+++ b/app/api/utils/__tests__/llm-file-utils.test.js
@@ -3,13 +3,20 @@
  */
 
 import {
-    buildAgentContext,
+    buildFileAccessPlan,
+    buildRunContext,
     buildWorkspacePromptVariables,
-    createCompoundContextId,
     determineFileContextId,
+    determineFileRouting,
+    extractBlobPathFromUrl,
     fetchShortLivedUrl,
     prepareFileContentForLLM,
 } from "../llm-file-utils";
+import {
+    createUserGlobalStorageTarget,
+    createWorkspacePrivateStorageTarget,
+    createWorkspaceSharedStorageTarget,
+} from "../../../../src/utils/storageTargets.js";
 
 // Mock config
 jest.mock("../../../../config", () => ({
@@ -82,6 +89,8 @@ describe("buildWorkspacePromptVariables", () => {
                         ],
                     },
                 ],
+                contextId: "",
+                contextKey: "",
             });
         });
 
@@ -116,6 +125,8 @@ describe("buildWorkspacePromptVariables", () => {
                         ],
                     },
                 ],
+                contextId: "",
+                contextKey: "",
             });
         });
 
@@ -145,6 +156,8 @@ describe("buildWorkspacePromptVariables", () => {
                         ],
                     },
                 ],
+                contextId: "",
+                contextKey: "",
             });
         });
 
@@ -221,6 +234,8 @@ describe("buildWorkspacePromptVariables", () => {
                         ],
                     },
                 ],
+                contextId: "",
+                contextKey: "",
             });
         });
     });
@@ -236,7 +251,7 @@ describe("buildWorkspacePromptVariables", () => {
                 systemPrompt: "Context",
                 prompt: "Analyze these images",
                 text: "What do you see?",
-                files: mockFiles,
+                userFiles: mockFiles,
             });
 
             const userMessage = result.chatHistory.find(
@@ -260,12 +275,79 @@ describe("buildWorkspacePromptVariables", () => {
             expect(userMessage.content[3]).toContain("image_url");
         });
 
+        it("routes workspace shared files and request files through explicit targets", async () => {
+            const originalFetch = global.fetch;
+            global.fetch = jest
+                .fn()
+                .mockResolvedValueOnce({
+                    ok: true,
+                    json: async () => ({
+                        url: "https://example.com/shared.jpg",
+                        shortLivedUrl: "https://example.com/shared-short",
+                    }),
+                })
+                .mockResolvedValueOnce({
+                    ok: true,
+                    json: async () => ({
+                        url: "https://example.com/private.jpg",
+                        shortLivedUrl: "https://example.com/private-short",
+                    }),
+                });
+
+            try {
+                const result = await buildWorkspacePromptVariables({
+                    prompt: "Analyze these files",
+                    sharedFiles: [
+                        {
+                            _id: "shared-file-1",
+                            hash: "shared-hash",
+                            url: "https://example.com/shared.jpg",
+                        },
+                    ],
+                    userFiles: [
+                        {
+                            hash: "user-hash",
+                            url: "https://example.com/private.jpg",
+                        },
+                    ],
+                    workspaceId: "workspace123",
+                    userContextId: "user456",
+                });
+
+                const userMessage = result.chatHistory.find(
+                    (message) => message.role === "user",
+                );
+                const sharedEntry = JSON.parse(userMessage.content[1]);
+                const userEntry = JSON.parse(userMessage.content[2]);
+
+                expect(sharedEntry).toEqual(
+                    expect.objectContaining({
+                        url: "https://example.com/shared-short",
+                        contextId: "workspace123",
+                        fileScope: "workspace-shared-legacy",
+                        workspaceId: "workspace123",
+                    }),
+                );
+                expect(userEntry).toEqual(
+                    expect.objectContaining({
+                        url: "https://example.com/private-short",
+                        contextId: "user456",
+                        fileScope: "workspace-user-legacy",
+                        userId: "user456",
+                        workspaceId: "workspace123",
+                    }),
+                );
+            } finally {
+                global.fetch = originalFetch;
+            }
+        });
+
         it("should include files even when no text content", async () => {
             const mockFiles = [{ hash: "hash1", url: "url1" }];
 
             const result = await buildWorkspacePromptVariables({
                 systemPrompt: "Context",
-                files: mockFiles,
+                userFiles: mockFiles,
             });
 
             const userMessage = result.chatHistory.find(
@@ -323,7 +405,7 @@ describe("buildWorkspacePromptVariables", () => {
                 systemPrompt: "Should be ignored",
                 prompt: "Should be ignored",
                 text: "Should be ignored",
-                files: mockFiles,
+                userFiles: mockFiles,
                 chatHistory: providedChatHistory,
             });
 
@@ -357,7 +439,7 @@ describe("buildWorkspacePromptVariables", () => {
             const mockFiles = [{ hash: "hash1", url: "url1" }];
 
             const result = await buildWorkspacePromptVariables({
-                files: mockFiles,
+                userFiles: mockFiles,
                 chatHistory: providedChatHistory,
             });
 
@@ -420,7 +502,7 @@ describe("buildWorkspacePromptVariables", () => {
             const mockFiles = [{ hash: "hash1", url: "url1" }];
 
             const result = await buildWorkspacePromptVariables({
-                files: mockFiles,
+                userFiles: mockFiles,
                 chatHistory: providedChatHistory,
             });
 
@@ -435,8 +517,8 @@ describe("buildWorkspacePromptVariables", () => {
         });
     });
 
-    describe("agentContext", () => {
-        it("should return agentContext with workspace and compound contexts when both are provided", async () => {
+    describe("fileAccessPlan and runContext", () => {
+        it("should return fileAccessPlan with workspace write target and user files read target when workspaceId is provided", async () => {
             const result = await buildWorkspacePromptVariables({
                 systemPrompt: "Context",
                 prompt: "Prompt",
@@ -445,45 +527,26 @@ describe("buildWorkspacePromptVariables", () => {
                 workspaceContextKey: "workspace-key",
                 userContextId: "user456",
                 userContextKey: "user-key",
-                useCompoundContextId: true,
             });
 
-            expect(result.agentContext).toHaveLength(2);
-            // First context is workspace (default)
-            expect(result.agentContext[0]).toEqual({
-                contextId: "workspace123",
-                contextKey: "workspace-key",
-                default: true,
-            });
-            // Second context is compound (user files in workspace)
-            expect(result.agentContext[1]).toEqual({
-                contextId: "workspace123:user456",
-                contextKey: "user-key",
-                default: false,
-            });
+            expect(result.fileAccessPlan).toEqual([
+                {
+                    kind: "app-shared",
+                    workspaceId: "workspace123",
+                    contextKey: "workspace-key",
+                    write: true,
+                },
+                {
+                    kind: "user-files",
+                    userContextId: "user456",
+                    contextKey: "user-key",
+                },
+            ]);
+            expect(result.contextId).toBe("workspace123");
+            expect(result.contextKey).toBe("workspace-key");
         });
 
-        it("should return only workspace context when useCompoundContextId is false", async () => {
-            const result = await buildWorkspacePromptVariables({
-                systemPrompt: "Context",
-                prompt: "Prompt",
-                text: "Text",
-                workspaceId: "workspace123",
-                workspaceContextKey: "workspace-key",
-                userContextId: "user456",
-                userContextKey: "user-key",
-                useCompoundContextId: false,
-            });
-
-            expect(result.agentContext).toHaveLength(1);
-            expect(result.agentContext[0]).toEqual({
-                contextId: "workspace123",
-                contextKey: "workspace-key",
-                default: true,
-            });
-        });
-
-        it("should return user context only when no workspaceId", async () => {
+        it("should return user-global write target only when no narrower context exists", async () => {
             const result = await buildWorkspacePromptVariables({
                 systemPrompt: "Context",
                 prompt: "Prompt",
@@ -491,28 +554,58 @@ describe("buildWorkspacePromptVariables", () => {
                 workspaceId: null,
                 userContextId: "user456",
                 userContextKey: "user-key",
-                useCompoundContextId: true,
             });
 
-            expect(result.agentContext).toHaveLength(1);
-            expect(result.agentContext[0]).toEqual({
-                contextId: "user456",
-                contextKey: "user-key",
-                default: true,
-            });
+            expect(result.fileAccessPlan).toEqual([
+                {
+                    kind: "user-global",
+                    userContextId: "user456",
+                    contextKey: "user-key",
+                    write: true,
+                },
+            ]);
+            expect(result.contextId).toBe("user456");
+            expect(result.contextKey).toBe("user-key");
         });
 
-        it("should not return agentContext when no contextIds provided", async () => {
+        it("should prefer current chat writes and include all user files for reads when chatId is provided", async () => {
+            const result = await buildWorkspacePromptVariables({
+                systemPrompt: "Context",
+                prompt: "Prompt",
+                text: "Text",
+                chatId: "chat789",
+                userContextId: "user456",
+                userContextKey: "user-key",
+            });
+
+            expect(result.fileAccessPlan).toEqual([
+                {
+                    kind: "chat",
+                    userContextId: "user456",
+                    chatId: "chat789",
+                    contextKey: "user-key",
+                    write: true,
+                },
+                {
+                    kind: "user-files",
+                    userContextId: "user456",
+                    contextKey: "user-key",
+                },
+            ]);
+        });
+
+        it("should not return fileAccessPlan when no contextIds provided", async () => {
             const result = await buildWorkspacePromptVariables({
                 systemPrompt: "Context",
                 prompt: "Prompt",
                 text: "Text",
                 workspaceId: null,
                 userContextId: null,
-                useCompoundContextId: true,
             });
 
-            expect(result.agentContext).toBeUndefined();
+            expect(result.fileAccessPlan).toBeUndefined();
+            expect(result.contextId).toBe("");
+            expect(result.contextKey).toBe("");
         });
 
         it("should handle missing contextKeys gracefully", async () => {
@@ -524,27 +617,21 @@ describe("buildWorkspacePromptVariables", () => {
                 workspaceContextKey: null,
                 userContextId: "user456",
                 userContextKey: null,
-                useCompoundContextId: true,
             });
 
-            expect(result.agentContext).toHaveLength(2);
-            expect(result.agentContext[0].contextKey).toBe("");
-            expect(result.agentContext[1].contextKey).toBe("");
-        });
-
-        it("should default useCompoundContextId to true", async () => {
-            const result = await buildWorkspacePromptVariables({
-                systemPrompt: "Context",
-                prompt: "Prompt",
-                text: "Text",
-                workspaceId: "workspace123",
-                workspaceContextKey: "workspace-key",
-                userContextId: "user456",
-                userContextKey: "user-key",
-            });
-
-            // Should include both workspace and compound contexts
-            expect(result.agentContext).toHaveLength(2);
+            expect(result.fileAccessPlan).toEqual([
+                {
+                    kind: "app-shared",
+                    workspaceId: "workspace123",
+                    write: true,
+                },
+                {
+                    kind: "user-files",
+                    userContextId: "user456",
+                },
+            ]);
+            expect(result.contextId).toBe("workspace123");
+            expect(result.contextKey).toBe("");
         });
     });
 
@@ -590,7 +677,7 @@ describe("buildWorkspacePromptVariables", () => {
                 systemPrompt: null,
                 prompt: undefined,
                 text: null,
-                files: null,
+                userFiles: null,
                 chatHistory: undefined,
             });
 
@@ -612,7 +699,7 @@ describe("buildWorkspacePromptVariables", () => {
                 systemPrompt: "Context",
                 prompt: "Prompt",
                 text: "Text",
-                files: [],
+                userFiles: [],
             });
 
             const userMessage = result.chatHistory.find(
@@ -623,79 +710,89 @@ describe("buildWorkspacePromptVariables", () => {
     });
 });
 
-describe("createCompoundContextId", () => {
-    it("should create compound contextId from workspaceId and userContextId", () => {
-        const result = createCompoundContextId("workspace123", "user456");
-        expect(result).toBe("workspace123:user456");
-    });
-
-    it("should handle various ID formats", () => {
-        expect(createCompoundContextId("abc-123", "xyz-789")).toBe(
-            "abc-123:xyz-789",
-        );
-        expect(createCompoundContextId("workspaceId", "contextId")).toBe(
-            "workspaceId:contextId",
-        );
-    });
-});
-
-describe("buildAgentContext", () => {
-    it("should build workspace context with compound context when all params provided", () => {
-        const result = buildAgentContext({
+describe("buildFileAccessPlan", () => {
+    it("should build workspace write target and user files read target when workspaceId is provided", () => {
+        const result = buildFileAccessPlan({
             workspaceId: "workspace123",
             workspaceContextKey: "workspace-key",
             userContextId: "user456",
             userContextKey: "user-key",
-            includeCompoundContext: true,
         });
 
-        expect(result).toHaveLength(2);
-        expect(result[0]).toEqual({
-            contextId: "workspace123",
-            contextKey: "workspace-key",
-            default: true,
-        });
-        expect(result[1]).toEqual({
-            contextId: "workspace123:user456",
-            contextKey: "user-key",
-            default: false,
-        });
+        expect(result).toEqual([
+            {
+                kind: "app-shared",
+                workspaceId: "workspace123",
+                contextKey: "workspace-key",
+                write: true,
+            },
+            {
+                kind: "user-files",
+                userContextId: "user456",
+                contextKey: "user-key",
+            },
+        ]);
     });
 
-    it("should build only workspace context when includeCompoundContext is false", () => {
-        const result = buildAgentContext({
+    it("should build workspace target only when no userContextId", () => {
+        const result = buildFileAccessPlan({
             workspaceId: "workspace123",
             workspaceContextKey: "workspace-key",
-            userContextId: "user456",
-            userContextKey: "user-key",
-            includeCompoundContext: false,
+            userContextId: null,
         });
 
-        expect(result).toHaveLength(1);
-        expect(result[0]).toEqual({
-            contextId: "workspace123",
-            contextKey: "workspace-key",
-            default: true,
-        });
+        expect(result).toEqual([
+            {
+                kind: "app-shared",
+                workspaceId: "workspace123",
+                contextKey: "workspace-key",
+                write: true,
+            },
+        ]);
     });
 
-    it("should build user context only when no workspaceId", () => {
-        const result = buildAgentContext({
+    it("should build user target only when no workspaceId", () => {
+        const result = buildFileAccessPlan({
             workspaceId: null,
             userContextId: "user456",
             userContextKey: "user-key",
         });
 
-        expect(result).toHaveLength(1);
-        expect(result[0]).toEqual({
-            contextId: "user456",
-            contextKey: "user-key",
-            default: true,
+        expect(result).toEqual([
+            {
+                kind: "user-global",
+                userContextId: "user456",
+                contextKey: "user-key",
+                write: true,
+            },
+        ]);
+    });
+
+    it("should build chat write target and user files read target when chatId is provided", () => {
+        const result = buildFileAccessPlan({
+            chatId: "chat789",
+            userContextId: "user456",
+            userContextKey: "user-key",
         });
+
+        expect(result).toEqual([
+            {
+                kind: "chat",
+                userContextId: "user456",
+                chatId: "chat789",
+                contextKey: "user-key",
+                write: true,
+            },
+            {
+                kind: "user-files",
+                userContextId: "user456",
+                contextKey: "user-key",
+            },
+        ]);
     });
 
     it("should return empty array when no contextIds provided", () => {
-        const result = buildAgentContext({
+        const result = buildFileAccessPlan({
             workspaceId: null,
             userContextId: null,
         });
@@ -703,30 +800,105 @@ describe("buildAgentContext", () => {
         expect(result).toEqual([]);
     });
 
-    it("should handle missing contextKeys with empty strings", () => {
-        const result = buildAgentContext({
+    it("should not build applet targets when applet userContextId is missing", () => {
+        const result = buildFileAccessPlan({
+            appletId: "applet-123",
+            workspaceId: "workspace123",
+            workspaceContextKey: "workspace-key",
+            userContextId: null,
+        });
+
+        expect(result).toEqual([]);
+    });
+
+    it("should omit contextKeys when they are missing", () => {
+        const result = buildFileAccessPlan({
             workspaceId: "workspace123",
             workspaceContextKey: null,
             userContextId: "user456",
             userContextKey: null,
-            includeCompoundContext: true,
         });
 
-        expect(result).toHaveLength(2);
-        expect(result[0].contextKey).toBe("");
-        expect(result[1].contextKey).toBe("");
+        expect(result).toEqual([
+            {
+                kind: "app-shared",
+                workspaceId: "workspace123",
+                write: true,
+            },
+            {
+                kind: "user-files",
+                userContextId: "user456",
+            },
+        ]);
+    });
+});
+
+describe("buildRunContext", () => {
+    it("should build workspace run context when workspaceId is provided", () => {
+        const result = buildRunContext({
+            workspaceId: "workspace123",
+            workspaceContextKey: "workspace-key",
+            userContextId: "user456",
+            userContextKey: "user-key",
+        });
+
+        expect(result).toEqual({
+            contextId: "workspace123",
+            contextKey: "workspace-key",
+        });
     });
 
-    it("should not include compound context when userContextId is missing", () => {
-        const result = buildAgentContext({
+    it("should build user run context when no workspaceId", () => {
+        const result = buildRunContext({
+            workspaceId: null,
+            userContextId: "user456",
+            userContextKey: "user-key",
+        });
+
+        expect(result).toEqual({
+            contextId: "user456",
+            contextKey: "user-key",
+        });
+    });
+
+    it("should return empty run context when no contextIds provided", () => {
+        const result = buildRunContext({
+            workspaceId: null,
+            userContextId: null,
+        });
+
+        expect(result).toEqual({
+            contextId: "",
+            contextKey: "",
+        });
+    });
+
+    it("should return empty run context when applet userContextId is missing", () => {
+        const result = buildRunContext({
+            appletId: "applet-123",
             workspaceId: "workspace123",
             workspaceContextKey: "workspace-key",
             userContextId: null,
-            includeCompoundContext: true,
         });
 
-        expect(result).toHaveLength(1);
-        expect(result[0].contextId).toBe("workspace123");
+        expect(result).toEqual({
+            contextId: "",
+            contextKey: "",
+        });
+    });
+
+    it("should handle missing contextKeys with empty strings", () => {
+        const result = buildRunContext({
+            workspaceId: "workspace123",
+            workspaceContextKey: null,
+            userContextId: "user456",
+            userContextKey: null,
+        });
+
+        expect(result).toEqual({
+            contextId: "workspace123",
+            contextKey: "",
+        });
     });
 });
 
@@ -747,46 +919,6 @@ describe("determineFileContextId", () => {
             userContextId: "user123",
         });
         expect(result).toBe("user123");
-    });
-
-    it("should return compound contextId for non-artifacts when useCompoundContextId is true", () => {
-        const result = determineFileContextId({
-            isArtifact: false,
-            workspaceId: "workspace123",
-            userContextId: "user123",
-            useCompoundContextId: true,
-        });
-        expect(result).toBe("workspace123:user123");
-    });
-
-    it("should return userContextId for non-artifacts when useCompoundContextId is true but workspaceId is missing", () => {
-        const result = determineFileContextId({
-            isArtifact: false,
-            workspaceId: null,
-            userContextId: "user123",
-            useCompoundContextId: true,
-        });
-        expect(result).toBe("user123");
-    });
-
-    it("should return null for non-artifacts when useCompoundContextId is true but userContextId is missing", () => {
-        const result = determineFileContextId({
-            isArtifact: false,
-            workspaceId: "workspace123",
-            userContextId: null,
-            useCompoundContextId: true,
-        });
-        expect(result).toBeNull();
-    });
-
-    it("should return workspaceId for artifacts even when useCompoundContextId is true", () => {
-        const result = determineFileContextId({
-            isArtifact: true,
-            workspaceId: "workspace123",
-            userContextId: "user123",
-            useCompoundContextId: true,
-        });
-        expect(result).toBe("workspace123");
     });
 
     it("should return userContextId for artifacts when workspaceId is not provided", () => {
@@ -834,6 +966,86 @@ describe("determineFileContextId", () => {
     });
 });
 
+describe("determineFileRouting", () => {
+    it("should return workspace-shared-legacy routing for artifacts with workspaceId", () => {
+        const result = determineFileRouting({
+            isArtifact: true,
+            workspaceId: "workspace123",
+            userId: "user123",
+        });
+        expect(result).toEqual({
+            workspaceId: "workspace123",
+            fileScope: "workspace-shared-legacy",
+        });
+    });
+
+    it("should return chat routing when chatId is provided", () => {
+        const result = determineFileRouting({
+            isArtifact: false,
+            workspaceId: null,
+            userId: "user123",
+            chatId: "chat456",
+        });
+        expect(result).toEqual({
+            userId: "user123",
+            chatId: "chat456",
+            workspaceId: null,
+            fileScope: "chat",
+        });
+    });
+
+    it("should return applet routing when workspaceId is provided without chatId", () => {
+        const result = determineFileRouting({
+            isArtifact: false,
+            workspaceId: "workspace123",
+            userId: "user123",
+        });
+        expect(result).toEqual({
+            userId: "user123",
+            chatId: null,
+            workspaceId: "workspace123",
+            fileScope: "workspace-user-legacy",
+        });
+    });
+
+    it("should return global routing when no chatId or workspaceId", () => {
+        const result = determineFileRouting({
+            isArtifact: false,
+            userId: "user123",
+        });
+        expect(result).toEqual({
+            userId: "user123",
+            chatId: null,
+            workspaceId: null,
+            fileScope: "global",
+        });
+    });
+
+    it("should fall back to user routing when artifact has no workspaceId", () => {
+        const result = determineFileRouting({
+            isArtifact: true,
+            workspaceId: null,
+            userId: "user123",
+        });
+        expect(result).toEqual({
+            userId: "user123",
+            chatId: null,
+            workspaceId: null,
+            fileScope: "global",
+        });
+    });
+
+    it("should handle empty options", () => {
+        const result = determineFileRouting({});
+        expect(result).toEqual({
+            userId: undefined,
+            chatId: null,
+            workspaceId: null,
+            fileScope: "global",
+        });
+    });
+});
+
 describe("fetchShortLivedUrl", () => {
     const originalFetch = global.fetch;
     const config = require("../../../../config");
@@ -851,7 +1063,7 @@ describe("fetchShortLivedUrl", () => {
         global.fetch = originalFetch;
     });
 
-    it("should return shortLivedUrl from media-helper response", async () => {
+    it("should return shortLivedUrl and gcs from media-helper response", async () => {
         const mockShortLivedUrl =
             "https://example.com/short-lived-url?expires=300";
         global.fetch.mockResolvedValue({
@@ -859,13 +1071,20 @@ describe("fetchShortLivedUrl", () => {
             json: async () => ({
                 url: "https://example.com/original-url",
                 shortLivedUrl: mockShortLivedUrl,
+                gcs: "gs://bucket/file.jpg",
                 hash: "testhash",
             }),
         });
 
-        const result = await fetchShortLivedUrl("testhash", "context123");
+        const result = await fetchShortLivedUrl({
+            hash: "testhash",
+            contextId: "context123",
+        });
 
-        expect(result).toBe(mockShortLivedUrl);
+        expect(result).toEqual({
+            url: mockShortLivedUrl,
+            gcs: "gs://bucket/file.jpg",
+        });
         expect(global.fetch).toHaveBeenCalledWith(
             expect.stringContaining("checkHash=true"),
         );
@@ -880,6 +1099,83 @@ describe("fetchShortLivedUrl", () => {
         );
     });
 
+    it("should prefer blobPath over hash when both provided", async () => {
+        global.fetch.mockResolvedValue({
+            ok: true,
+            json: async () => ({
+                url: "https://example.com/url",
+                shortLivedUrl: "https://example.com/short",
+            }),
+        });
+
+        await fetchShortLivedUrl({
+            blobPath: "global/abc_file.pdf",
+            hash: "testhash",
+            contextId: "context123",
+        });
+
+        const fetchUrl = global.fetch.mock.calls[0][0];
+        expect(fetchUrl).toContain("blobPath=");
+        expect(fetchUrl).not.toContain("hash=testhash");
+        expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it("should fall back to hash when blobPath lookup misses", async () => {
+        global.fetch
+            .mockResolvedValueOnce({
+                ok: false,
+                status: 404,
+                text: async () => "Blob path not found",
+            })
+            .mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({
+                    url: "https://example.com/url",
+                    shortLivedUrl: "https://example.com/short",
+                    gcs: "gs://bucket/fallback.pdf",
+                }),
+            });
+
+        const result = await fetchShortLivedUrl({
+            blobPath: "global/abc_file.pdf",
+            hash: "testhash",
+            contextId: "context123",
+        });
+
+        expect(result).toEqual({
+            url: "https://example.com/short",
+            gcs: "gs://bucket/fallback.pdf",
+        });
+        expect(global.fetch).toHaveBeenCalledTimes(2);
+        expect(global.fetch.mock.calls[0][0]).toContain("blobPath=");
+        expect(global.fetch.mock.calls[0][0]).not.toContain("hash=testhash");
+        expect(global.fetch.mock.calls[1][0]).toContain("hash=testhash");
+        expect(global.fetch.mock.calls[1][0]).toContain("checkHash=true");
+    });
+
+    it("should work with blobPath only (no hash)", async () => {
+        global.fetch.mockResolvedValue({
+            ok: true,
+            json: async () => ({
+                url: "https://example.com/url",
+                shortLivedUrl: "https://example.com/short",
+            }),
+        });
+
+        const result = await fetchShortLivedUrl({
+            blobPath: "global/abc_file.pdf",
+            contextId: "context123",
+        });
+
+        expect(result).toEqual({
+            url: "https://example.com/short",
+            gcs: null,
+        });
+        const fetchUrl = global.fetch.mock.calls[0][0];
+        expect(fetchUrl).toContain("blobPath=");
+        expect(fetchUrl).not.toContain("checkHash=");
+    });
+
     it("should fallback to url if shortLivedUrl is not in response", async () => {
         const mockUrl = "https://example.com/original-url";
         global.fetch.mockResolvedValue({
@@ -890,15 +1186,21 @@ describe("fetchShortLivedUrl", () => {
             }),
         });
 
-        const result = await fetchShortLivedUrl("testhash", "context123");
+        const result = await fetchShortLivedUrl({
+            hash: "testhash",
+            contextId: "context123",
+        });
 
-        expect(result).toBe(mockUrl);
+        expect(result).toEqual({ url: mockUrl, gcs: null });
     });
 
     it("should return null when media-helper URL is not configured", async () => {
         config.endpoints.mediaHelperDirect.mockReturnValue(null);
 
-        const result = await fetchShortLivedUrl("testhash", "context123");
+        const result = await fetchShortLivedUrl({
+            hash: "testhash",
+            contextId: "context123",
+        });
 
         expect(result).toBeNull();
         expect(global.fetch).not.toHaveBeenCalled();
@@ -907,7 +1209,10 @@ describe("fetchShortLivedUrl", () => {
     it("should return null when fetch fails", async () => {
         global.fetch.mockRejectedValue(new Error("Network error"));
 
-        const result = await fetchShortLivedUrl("testhash", "context123");
+        const result = await fetchShortLivedUrl({
+            hash: "testhash",
+            contextId: "context123",
+        });
 
         expect(result).toBeNull();
     });
@@ -919,7 +1224,10 @@ describe("fetchShortLivedUrl", () => {
             text: async () => "Not found",
         });
 
-        const result = await fetchShortLivedUrl("testhash", "context123");
+        const result = await fetchShortLivedUrl({
+            hash: "testhash",
+            contextId: "context123",
+        });
 
         expect(result).toBeNull();
     });
@@ -932,7 +1240,10 @@ describe("fetchShortLivedUrl", () => {
             },
         });
 
-        const result = await fetchShortLivedUrl("testhash", "context123");
+        const result = await fetchShortLivedUrl({
+            hash: "testhash",
+            contextId: "context123",
+        });
 
         expect(result).toBeNull();
     });
@@ -945,7 +1256,7 @@ describe("fetchShortLivedUrl", () => {
             }),
         });
 
-        await fetchShortLivedUrl("testhash", null);
+        await fetchShortLivedUrl({ hash: "testhash" });
 
         expect(global.fetch).toHaveBeenCalledWith(
             expect.not.stringContaining("contextId"),
@@ -975,13 +1286,12 @@ describe("prepareFileContentForLLM", () => {
         expect(result).toEqual([]);
     });
 
-    it("should format files with workspaceId for artifacts", async () => {
+    it("should format files with a workspace-shared storage target", async () => {
         const mockFiles = [
             {
                 _id: "file123",
                 hash: "hash1",
                 url: "https://example.com/file1.jpg",
-                gcsUrl: "gs://bucket/file1.jpg",
             },
         ];
 
@@ -990,15 +1300,13 @@ describe("prepareFileContentForLLM", () => {
             json: async () => ({
                 url: "https://example.com/file1.jpg",
                 shortLivedUrl: "https://example.com/short-lived-1",
+                gcs: "gs://bucket/file1.jpg",
             }),
         });
 
-        const result = await prepareFileContentForLLM(
-            mockFiles,
-            "workspace123",
-            null,
-            true,
-        );
+        const result = await prepareFileContentForLLM(mockFiles, {
+            storageTarget: createWorkspaceSharedStorageTarget("workspace123"),
+        });
 
         expect(result).toHaveLength(1);
         const fileObj = JSON.parse(result[0]);
@@ -1009,12 +1317,11 @@ describe("prepareFileContentForLLM", () => {
         expect(fileObj.contextId).toBe("workspace123");
     });
 
-    it("should format files with userContextId for non-artifacts", async () => {
+    it("should format files with a user-global storage target", async () => {
         const mockFiles = [
             {
                 hash: "hash1",
                 url: "https://example.com/file1.jpg",
-                gcsUrl: "gs://bucket/file1.jpg",
             },
         ];
 
@@ -1026,12 +1333,9 @@ describe("prepareFileContentForLLM", () => {
             }),
         });
 
-        const result = await prepareFileContentForLLM(
-            mockFiles,
-            null,
-            "user123",
-            true,
-        );
+        const result = await prepareFileContentForLLM(mockFiles, {
+            storageTarget: createUserGlobalStorageTarget("user123"),
+        });
 
         expect(result).toHaveLength(1);
         const fileObj = JSON.parse(result[0]);
@@ -1044,16 +1348,13 @@ describe("prepareFileContentForLLM", () => {
                 _id: "file123",
                 hash: "hash1",
                 url: "https://example.com/file1.jpg",
-                gcsUrl: "gs://bucket/file1.jpg",
             },
         ];
 
-        const result = await prepareFileContentForLLM(
-            mockFiles,
-            "workspace123",
-            null,
-            false,
-        );
+        const result = await prepareFileContentForLLM(mockFiles, {
+            storageTarget: createWorkspaceSharedStorageTarget("workspace123"),
+            fetchShortLivedUrls: false,
+        });
 
         expect(result).toHaveLength(1);
         const fileObj = JSON.parse(result[0]);
@@ -1066,16 +1367,12 @@ describe("prepareFileContentForLLM", () => {
             {
                 _id: "file123",
                 url: "https://example.com/file1.jpg",
-                gcsUrl: "gs://bucket/file1.jpg",
             },
         ];
 
-        const result = await prepareFileContentForLLM(
-            mockFiles,
-            "workspace123",
-            null,
-            true,
-        );
+        const result = await prepareFileContentForLLM(mockFiles, {
+            storageTarget: createWorkspaceSharedStorageTarget("workspace123"),
+        });
 
         expect(result).toHaveLength(1);
         const fileObj = JSON.parse(result[0]);
@@ -1089,16 +1386,12 @@ describe("prepareFileContentForLLM", () => {
                 _id: "file123",
                 hash: "hash1",
                 url: "https://example.com/file1.jpg",
-                gcsUrl: "gs://bucket/file1.jpg",
             },
         ];
 
-        const result = await prepareFileContentForLLM(
-            mockFiles,
-            null,
-            null,
-            true,
-        );
+        const result = await prepareFileContentForLLM(mockFiles, {
+            storageTarget: createWorkspaceSharedStorageTarget(null),
+        });
 
         expect(result).toHaveLength(1);
         const fileObj = JSON.parse(result[0]);
@@ -1106,50 +1399,72 @@ describe("prepareFileContentForLLM", () => {
         expect(global.fetch).not.toHaveBeenCalled();
     });
 
-    it("should use converted file URL and hash when available", async () => {
+    it("should use file URL and hash for short-lived URL fetch", async () => {
         const mockFiles = [
             {
                 _id: "file123",
-                hash: "original-hash",
+                hash: "file-hash",
                 url: "https://example.com/original.jpg",
-                converted: {
-                    hash: "converted-hash",
-                    url: "https://example.com/converted.jpg",
-                    gcs: "gs://bucket/converted.jpg",
-                },
             },
         ];
 
         global.fetch.mockResolvedValue({
             ok: true,
             json: async () => ({
-                url: "https://example.com/converted.jpg",
-                shortLivedUrl: "https://example.com/short-lived-converted",
+                url: "https://example.com/original.jpg",
+                shortLivedUrl: "https://example.com/short-lived-original",
+                gcs: "gs://bucket/original.jpg",
             }),
         });
 
-        const result = await prepareFileContentForLLM(
-            mockFiles,
-            "workspace123",
-            null,
-            true,
-        );
+        const result = await prepareFileContentForLLM(mockFiles, {
+            storageTarget: createWorkspaceSharedStorageTarget("workspace123"),
+        });
 
         expect(result).toHaveLength(1);
         const fileObj = JSON.parse(result[0]);
-        expect(fileObj.url).toBe("https://example.com/short-lived-converted");
-        expect(fileObj.gcs).toBe("gs://bucket/converted.jpg");
-        expect(fileObj.hash).toBe("converted-hash");
-        // Should use converted hash for fetching short-lived URL
+        expect(fileObj.url).toBe("https://example.com/short-lived-original");
+        expect(fileObj.gcs).toBe("gs://bucket/original.jpg");
+        expect(fileObj.hash).toBe("file-hash");
+        // Should use hash for fetching short-lived URL
         expect(global.fetch).toHaveBeenCalledWith(
-            expect.stringContaining("hash=converted-hash"),
+            expect.stringContaining("hash=file-hash"),
+            expect.objectContaining({ cache: "no-store" }),
         );
     });
 
-    it("should handle multiple files", async () => {
+    it("should preserve blobPath and hash in Cortex file content", async () => {
         const mockFiles = [
             {
-                _id: "file1",
+                _id: "file123",
+                blobPath: "global/concierge-gemini.png",
+                hash: "file-hash",
+                url: "https://example.com/original.jpg",
+            },
+        ];
+
+        global.fetch.mockResolvedValue({
+            ok: true,
+            json: async () => ({
+                url: "https://example.com/original.jpg",
+                shortLivedUrl: "https://example.com/short-lived-original",
+            }),
+        });
+
+        const result = await prepareFileContentForLLM(mockFiles, {
+            storageTarget: createWorkspaceSharedStorageTarget("workspace123"),
+        });
+
+        const fileObj = JSON.parse(result[0]);
+        expect(fileObj.blobPath).toBe("global/concierge-gemini.png");
+        expect(fileObj.hash).toBe("file-hash");
+        expect(global.fetch.mock.calls[0][0]).toContain("blobPath=");
+        expect(global.fetch.mock.calls[0][0]).not.toContain("hash=file-hash");
+    });
+
+    it("should handle multiple files with one explicit storage target", async () => {
+        const mockFiles = [
+            {
                 hash: "hash1",
                 url: "https://example.com/file1.jpg",
             },
@@ -1159,139 +1474,16 @@ describe("prepareFileContentForLLM", () => {
             },
         ];
 
-        global.fetch
-            .mockResolvedValueOnce({
-                ok: true,
-                json: async () => ({
-                    url: "https://example.com/file1.jpg",
-                    shortLivedUrl: "https://example.com/short-lived-1",
-                }),
-            })
-            .mockResolvedValueOnce({
-                ok: true,
-                json: async () => ({
-                    url: "https://example.com/file2.jpg",
-                    shortLivedUrl: "https://example.com/short-lived-2",
-                }),
-            });
-
-        const result = await prepareFileContentForLLM(
-            mockFiles,
-            "workspace123",
-            "user123",
-            true,
-        );
+        const result = await prepareFileContentForLLM(mockFiles, {
+            storageTarget: createUserGlobalStorageTarget("user123"),
+            fetchShortLivedUrls: false,
+        });
 
         expect(result).toHaveLength(2);
         const file1Obj = JSON.parse(result[0]);
         const file2Obj = JSON.parse(result[1]);
-        expect(file1Obj.contextId).toBe("workspace123");
+        expect(file1Obj.contextId).toBe("user123");
         expect(file2Obj.contextId).toBe("user123");
-    });
-
-    it("should use compound contextId for non-artifact files when useCompoundContextId is true", async () => {
-        const mockFiles = [
-            {
-                // No _id, so it's a user file (non-artifact)
-                hash: "hash1",
-                url: "https://example.com/file1.jpg",
-            },
-        ];
-
-        global.fetch.mockResolvedValue({
-            ok: true,
-            json: async () => ({
-                url: "https://example.com/file1.jpg",
-                shortLivedUrl: "https://example.com/short-lived-1",
-            }),
-        });
-
-        const result = await prepareFileContentForLLM(
-            mockFiles,
-            "workspace123",
-            "user123",
-            true,
-            true, // useCompoundContextId
-        );
-
-        expect(result).toHaveLength(1);
-        const fileObj = JSON.parse(result[0]);
-        expect(fileObj.contextId).toBe("workspace123:user123");
-    });
-
-    it("should use workspaceId for artifact files even when useCompoundContextId is true", async () => {
-        const mockFiles = [
-            {
-                _id: "file123", // Has _id, so it's an artifact
-                hash: "hash1",
-                url: "https://example.com/file1.jpg",
-            },
-        ];
-
-        global.fetch.mockResolvedValue({
-            ok: true,
-            json: async () => ({
-                url: "https://example.com/file1.jpg",
-                shortLivedUrl: "https://example.com/short-lived-1",
-            }),
-        });
-
-        const result = await prepareFileContentForLLM(
-            mockFiles,
-            "workspace123",
-            "user123",
-            true,
-            true, // useCompoundContextId - but should not apply to artifacts
-        );
-
-        expect(result).toHaveLength(1);
-        const fileObj = JSON.parse(result[0]);
-        expect(fileObj.contextId).toBe("workspace123"); // Artifact uses workspaceId
-    });
-
-    it("should handle mixed artifact and user files with useCompoundContextId", async () => {
-        const mockFiles = [
-            {
-                _id: "file1", // Artifact
-                hash: "hash1",
-                url: "https://example.com/artifact.jpg",
-            },
-            {
-                // User file (no _id)
-                hash: "hash2",
-                url: "https://example.com/userfile.jpg",
-            },
-        ];
-
-        global.fetch
-            .mockResolvedValueOnce({
-                ok: true,
-                json: async () => ({
-                    url: "https://example.com/artifact.jpg",
-                    shortLivedUrl: "https://example.com/short-lived-1",
-                }),
-            })
-            .mockResolvedValueOnce({
-                ok: true,
-                json: async () => ({
-                    url: "https://example.com/userfile.jpg",
-                    shortLivedUrl: "https://example.com/short-lived-2",
-                }),
-            });
-
-        const result = await prepareFileContentForLLM(
-            mockFiles,
-            "workspace123",
-            "user123",
-            true,
-            true, // useCompoundContextId
-        );
-
-        expect(result).toHaveLength(2);
-        const file1Obj = JSON.parse(result[0]);
-        const file2Obj = JSON.parse(result[1]);
-        expect(file1Obj.contextId).toBe("workspace123"); // Artifact uses workspaceId
-        expect(file2Obj.contextId).toBe("workspace123:user123"); // User file uses compound
     });
 
     it("should fallback to original URL when short-lived URL fetch fails", async () => {
@@ -1300,7 +1492,6 @@ describe("prepareFileContentForLLM", () => {
                 _id: "file123",
                 hash: "hash1",
                 url: "https://example.com/file1.jpg",
-                gcsUrl: "gs://bucket/file1.jpg",
             },
         ];
 
@@ -1309,12 +1500,9 @@ describe("prepareFileContentForLLM", () => {
             status: 404,
         });
 
-        const result = await prepareFileContentForLLM(
-            mockFiles,
-            "workspace123",
-            null,
-            true,
-        );
+        const result = await prepareFileContentForLLM(mockFiles, {
+            storageTarget: createWorkspaceSharedStorageTarget("workspace123"),
+        });
 
         expect(result).toHaveLength(1);
         const fileObj = JSON.parse(result[0]);
@@ -1338,12 +1526,9 @@ describe("prepareFileContentForLLM", () => {
             }),
         });
 
-        const result = await prepareFileContentForLLM(
-            mockFiles,
-            "workspace123",
-            null,
-            true,
-        );
+        const result = await prepareFileContentForLLM(mockFiles, {
+            storageTarget: createWorkspaceSharedStorageTarget("workspace123"),
+        });
 
         const fileObj = JSON.parse(result[0]);
         expect(fileObj.image_url).toEqual({
@@ -1351,7 +1536,7 @@ describe("prepareFileContentForLLM", () => {
         });
     });
 
-    it("should handle files without gcsUrl", async () => {
+    it("should omit gcs when CFH response has no gcs", async () => {
         const mockFiles = [
             {
                 _id: "file123",
@@ -1368,14 +1553,99 @@ describe("prepareFileContentForLLM", () => {
             }),
         });
 
-        const result = await prepareFileContentForLLM(
-            mockFiles,
-            "workspace123",
-            null,
-            true,
-        );
+        const result = await prepareFileContentForLLM(mockFiles, {
+            storageTarget: createWorkspaceSharedStorageTarget("workspace123"),
+        });
 
         const fileObj = JSON.parse(result[0]);
-        expect(fileObj.gcs).toBe("https://example.com/file1.jpg");
+        expect(fileObj.gcs).toBeUndefined();
+    });
+
+    it("should preserve mimeType for signed blob URLs", async () => {
+        const mockFiles = [
+            {
+                hash: "hash1",
+                mimeType: "text/csv",
+                url: "https://storage.example.blob.core.windows.net/container/concierge-users.csv?sv=2025-05-05&sig=abc123",
+            },
+        ];
+
+        const result = await prepareFileContentForLLM(mockFiles, {
+            storageTarget: createWorkspacePrivateStorageTarget(
+                "user123",
+                "workspace123",
+            ),
+            fetchShortLivedUrls: false,
+        });
+
+        const fileObj = JSON.parse(result[0]);
+        expect(fileObj.mimeType).toBe("text/csv");
+        expect(fileObj.image_url).toEqual({
+            url: "https://storage.example.blob.core.windows.net/container/concierge-users.csv?sv=2025-05-05&sig=abc123",
+        });
+    });
+});
+
+describe("extractBlobPathFromUrl", () => {
+    it("should extract blob path from Azure blob URL", () => {
+        const url =
+            "https://storage.example.blob.core.windows.net/container/global/abc123_myfile.pdf";
+        expect(extractBlobPathFromUrl(url)).toBe("global/abc123_myfile.pdf");
+    });
+
+    it("should extract blob path from Azure URL with nested folders", () => {
+        const url =
+            "https://account.blob.core.windows.net/container/chats/chatId/abc123_myfile.pdf";
+        expect(extractBlobPathFromUrl(url)).toBe(
+            "chats/chatId/abc123_myfile.pdf",
+        );
+    });
+
+    it("should extract blob path from Azurite URL (127.0.0.1)", () => {
+        const url =
+            "http://127.0.0.1:10000/devstoreaccount1/container/global/abc123_myfile.pdf";
+        expect(extractBlobPathFromUrl(url)).toBe("global/abc123_myfile.pdf");
+    });
+
+    it("should extract blob path from Azurite URL (localhost)", () => {
+        const url =
+            "http://localhost:10000/devstoreaccount1/container/chats/chatId/file.txt";
+        expect(extractBlobPathFromUrl(url)).toBe("chats/chatId/file.txt");
+    });
+
+    it("should decode URI-encoded segments", () => {
+        const url =
+            "https://account.blob.core.windows.net/container/global/abc123_my%20file.pdf";
+        expect(extractBlobPathFromUrl(url)).toBe("global/abc123_my file.pdf");
+    });
+
+    it("should return null for URL with only container (no blob path)", () => {
+        const url = "https://account.blob.core.windows.net/container";
+        expect(extractBlobPathFromUrl(url)).toBeNull();
+    });
+
+    it("should return null for Azurite URL with only account and container", () => {
+        const url = "http://127.0.0.1:10000/devstoreaccount1/container";
+        expect(extractBlobPathFromUrl(url)).toBeNull();
+    });
+
+    it("should return null for invalid URL", () => {
+        expect(extractBlobPathFromUrl("not-a-url")).toBeNull();
+    });
+
+    it("should return null for empty string", () => {
+        expect(extractBlobPathFromUrl("")).toBeNull();
+    });
+
+    it("should handle SAS token in URL (query params are ignored)", () => {
+        const url =
+            "https://account.blob.core.windows.net/container/global/file.pdf?sv=2022-11-02&sig=abc";
+        expect(extractBlobPathFromUrl(url)).toBe("global/file.pdf");
+    });
+
+    it("should handle single-segment blob path", () => {
+        const url =
+            "https://account.blob.core.windows.net/container/abc123_file.pdf";
+        expect(extractBlobPathFromUrl(url)).toBe("abc123_file.pdf");
     });
 });

--- a/app/api/utils/__tests__/media-service-utils.test.js
+++ b/app/api/utils/__tests__/media-service-utils.test.js
@@ -1,0 +1,168 @@
+/**
+ * @jest-environment node
+ */
+
+jest.mock("../../../../config", () => ({
+    endpoints: {
+        mediaHelperDirect: jest.fn(() => "http://media-helper.test"),
+    },
+}));
+
+const {
+    checkMediaFile,
+    deleteMediaFile,
+    readBlobContent,
+} = require("../media-service-utils.js");
+
+describe("media-service-utils identifier fallbacks", () => {
+    const originalFetch = global.fetch;
+    const originalLog = console.log;
+    const originalWarn = console.warn;
+    const originalError = console.error;
+    const config = require("../../../../config");
+
+    beforeEach(() => {
+        global.fetch = jest.fn();
+        jest.clearAllMocks();
+        config.endpoints.mediaHelperDirect.mockReturnValue(
+            "http://media-helper.test",
+        );
+        console.log = jest.fn();
+        console.warn = jest.fn();
+        console.error = jest.fn();
+    });
+
+    afterAll(() => {
+        global.fetch = originalFetch;
+        console.log = originalLog;
+        console.warn = originalWarn;
+        console.error = originalError;
+    });
+
+    it("checkMediaFile tries blobPath before hash fallback", async () => {
+        global.fetch
+            .mockResolvedValueOnce({
+                ok: false,
+                status: 404,
+            })
+            .mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({
+                    url: "https://example.com/file.pdf",
+                    hash: "hash123",
+                }),
+            });
+
+        const result = await checkMediaFile({
+            blobPath: "global/file.pdf",
+            hash: "hash123",
+            contextId: "ctx123",
+        });
+
+        expect(result).toEqual({
+            url: "https://example.com/file.pdf",
+            hash: "hash123",
+        });
+        expect(global.fetch).toHaveBeenCalledTimes(2);
+
+        const firstUrl = new URL(global.fetch.mock.calls[0][0]);
+        expect(global.fetch.mock.calls[0][1]).toMatchObject({
+            cache: "no-store",
+        });
+        expect(firstUrl.searchParams.get("blobPath")).toBe("global/file.pdf");
+        expect(firstUrl.searchParams.get("hash")).toBeNull();
+        expect(firstUrl.searchParams.get("checkHash")).toBeNull();
+
+        const secondUrl = new URL(global.fetch.mock.calls[1][0]);
+        expect(global.fetch.mock.calls[1][1]).toMatchObject({
+            cache: "no-store",
+        });
+        expect(secondUrl.searchParams.get("blobPath")).toBeNull();
+        expect(secondUrl.searchParams.get("hash")).toBe("hash123");
+        expect(secondUrl.searchParams.get("checkHash")).toBe("true");
+    });
+
+    it("deleteMediaFile retries with hash after blobPath miss", async () => {
+        global.fetch
+            .mockResolvedValueOnce({
+                ok: false,
+                status: 404,
+                statusText: "Not Found",
+                text: async () => "blob missing",
+            })
+            .mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({ deleted: true }),
+            });
+
+        const result = await deleteMediaFile({
+            blobPath: "global/file.pdf",
+            hash: "hash123",
+            contextId: "ctx123",
+        });
+
+        expect(result).toEqual({ deleted: true });
+        expect(global.fetch).toHaveBeenCalledTimes(2);
+        expect(global.fetch.mock.calls[0][1]).toMatchObject({
+            method: "DELETE",
+        });
+
+        const firstUrl = new URL(global.fetch.mock.calls[0][0]);
+        expect(firstUrl.searchParams.get("blobPath")).toBe("global/file.pdf");
+        expect(firstUrl.searchParams.get("hash")).toBeNull();
+
+        const secondUrl = new URL(global.fetch.mock.calls[1][0]);
+        expect(secondUrl.searchParams.get("blobPath")).toBeNull();
+        expect(secondUrl.searchParams.get("hash")).toBe("hash123");
+    });
+
+    it("deleteMediaFile can skip hash fallback after blobPath miss", async () => {
+        global.fetch.mockResolvedValueOnce({
+            ok: false,
+            status: 404,
+            statusText: "Not Found",
+            text: async () => "blob missing",
+        });
+
+        const result = await deleteMediaFile({
+            blobPath: "global/file.pdf",
+            hash: "hash123",
+            fallbackToHash: false,
+            contextId: "ctx123",
+        });
+
+        expect(result).toBeNull();
+        expect(global.fetch).toHaveBeenCalledTimes(1);
+
+        const url = new URL(global.fetch.mock.calls[0][0]);
+        expect(url.searchParams.get("blobPath")).toBe("global/file.pdf");
+        expect(url.searchParams.get("hash")).toBeNull();
+    });
+
+    it("readBlobContent bypasses fetch cache for CFH lookup and signed blob read", async () => {
+        global.fetch
+            .mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({ url: "https://signed.example/file.html" }),
+            })
+            .mockResolvedValueOnce({
+                ok: true,
+                text: async () => "<html>published</html>",
+            });
+
+        const result = await readBlobContent("applets/v1.html", {
+            kind: "applet-global",
+            userContextId: "ctx123",
+        });
+
+        expect(result).toBe("<html>published</html>");
+        expect(global.fetch).toHaveBeenCalledTimes(2);
+        expect(global.fetch.mock.calls[0][1]).toMatchObject({
+            cache: "no-store",
+        });
+        expect(global.fetch.mock.calls[1]).toEqual([
+            "https://signed.example/file.html",
+            { cache: "no-store" },
+        ]);
+    });
+});

--- a/app/api/utils/applet-shared-file-utils.js
+++ b/app/api/utils/applet-shared-file-utils.js
@@ -1,0 +1,108 @@
+import AppletSharedFile from "../models/applet-shared-file.js";
+import Prompt from "../models/prompt.js";
+
+function normalizeId(value) {
+    if (!value) {
+        return null;
+    }
+    if (typeof value === "string") {
+        return value;
+    }
+    if (typeof value.toString === "function") {
+        return value.toString();
+    }
+    return String(value);
+}
+
+function appendIds(targetSet, values = []) {
+    for (const value of values) {
+        const normalized = normalizeId(value);
+        if (normalized) {
+            targetSet.add(normalized);
+        }
+    }
+}
+
+async function loadWorkspacePromptEntries(workspace) {
+    const promptEntries = Array.isArray(workspace?.prompts)
+        ? workspace.prompts.filter(Boolean)
+        : [];
+
+    if (promptEntries.length === 0) {
+        return [];
+    }
+
+    const promptsArePopulated = promptEntries.every(
+        (prompt) => prompt && Array.isArray(prompt.files),
+    );
+    if (promptsArePopulated) {
+        return promptEntries;
+    }
+
+    const promptIds = promptEntries.map(normalizeId).filter(Boolean);
+    if (promptIds.length === 0) {
+        return [];
+    }
+
+    return Prompt.find({
+        _id: {
+            $in: promptIds,
+        },
+    }).select("files");
+}
+
+export async function collectLegacyAppletSharedFileIds(workspace) {
+    const fileIds = new Set();
+
+    appendIds(fileIds, workspace?.files);
+
+    const prompts = await loadWorkspacePromptEntries(workspace);
+    for (const prompt of prompts) {
+        appendIds(fileIds, prompt?.files);
+    }
+
+    return Array.from(fileIds);
+}
+
+export async function ensureAppletSharedFileStore(
+    workspace,
+    { match = null, populateFiles = true } = {},
+) {
+    if (!workspace?.applet) {
+        return null;
+    }
+
+    const fileIds = await collectLegacyAppletSharedFileIds(workspace);
+
+    if (fileIds.length > 0) {
+        await AppletSharedFile.findOneAndUpdate(
+            { appletId: workspace.applet },
+            {
+                $addToSet: {
+                    files: {
+                        $each: fileIds,
+                    },
+                },
+            },
+            {
+                new: true,
+                upsert: true,
+                runValidators: true,
+            },
+        );
+    }
+
+    const query = AppletSharedFile.findOne({
+        appletId: workspace.applet,
+    });
+
+    if (!populateFiles) {
+        return query;
+    }
+
+    if (match) {
+        return query.populate({ path: "files", match });
+    }
+
+    return query.populate("files");
+}

--- a/app/api/utils/file-refresh-utils.js
+++ b/app/api/utils/file-refresh-utils.js
@@ -1,164 +1,46 @@
 import File from "../models/file";
-import { uploadBufferToMediaService, hashBuffer } from "./media-service-utils";
-
-/**
- * Check if a file exists in the file handler system by hash
- * @param {string} hash - File hash (must be truthy)
- * @param {string} contextId - Context ID for file scoping
- * @param {string} mediaHelperUrl - Media helper URL
- * @returns {Promise<Object|null>} File data if exists, null otherwise
- */
-async function checkFileExists(hash, contextId, mediaHelperUrl) {
-    // If hash is missing, file cannot exist (legacy files without hash need re-upload)
-    if (!hash) {
-        return null;
-    }
-
-    try {
-        const checkUrl = new URL(mediaHelperUrl);
-        checkUrl.searchParams.set("hash", hash);
-        checkUrl.searchParams.set("checkHash", "true");
-        if (contextId) {
-            checkUrl.searchParams.set("contextId", contextId);
-        }
-
-        const checkResponse = await fetch(checkUrl.toString());
-        if (checkResponse.ok) {
-            const data = await checkResponse.json().catch(() => null);
-            if (data && data.url) {
-                return data;
-            }
-        }
-    } catch (error) {
-        console.error(`Error checking file hash ${hash}:`, error.message);
-    }
-    return null;
-}
-
-/**
- * Attempt to re-upload a file from its last known URL
- * Downloads the file, hashes it, and uploads it using uploadBufferToMediaService
- * @param {Object} file - File document
- * @param {string} contextId - Context ID for file scoping
- * @param {string} mediaHelperUrl - Media helper URL (unused, kept for API consistency)
- * @returns {Promise<Object|null>} Upload data if successful, null otherwise
- */
-async function refreshFileFromUrl(file, contextId, mediaHelperUrl) {
-    if (!file.url) {
-        return null;
-    }
-
-    try {
-        // Download the file from the URL
-        const response = await fetch(file.url);
-        if (!response.ok) {
-            console.error(
-                `Failed to download file ${file._id} from ${file.url}: ${response.statusText}`,
-            );
-            return null;
-        }
-
-        // Convert response to buffer
-        const arrayBuffer = await response.arrayBuffer();
-        const fileBuffer = Buffer.from(arrayBuffer);
-
-        // Hash the buffer and check if file already exists in workspace contextId
-        const hash = await hashBuffer(fileBuffer);
-        const existingFile = await checkFileExists(
-            hash,
-            contextId,
-            mediaHelperUrl,
-        );
-        if (existingFile) {
-            // Already exists in workspace contextId
-            return existingFile;
-        }
-
-        // Upload to workspace contextId (uploadBufferToMediaService handles deduplication)
-        const uploadResult = await uploadBufferToMediaService(
-            fileBuffer,
-            {
-                filename: file.originalName || file.filename,
-                mimeType: file.mimeType,
-                size: fileBuffer.length,
-                hash: hash,
-            },
-            true, // permanent = true for workspace files
-            contextId,
-        );
-
-        if (uploadResult.error) {
-            console.error(
-                `Error uploading file ${file._id}:`,
-                uploadResult.error,
-            );
-            return null;
-        }
-
-        return uploadResult.data;
-    } catch (error) {
-        console.error(`Error re-uploading file ${file._id}:`, error.message);
-    }
-    return null;
-}
+import { resolveAndHealFile } from "./file-resolution-utils.js";
 
 /**
  * Validate and refresh a single file
  * Handles legacy files that exist in generic FileStoreMap but not in workspace contextId
  * @param {Object} file - File document
- * @param {string} contextId - Context ID for file scoping
+ * @param {Object} storageTarget - Storage target for file scoping
  * @param {string} mediaHelperUrl - Media helper URL
+ * @param {Object} options - Optional validation options
+ * @param {Array} options.fallbackStorageTargets - Additional storage targets to try before failing
  * @returns {Promise<Object>} Result with fileId and status
  */
-export async function validateAndRefreshFile(file, contextId, mediaHelperUrl) {
-    // Check if file exists in workspace contextId with stored hash
-    if (file.hash) {
-        const existingFile = await checkFileExists(
-            file.hash,
-            contextId,
-            mediaHelperUrl,
-        );
+export async function validateAndRefreshFile(
+    file,
+    storageTarget,
+    mediaHelperUrl,
+    { fallbackStorageTargets = [] } = {},
+) {
+    void mediaHelperUrl;
 
-        if (existingFile) {
-            // File exists and is kosher, clear any error
-            if (file.error) {
-                await File.findByIdAndUpdate(file._id, {
-                    $unset: { error: "" },
-                });
-            }
-            return { fileId: file._id, status: "exists" };
-        }
+    const result = await resolveAndHealFile(file, {
+        storageTarget,
+        fallbackStorageTargets,
+        allowUrlRefresh: true,
+        persistResolvedFile: async (updateFields) => {
+            await File.findByIdAndUpdate(file._id, updateFields);
+        },
+    });
+
+    if (result.status === "resolved") {
+        return { fileId: file._id, status: "exists" };
     }
 
-    // File doesn't exist in workspace contextId (or has no hash)
-    // Download from last known URL and re-upload to workspace contextId
-    if (!file.url) {
-        await File.findByIdAndUpdate(file._id, {
-            error: "File has no URL and could not be validated",
-        });
-        return { fileId: file._id, status: "error" };
-    }
-
-    const uploadData = await refreshFileFromUrl(
-        file,
-        contextId,
-        mediaHelperUrl,
-    );
-
-    if (uploadData) {
-        // Update file with new URLs and hash
-        await File.findByIdAndUpdate(file._id, {
-            url: uploadData.url,
-            gcsUrl: uploadData.gcs || file.gcsUrl,
-            hash: uploadData.hash,
-            $unset: { error: "" },
-        });
+    if (result.status === "refreshed") {
         return { fileId: file._id, status: "refreshed" };
     }
 
-    // Download failed, mark as error
     await File.findByIdAndUpdate(file._id, {
-        error: "File not found and could not be re-uploaded",
+        error:
+            file.url || file.hash || file.blobPath
+                ? "File not found and could not be re-uploaded"
+                : "File has no URL and could not be validated",
     });
     return { fileId: file._id, status: "error" };
 }

--- a/app/api/utils/file-resolution-utils.js
+++ b/app/api/utils/file-resolution-utils.js
@@ -1,0 +1,319 @@
+import { resolveStorageTarget } from "../../../src/utils/storageTargets.js";
+import {
+    checkMediaFile,
+    hashBuffer,
+    uploadBufferToMediaService,
+} from "./media-service-utils.js";
+
+function toPlainFile(file) {
+    if (!file) return null;
+    if (typeof file.toObject === "function") {
+        return file.toObject();
+    }
+    return { ...file };
+}
+
+function extractBlobPathFromUrl(blobUrl) {
+    try {
+        const urlObj = new URL(blobUrl);
+        const segments = urlObj.pathname.split("/").filter(Boolean);
+        const isAzurite =
+            urlObj.hostname === "127.0.0.1" || urlObj.hostname === "localhost";
+        const skip = isAzurite ? 2 : 1;
+        if (segments.length <= skip) return null;
+        return segments.slice(skip).map(decodeURIComponent).join("/");
+    } catch {
+        return null;
+    }
+}
+
+function extractHashFromBlobUrl(blobUrl) {
+    try {
+        const urlObj = new URL(blobUrl);
+        const lastSegment = urlObj.pathname.split("/").pop();
+        if (!lastSegment) return null;
+        const decoded = decodeURIComponent(lastSegment);
+        const idx = decoded.indexOf("_");
+        if (idx > 0) {
+            const prefix = decoded.substring(0, idx);
+            if (/^[0-9a-f]+$/i.test(prefix)) {
+                return prefix;
+            }
+        }
+    } catch {
+        // ignore
+    }
+    return null;
+}
+
+function mergeResolvedFile(baseFile, resolvedData, fallback = {}) {
+    const hasResolvedData = !!resolvedData;
+    const merged = {
+        ...baseFile,
+        ...(resolvedData || {}),
+        ...fallback,
+        url: resolvedData?.url || fallback.url || baseFile?.url || null,
+        gcsUrl: hasResolvedData
+            ? resolvedData?.gcs || fallback.gcsUrl || null
+            : fallback.gcsUrl || baseFile?.gcsUrl || null,
+        hash: resolvedData?.hash || fallback.hash || baseFile?.hash || null,
+        blobPath:
+            resolvedData?.blobPath ||
+            fallback.blobPath ||
+            baseFile?.blobPath ||
+            null,
+    };
+
+    if (resolvedData?.converted || baseFile?.converted) {
+        merged.converted = {
+            ...(baseFile?.converted || {}),
+            ...(resolvedData?.converted || {}),
+        };
+    }
+
+    return merged;
+}
+
+function buildPersistenceUpdate(mergedFile) {
+    const update = {
+        url: mergedFile.url,
+        $unset: { error: "" },
+    };
+
+    if (mergedFile.hash) {
+        update.hash = mergedFile.hash;
+    }
+    if (mergedFile.gcsUrl) {
+        update.gcsUrl = mergedFile.gcsUrl;
+    } else {
+        update.$unset.gcsUrl = "";
+    }
+    if (mergedFile.blobPath) {
+        update.blobPath = mergedFile.blobPath;
+    }
+
+    return update;
+}
+
+async function resolveFromMediaService(file, storageTarget) {
+    const blobPath = file?.blobPath || extractBlobPathFromUrl(file?.url);
+    const hash = file?.hash || extractHashFromBlobUrl(file?.url);
+
+    if (!blobPath && !hash) {
+        return null;
+    }
+
+    const resolved = await checkMediaFile({
+        blobPath,
+        hash,
+        storageTarget,
+    });
+
+    if (!resolved) {
+        return null;
+    }
+
+    return mergeResolvedFile(file, resolved, {
+        blobPath,
+        hash,
+    });
+}
+
+async function refreshFromStoredUrl(file, storageTarget) {
+    if (!file?.url) {
+        return null;
+    }
+
+    const response = await fetch(file.url, {
+        redirect: "follow",
+    });
+    if (!response.ok) {
+        return null;
+    }
+
+    const arrayBuffer = await response.arrayBuffer();
+    const fileBuffer = Buffer.from(arrayBuffer);
+    const hash = file.hash || (await hashBuffer(fileBuffer));
+
+    const existingFile = await checkMediaFile({
+        hash,
+        storageTarget,
+    });
+    if (existingFile) {
+        return mergeResolvedFile(file, existingFile, { hash });
+    }
+
+    const contentType =
+        file.mimeType ||
+        response.headers.get("content-type") ||
+        "application/octet-stream";
+    const filename = file.originalName || file.filename || "file";
+
+    const uploadResult = await uploadBufferToMediaService(
+        fileBuffer,
+        {
+            filename,
+            mimeType: contentType,
+            size: file.size || fileBuffer.length,
+            hash,
+        },
+        {
+            storageTarget,
+        },
+    );
+
+    if (uploadResult?.error || !uploadResult?.data) {
+        return null;
+    }
+
+    const uploadedFile = mergeResolvedFile(file, uploadResult.data, { hash });
+    const refreshedFile = await checkMediaFile({
+        blobPath: uploadedFile.blobPath,
+        hash: uploadedFile.hash,
+        storageTarget,
+    });
+
+    return refreshedFile
+        ? mergeResolvedFile(uploadedFile, refreshedFile)
+        : uploadedFile;
+}
+
+function toStorageTargetKey(storageTarget) {
+    const resolved = resolveStorageTarget({ storageTarget });
+    return [
+        resolved.kind,
+        resolved.userContextId || "",
+        resolved.workspaceId || "",
+        resolved.appletId || "",
+        resolved.chatId || "",
+    ].join("|");
+}
+
+function normalizeFallbackStorageTargets(
+    storageTarget,
+    fallbackStorageTargets = [],
+) {
+    const primaryTarget = resolveStorageTarget({ storageTarget });
+    const primaryKey = toStorageTargetKey(primaryTarget);
+    const seen = new Set([primaryKey]);
+    const normalizedTargets = [];
+
+    const fallbackTargets = Array.isArray(fallbackStorageTargets)
+        ? fallbackStorageTargets
+        : [fallbackStorageTargets];
+
+    for (const fallbackStorageTarget of fallbackTargets) {
+        if (!fallbackStorageTarget) {
+            continue;
+        }
+
+        const resolvedTarget = resolveStorageTarget({
+            storageTarget: fallbackStorageTarget,
+        });
+        const resolvedKey = toStorageTargetKey(resolvedTarget);
+
+        if (seen.has(resolvedKey)) {
+            continue;
+        }
+
+        seen.add(resolvedKey);
+        normalizedTargets.push(resolvedTarget);
+    }
+
+    return normalizedTargets;
+}
+
+async function resolveFromFallbackTargets(file, fallbackStorageTargets = []) {
+    for (const fallbackStorageTarget of fallbackStorageTargets) {
+        const resolvedFile = await resolveFromMediaService(
+            file,
+            fallbackStorageTarget,
+        );
+        if (resolvedFile) {
+            return {
+                file: resolvedFile,
+                storageTarget: fallbackStorageTarget,
+            };
+        }
+    }
+
+    return null;
+}
+
+export async function resolveAndHealFile(
+    file,
+    {
+        storageTarget,
+        fallbackStorageTargets = [],
+        persistResolvedFile = null,
+        allowUrlRefresh = false,
+    } = {},
+) {
+    const plainFile = toPlainFile(file);
+    if (!plainFile || !storageTarget) {
+        return {
+            file: plainFile,
+            accessUrl: plainFile?.url || null,
+            status: "unresolved",
+        };
+    }
+
+    const primaryStorageTarget = resolveStorageTarget({ storageTarget });
+    const normalizedFallbackStorageTargets = normalizeFallbackStorageTargets(
+        primaryStorageTarget,
+        fallbackStorageTargets,
+    );
+
+    let resolvedFile = await resolveFromMediaService(
+        plainFile,
+        primaryStorageTarget,
+    );
+    let status = "resolved";
+
+    if (!resolvedFile) {
+        const fallbackResolution = await resolveFromFallbackTargets(
+            plainFile,
+            normalizedFallbackStorageTargets,
+        );
+
+        if (fallbackResolution) {
+            resolvedFile = fallbackResolution.file;
+
+            if (allowUrlRefresh) {
+                const refreshedFile = await refreshFromStoredUrl(
+                    fallbackResolution.file,
+                    primaryStorageTarget,
+                );
+
+                if (refreshedFile) {
+                    resolvedFile = refreshedFile;
+                    status = "refreshed";
+                }
+            }
+        } else if (allowUrlRefresh) {
+            resolvedFile = await refreshFromStoredUrl(
+                plainFile,
+                primaryStorageTarget,
+            );
+            status = resolvedFile ? "refreshed" : "unresolved";
+        } else {
+            status = "unresolved";
+        }
+    }
+
+    const finalFile = resolvedFile || plainFile;
+
+    if (resolvedFile && typeof persistResolvedFile === "function") {
+        await persistResolvedFile(buildPersistenceUpdate(finalFile), finalFile);
+    }
+
+    return {
+        file: finalFile,
+        accessUrl:
+            finalFile?.shortLivedUrl ||
+            finalFile?.url ||
+            plainFile?.url ||
+            null,
+        status,
+    };
+}

--- a/app/api/utils/file-route-utils.js
+++ b/app/api/utils/file-route-utils.js
@@ -1,0 +1,95 @@
+import Workspace from "../models/workspace.js";
+import {
+    buildMediaHelperFileParams,
+    resolveStorageTarget,
+} from "../../../src/utils/storageTargets.js";
+
+function createHttpError(status, message) {
+    const error = new Error(message);
+    error.status = status;
+    return error;
+}
+
+async function assertWorkspaceOwnership(user, workspaceId) {
+    try {
+        const ownedWorkspace = await Workspace.findOne({
+            _id: workspaceId,
+            owner: user._id,
+        }).select("_id");
+
+        if (!ownedWorkspace) {
+            throw createHttpError(
+                403,
+                "Not authorized to access files in this context",
+            );
+        }
+    } catch (error) {
+        if (error.status) {
+            throw error;
+        }
+        throw createHttpError(
+            403,
+            "Not authorized to access files in this context",
+        );
+    }
+}
+
+export async function resolveAuthorizedMediaRouting({
+    user,
+    routingInput = {},
+} = {}) {
+    const requestedUserId =
+        routingInput.userId || routingInput.userContextId || null;
+    if (requestedUserId && requestedUserId !== user.contextId) {
+        throw createHttpError(
+            403,
+            "Not authorized to access files in this context",
+        );
+    }
+
+    const workspaceContextOnly =
+        routingInput.contextId &&
+        routingInput.contextId !== user.contextId &&
+        !routingInput.workspaceId &&
+        !routingInput.userId &&
+        !routingInput.userContextId &&
+        !routingInput.chatId &&
+        !routingInput.fileScope;
+
+    const normalizedInput = {
+        ...routingInput,
+        workspaceId:
+            routingInput.workspaceId ||
+            (workspaceContextOnly ? routingInput.contextId : null),
+        fileScope:
+            routingInput.fileScope ||
+            (workspaceContextOnly ? "workspace-shared-legacy" : null),
+    };
+
+    const requestedContextId =
+        normalizedInput.contextId ||
+        (normalizedInput.fileScope === "workspace-shared-legacy"
+            ? normalizedInput.workspaceId
+            : requestedUserId || user.contextId);
+
+    if (requestedContextId && requestedContextId !== user.contextId) {
+        await assertWorkspaceOwnership(user, requestedContextId);
+    }
+
+    const storageTarget = resolveStorageTarget({
+        ...normalizedInput,
+        userId:
+            normalizedInput.fileScope === "workspace-shared-legacy"
+                ? null
+                : requestedUserId || user.contextId,
+        contextId:
+            normalizedInput.fileScope === "workspace-shared-legacy"
+                ? requestedContextId || normalizedInput.workspaceId
+                : user.contextId,
+    });
+
+    return {
+        storageTarget,
+        routingParams: buildMediaHelperFileParams({ storageTarget }),
+    };
+}

--- a/app/api/utils/llm-file-utils.js
+++ b/app/api/utils/llm-file-utils.js
@@ -1,181 +1,173 @@
 import config from "../../../config";
+import {
+    buildFileAccessPlan,
+    buildRunContext,
+} from "../../../src/utils/fileAccessPlanUtils.js";
+import {
+    buildMediaHelperFileParams,
+    createAppletSharedStorageTarget,
+    createAppletUserStorageTarget,
+    createUserGlobalStorageTarget,
+    createWorkspacePrivateStorageTarget,
+    createWorkspaceSharedStorageTarget,
+    getStorageContextId,
+    resolveStorageTarget,
+} from "../../../src/utils/storageTargets.js";
+import { resolveAndHealFile } from "./file-resolution-utils.js";
 
 /**
- * Create a compound contextId for workspace-specific user files
- * This allows each user to have their own private file collection within a workspace
- * @param {string} workspaceId - Workspace ID
- * @param {string} userContextId - User context ID
- * @returns {string} - Compound contextId in format "workspaceId:userContextId"
+ * Allowed blob storage domains for proxy routes.
+ * Used by image-proxy, text-proxy, and media-proxy to validate URLs.
+ */
+export const ALLOWED_BLOB_DOMAINS = [
+    "blob.core.windows.net",
+    "storage.googleapis.com",
+    "storage.cloud.google.com",
+    "127.0.0.1", // Azurite local development
+    "localhost", // Azurite local development
+];
+
+/**
+ * Check if a hostname is from an allowed blob storage domain.
+ * Uses exact match or subdomain match (e.g., "foo.blob.core.windows.net" matches "blob.core.windows.net").
+ * @param {string} hostname - The hostname to check
+ * @returns {boolean}
+ */
+export function isAllowedBlobDomain(hostname) {
+    return ALLOWED_BLOB_DOMAINS.some((domain) => {
+        return hostname === domain || hostname.endsWith(`.${domain}`);
+    });
+}
+
+/** Characters that are invalid in filenames (cross-platform). */
+// eslint-disable-next-line no-control-regex
+export const INVALID_FILENAME_CHARS = /[<>:"|?*\x00-\x1f]/g;
+
+/**
+ * Sanitize a filename: remove invalid characters and prevent path traversal.
+ * @param {string} filename
+ * @returns {string}
+ */
+export function sanitizeFilename(filename) {
+    return filename
+        .replace(INVALID_FILENAME_CHARS, "_")
+        .replace(/\.\./g, "_")
+        .replace(/^\/+/, "");
+}
+
+/**
+ * Determine file routing — which container and folder a file should go to.
+ * Returns an object with explicit fields for container and folder derivation.
+ *
+ * @param {Object} options
+ * @param {boolean} options.isArtifact - Workspace artifacts (permanent, per-workspace container)
+ * @param {string|null} options.workspaceId - Workspace ID if available
+ * @param {string|null} options.userId - User ID for user-submitted files
+ * @param {string|null} options.chatId - Chat ID for chat-scoped files
+ * @returns {Object} { userId, workspaceId, chatId, fileScope }
+ */
+export function determineFileRouting({
+    isArtifact,
+    workspaceId,
+    userId,
+    chatId,
+}) {
+    const resolved = resolveStorageTarget({
+        isArtifact,
+        workspaceId,
+        userId,
+        chatId,
+    });
+    if (resolved.fileScope === "workspace-shared-legacy") {
+        return {
+            workspaceId: resolved.workspaceId,
+            fileScope: resolved.fileScope,
+        };
+    }
+    const routing = buildMediaHelperFileParams({ storageTarget: resolved });
+    return {
+        userId: routing.userId,
+        chatId: routing.chatId || null,
+        workspaceId: routing.workspaceId || null,
+        fileScope: routing.fileScope,
+    };
+}
+
+/**
+ * @deprecated Use determineFileRouting instead. Kept for backward compatibility during transition.
+ */
+export function determineFileContextId({
+    isArtifact = false,
+    workspaceId = null,
+    userContextId = null,
+    chatId = null,
+    returnObject = false,
+}) {
+    const storageTarget = resolveStorageTarget({
+        isArtifact,
+        workspaceId,
+        userId: userContextId,
+        chatId,
+    });
+    const routing = determineFileRouting({
+        isArtifact,
+        workspaceId,
+        userId: userContextId,
+        chatId,
+    });
+    const contextId = getStorageContextId({ storageTarget });
+    if (returnObject) {
+        return { contextId, ...routing };
+    }
+    return contextId;
+}
+
+/**
+ * @deprecated Kept for legacy Concierge routes that still pass Cortex agentContext.
  */
 export function createCompoundContextId(workspaceId, userContextId) {
     return `${workspaceId}:${userContextId}`;
 }
 
 /**
- * Determine the appropriate contextId for a file based on its type
- * @param {Object} options - Options for contextId determination
- * @param {boolean} options.isArtifact - Whether this is a workspace/applet artifact (permanent, shared)
- * @param {string|null} options.workspaceId - Workspace ID if available
- * @param {string|null} options.userContextId - User context ID for user-submitted files
- * @param {boolean} options.useCompoundContextId - If true, creates a compound contextId for user files in workspaces
- * @returns {string|null} - The appropriate contextId, or null if neither is available
+ * @deprecated New prompt execution uses fileAccessPlan/runContext. Kept for legacy routes.
  */
-export function determineFileContextId({
-    isArtifact = false,
+export function buildAgentContext({
     workspaceId = null,
+    workspaceContextKey = null,
     userContextId = null,
-    useCompoundContextId = false,
+    userContextKey = null,
+    includeCompoundContext = false,
 }) {
-    // Workspace/applet artifacts use workspaceId (shared across all users)
-    if (isArtifact && workspaceId) {
-        return workspaceId;
-    }
-    // User-submitted files in workspace context use compound contextId
-    // This allows each user to have private files per workspace
-    if (useCompoundContextId && workspaceId && userContextId) {
-        return createCompoundContextId(workspaceId, userContextId);
-    }
-    // User-submitted files use userContextId (user-specific)
-    return userContextId || null;
-}
+    const contexts = [];
 
-/**
- * Fetch a 5-minute short-lived URL for a file from media-helper using checkHash
- * @param {string} hash - File hash
- * @param {string} contextId - Context ID for file scoping
- * @returns {Promise<string|null>} Short-lived URL or null if fetch fails
- */
-export async function fetchShortLivedUrl(hash, contextId) {
-    try {
-        const mediaHelperUrl = config.endpoints.mediaHelperDirect();
-        if (!mediaHelperUrl) {
-            console.warn("Media helper URL not configured, using original URL");
-            return null;
-        }
+    if (workspaceId) {
+        contexts.push({
+            contextId: workspaceId,
+            contextKey: workspaceContextKey || "",
+            default: true,
+        });
 
-        const url = new URL(mediaHelperUrl);
-        url.searchParams.set("hash", hash);
-        url.searchParams.set("checkHash", "true");
-        if (contextId) {
-            url.searchParams.set("contextId", contextId);
-        }
-        // Request 5-minute short-lived URL (300 seconds)
-        url.searchParams.set("shortLived", "true");
-        url.searchParams.set("duration", "300");
-
-        const requestUrl = url.toString();
-        const response = await fetch(requestUrl);
-        if (response.ok) {
-            const data = await response.json().catch((err) => {
-                console.warn("Failed to parse short-lived URL response:", err);
-                return null;
+        if (includeCompoundContext && userContextId) {
+            contexts.push({
+                contextId: createCompoundContextId(workspaceId, userContextId),
+                contextKey: userContextKey || "",
+                default: false,
             });
-            // Media-helper returns short-lived URL in shortLivedUrl field
-            if (data && data.shortLivedUrl) {
-                return data.shortLivedUrl;
-            }
-            // Fallback to regular url if shortLivedUrl not available
-            if (data && data.url) {
-                return data.url;
-            }
-            console.warn("Short-lived URL response missing url fields:", data);
-        } else {
-            const errorText = await response.text().catch(() => "");
-            console.warn(
-                "Short-lived URL fetch failed:",
-                response.status,
-                errorText,
-            );
         }
-    } catch (error) {
-        console.warn("Failed to fetch short-lived URL:", error);
+    } else if (userContextId) {
+        contexts.push({
+            contextId: userContextId,
+            contextKey: userContextKey || "",
+            default: true,
+        });
     }
-    return null;
+
+    return contexts;
 }
 
 /**
- * Prepare file content for chat history
- * For workspaces/applets/system workspaces: fetches 5-minute short-lived URLs
- * For chat: uses original URLs (chat goes through agentic pathway which handles URLs)
- * @param {Array} files - Array of file objects
- * @param {string} workspaceId - Optional workspace ID for workspace artifacts
- * @param {string} userContextId - Optional user context ID for user-submitted files
- * @param {boolean} fetchShortLivedUrls - Whether to fetch short-lived URLs (default: true for workspaces/applets)
- * @param {boolean} useCompoundContextId - Whether to use compound contextId for user files in workspaces
- * @returns {Promise<Array>} Array of stringified file content objects
- */
-export async function prepareFileContentForLLM(
-    files,
-    workspaceId = null,
-    userContextId = null,
-    fetchShortLivedUrls = true,
-    useCompoundContextId = false,
-) {
-    if (!files || files.length === 0) return [];
-
-    // Format files like chat does
-    // Files with _id are workspace/applet artifacts (use workspaceId)
-    // Files without _id are user-submitted files (use compound contextId or userContextId)
-    const fileObjects = await Promise.all(
-        files.map(async (file) => {
-            const contextId = determineFileContextId({
-                isArtifact: !!file._id,
-                workspaceId,
-                userContextId,
-                useCompoundContextId: !file._id && useCompoundContextId, // Only for user files
-            });
-
-            const originalUrl = file.converted?.url || file.url;
-            const gcsUrl =
-                file.converted?.gcs || file.gcsUrl || file.gcs || file.url;
-
-            // Fetch 5-minute short-lived URL if requested and hash is available
-            // Use converted hash if available (for converted files), otherwise use original hash
-            let fileUrl = originalUrl;
-            const hashToUse = file.converted?.hash || file.hash;
-            if (fetchShortLivedUrls && hashToUse && contextId) {
-                const shortLivedUrl = await fetchShortLivedUrl(
-                    hashToUse,
-                    contextId,
-                );
-                if (shortLivedUrl) {
-                    fileUrl = shortLivedUrl;
-                }
-            }
-
-            const obj = {
-                type: "image_url",
-            };
-
-            obj.gcs = gcsUrl;
-            obj.url = fileUrl;
-            obj.image_url = { url: fileUrl };
-
-            // Include hash if available (Cortex uses this to look up files)
-            // Use converted hash if available, otherwise use original hash
-            const hashToInclude = file.converted?.hash || file.hash;
-            if (hashToInclude) {
-                obj.hash = hashToInclude;
-            }
-
-            // Include contextId so Cortex knows where to look up the file
-            // workspaceId for workspace artifacts, userContextId for user files
-            if (contextId) {
-                obj.contextId = contextId;
-            }
-
-            return JSON.stringify(obj);
-        }),
-    );
-
-    return fileObjects;
-}
-
-/**
- * Get LLM by ID with fallback to default LLM
- * @param {import('../models/llm')} LLM - LLM model
- * @param {string} llmId - LLM ID to lookup
- * @returns {Promise<Object>} - LLM object
+ * Get LLM by ID with fallback to default LLM.
  */
 export async function getLLMWithFallback(LLM, llmId) {
     let llm;
@@ -184,7 +176,6 @@ export async function getLLMWithFallback(LLM, llmId) {
         llm = await LLM.findOne({ _id: llmId });
     }
 
-    // If no LLM is found, use the default LLM
     if (!llm) {
         llm = await LLM.findOne({ isDefault: true });
     }
@@ -201,55 +192,268 @@ export async function getAnyAgenticLLM(LLM) {
 }
 
 /**
- * Build agentContext array for Cortex API
- * @param {Object} params
- * @param {string} params.workspaceId - Workspace ID (used as primary contextId for workspace files)
- * @param {string} params.workspaceContextKey - Workspace context key
- * @param {string} params.userContextId - User context ID
- * @param {string} params.userContextKey - User context key
- * @param {boolean} params.includeCompoundContext - If true, include compound contextId for user files in workspaces
- * @returns {Array} agentContext array for Cortex API
+ * Extract the blob path (path within the container) from an Azure blob URL.
+ * Handles both Azure Blob Storage and Azurite (local dev) URL formats.
+ *
+ * Azure: https://account.blob.core.windows.net/container/path/to/file
+ *   pathname = /container/path/to/file → skip 1 segment → "path/to/file"
+ *
+ * Azurite: http://127.0.0.1:10000/devstoreaccount1/container/path/to/file
+ *   pathname = /devstoreaccount1/container/path/to/file → skip 2 segments → "path/to/file"
+ *
+ * @param {string} blobUrl - The full blob URL
+ * @returns {string|null} The blob path within the container, or null if not extractable
  */
-export function buildAgentContext({
-    workspaceId = null,
-    workspaceContextKey = null,
-    userContextId = null,
-    userContextKey = null,
-    includeCompoundContext = false,
-}) {
-    const contexts = [];
+export function extractBlobPathFromUrl(blobUrl) {
+    try {
+        const urlObj = new URL(blobUrl);
+        const segments = urlObj.pathname.split("/").filter(Boolean);
+        // Azurite: /devstoreaccount1/container/path... (skip 2)
+        // Azure: /container/path... (skip 1)
+        const isAzurite =
+            urlObj.hostname === "127.0.0.1" || urlObj.hostname === "localhost";
+        const skip = isAzurite ? 2 : 1;
+        if (segments.length <= skip) return null;
+        return segments.slice(skip).map(decodeURIComponent).join("/");
+    } catch {
+        return null;
+    }
+}
 
-    // For workspace prompt executions: workspace context is the default
-    if (workspaceId) {
-        contexts.push({
-            contextId: workspaceId,
-            contextKey: workspaceContextKey || "",
-            default: true,
-        });
-
-        // Add compound context for user files in workspace
-        if (includeCompoundContext && userContextId) {
-            const compoundContextId = createCompoundContextId(
-                workspaceId,
-                userContextId,
-            );
-            contexts.push({
-                contextId: compoundContextId,
-                contextKey: userContextKey || "",
-                default: false,
-            });
+/**
+ * Extract the file hash from an Azure blob URL.
+ * Blob names follow the pattern: {hash}_{filename} where hash is a hex string (xxHash64).
+ * The blob path may include folder segments like chats/{chatId}/ or global/.
+ * @param {string} blobUrl - The full Azure blob URL
+ * @returns {string|null} The hash prefix, or null if not found
+ */
+export function extractHashFromBlobUrl(blobUrl) {
+    try {
+        const urlObj = new URL(blobUrl);
+        const lastSegment = urlObj.pathname.split("/").pop();
+        if (!lastSegment) return null;
+        const decoded = decodeURIComponent(lastSegment);
+        const idx = decoded.indexOf("_");
+        if (idx > 0) {
+            const prefix = decoded.substring(0, idx);
+            if (/^[0-9a-f]+$/i.test(prefix)) {
+                return prefix;
+            }
         }
-    } else if (userContextId) {
-        // For user chat: user context is the only/default context
-        contexts.push({
-            contextId: userContextId,
-            contextKey: userContextKey || "",
-            default: true,
-        });
+    } catch {
+        // ignore parse errors
+    }
+    return null;
+}
+
+/**
+ * Fetch a 5-minute short-lived URL (and GCS URL) for a file from media-helper using checkHash.
+ * GCS URL is resolved here on-demand rather than stored in file entries.
+ * Prefers blobPath when available; falls back to hash for backward compatibility.
+ * @param {Object} params
+ * @param {string} [params.blobPath] - Blob path within the container (preferred)
+ * @param {string} [params.hash] - File hash (fallback)
+ * @param {string} [params.contextId] - Context ID for file scoping
+ * @returns {Promise<{url: string, gcs: string|null}|null>} Short-lived URL + GCS URL, or null if fetch fails
+ */
+export async function fetchShortLivedUrl({ blobPath, hash, contextId } = {}) {
+    const attempts = [];
+    if (blobPath) {
+        attempts.push({ blobPath });
+    }
+    if (hash) {
+        attempts.push({ hash });
     }
 
-    return contexts;
+    try {
+        const mediaHelperUrl = config.endpoints.mediaHelperDirect();
+        if (!mediaHelperUrl) {
+            console.warn("Media helper URL not configured, using original URL");
+            return null;
+        }
+
+        for (const attempt of attempts) {
+            const url = new URL(mediaHelperUrl);
+            if (attempt.blobPath) {
+                url.searchParams.set("blobPath", attempt.blobPath);
+            } else if (attempt.hash) {
+                url.searchParams.set("hash", attempt.hash);
+                url.searchParams.set("checkHash", "true");
+            }
+            if (contextId) {
+                url.searchParams.set("contextId", contextId);
+            }
+            // Request 5-minute short-lived URL (300 seconds)
+            url.searchParams.set("shortLived", "true");
+            url.searchParams.set("duration", "300");
+
+            const requestUrl = url.toString();
+            const response = await fetch(requestUrl);
+            if (response.ok) {
+                const data = await response.json().catch((err) => {
+                    console.warn(
+                        "Failed to parse short-lived URL response:",
+                        err,
+                    );
+                    return null;
+                });
+                // Media-helper returns short-lived URL in shortLivedUrl field
+                const resolvedUrl = data?.shortLivedUrl || data?.url || null;
+                if (resolvedUrl) {
+                    return { url: resolvedUrl, gcs: data.gcs || null };
+                }
+                console.warn(
+                    "Short-lived URL response missing url fields:",
+                    data,
+                );
+                continue;
+            }
+
+            if (!attempt.hash || attempts.length === 1) {
+                const errorText = await response.text().catch(() => "");
+                console.warn(
+                    "Short-lived URL fetch failed:",
+                    response.status,
+                    errorText,
+                );
+            }
+        }
+    } catch (error) {
+        console.warn("Failed to fetch short-lived URL:", error);
+    }
+    return null;
 }
+
+/**
+ * Prepare file content for chat history using an explicit storage target.
+ * @param {Array} files - Array of file objects
+ * @param {Object} options
+ * @param {Object|null} options.storageTarget - Explicit storage target for all files
+ * @param {Array} options.fallbackStorageTargets - Optional legacy targets to try during migration
+ * @param {boolean} options.fetchShortLivedUrls - Whether to fetch short-lived URLs
+ * @returns {Promise<Array>} Array of stringified file content objects
+ */
+export async function prepareFileContentForLLM(
+    files,
+    options = {},
+    ...legacyArgs
+) {
+    if (
+        options === null ||
+        typeof options !== "object" ||
+        Array.isArray(options)
+    ) {
+        const workspaceId = options;
+        const userContextId = legacyArgs[0] || null;
+        const fetchShortLivedUrls = legacyArgs[1] !== false;
+        options = {
+            storageTarget: workspaceId
+                ? createWorkspaceSharedStorageTarget(workspaceId)
+                : createUserGlobalStorageTarget(userContextId),
+            fetchShortLivedUrls,
+        };
+    }
+
+    const {
+        storageTarget = null,
+        fallbackStorageTargets = [],
+        fetchShortLivedUrls = true,
+    } = options;
+
+    if (!files || files.length === 0 || !storageTarget) return [];
+
+    const resolvedStorageTarget = resolveStorageTarget({ storageTarget });
+    const contextId = getStorageContextId({
+        storageTarget: resolvedStorageTarget,
+    });
+
+    const fileObjects = await Promise.all(
+        files.map(async (file) => {
+            // Prefer converted version (e.g., PDF converted to text) if available
+            let resolvedFile = file;
+            let fileUrl = file.converted?.url || file.url;
+            let gcsUrl = null;
+            if (fetchShortLivedUrls && contextId) {
+                const resolved = await resolveAndHealFile(file, {
+                    storageTarget: resolvedStorageTarget,
+                    fallbackStorageTargets,
+                    allowUrlRefresh:
+                        fallbackStorageTargets.length > 0 ||
+                        !!file?.hash ||
+                        !!file?.blobPath,
+                });
+                resolvedFile = resolved.file || file;
+                fileUrl =
+                    resolvedFile.converted?.shortLivedUrl ||
+                    resolvedFile.converted?.url ||
+                    resolved.accessUrl ||
+                    resolvedFile.url ||
+                    fileUrl;
+                gcsUrl =
+                    resolvedFile.converted?.gcs || resolvedFile.gcsUrl || null;
+            }
+
+            const obj = {
+                type: "image_url",
+            };
+
+            if (gcsUrl) obj.gcs = gcsUrl;
+            obj.url = fileUrl;
+            obj.image_url = { url: fileUrl };
+            const mimeTypeToInclude =
+                resolvedFile.converted?.mimeType ||
+                resolvedFile.mimeType ||
+                file.converted?.mimeType ||
+                file.mimeType ||
+                null;
+            if (mimeTypeToInclude) {
+                obj.mimeType = mimeTypeToInclude;
+            }
+
+            const blobPathToInclude =
+                resolvedFile.converted?.blobPath ||
+                resolvedFile.blobPath ||
+                file.converted?.blobPath ||
+                file.blobPath;
+            if (blobPathToInclude) {
+                obj.blobPath = blobPathToInclude;
+            }
+
+            // Include hash if available as a legacy fallback.
+            const hashToInclude =
+                resolvedFile.converted?.hash || resolvedFile.hash;
+            if (hashToInclude) {
+                obj.hash = hashToInclude;
+            }
+
+            if (contextId) {
+                obj.contextId = contextId;
+            }
+            if (resolvedStorageTarget.fileScope) {
+                obj.fileScope = resolvedStorageTarget.fileScope;
+            }
+            if (resolvedStorageTarget.appletId) {
+                obj.appletId = resolvedStorageTarget.appletId;
+            }
+            if (resolvedStorageTarget.userContextId) {
+                obj.userId = resolvedStorageTarget.userContextId;
+            }
+            if (resolvedStorageTarget.workspaceId) {
+                obj.workspaceId = resolvedStorageTarget.workspaceId;
+            }
+
+            return JSON.stringify(obj);
+        }),
+    );
+
+    return fileObjects;
+}
+/**
+ * Build the file access plan for Cortex agent file lookups.
+ * @param {Object} params
+ * @returns {Array} Ordered file access targets for Cortex
+ */
+export { buildFileAccessPlan, buildRunContext };
 
 /**
  * Build variables for workspace prompt query
@@ -258,26 +462,30 @@ export function buildAgentContext({
  * @param {string} params.systemPrompt - Workspace system prompt (workspace context)
  * @param {string} params.prompt - Prompt text
  * @param {string} params.text - User input text
- * @param {Array} params.files - Array of files (optional)
+ * @param {Array} params.sharedFiles - Persisted prompt/app files
+ * @param {Array} params.userFiles - Request/user-attached files
  * @param {Array} params.chatHistory - Existing chat history (optional)
+ * @param {string} params.chatId - Optional chat ID for chat-scoped files
  * @param {string} params.workspaceId - Optional workspace ID for workspace artifacts
  * @param {string} params.userContextId - Optional user context ID for user-submitted files
  * @param {string} params.userContextKey - Optional user context key for user-submitted files
  * @param {string} params.workspaceContextKey - Optional workspace context key for workspace files
- * @param {boolean} params.useCompoundContextId - If true, use compound contextId for user files
- * @returns {Promise<Object>} Variables object with chatHistory and agentContext for GraphQL query
+ * @returns {Promise<Object>} Variables object with chatHistory, fileAccessPlan, and runtime context
  */
 export async function buildWorkspacePromptVariables({
     systemPrompt,
     prompt,
     text,
-    files = [],
+    sharedFiles = [],
+    userFiles = [],
     chatHistory = null,
+    appletId = null,
+    chatId = null,
     workspaceId = null,
     userContextId = null,
     userContextKey = null,
     workspaceContextKey = null,
-    useCompoundContextId = true,
+    includeUserGlobal = appletId ? false : true,
 }) {
     // Combine prompt + text for user message
     const combinedUserText = prompt
@@ -286,25 +494,86 @@ export async function buildWorkspacePromptVariables({
             : prompt
         : text || "";
 
-    // Build agentContext for Cortex API
-    const agentContext = buildAgentContext({
+    const fileAccessPlan = buildFileAccessPlan({
+        appletId,
+        workspaceId,
+        userContextId,
+        userContextKey,
+        workspaceContextKey,
+        chatId,
+        includeUserGlobal,
+    });
+    const runContext = buildRunContext({
+        appletId,
         workspaceId,
         workspaceContextKey,
         userContextId,
         userContextKey,
-        includeCompoundContext: useCompoundContextId,
     });
 
-    const fileContent =
-        files && files.length > 0
-            ? await prepareFileContentForLLM(
-                  files,
-                  workspaceId,
-                  userContextId,
-                  true, // Fetch short-lived URLs for workspaces/applets
-                  useCompoundContextId,
-              )
-            : [];
+    const resolvedSharedFiles = Array.isArray(sharedFiles) ? sharedFiles : [];
+    const resolvedUserFiles = Array.isArray(userFiles) ? userFiles : [];
+    let fileContent = [];
+    const appendPreparedFiles = async ({
+        files: filesToPrepare,
+        storageTarget,
+        fallbackStorageTargets = [],
+    }) => {
+        if (!filesToPrepare.length || !storageTarget) {
+            return;
+        }
+        fileContent.push(
+            ...(await prepareFileContentForLLM(filesToPrepare, {
+                storageTarget,
+                fallbackStorageTargets,
+                fetchShortLivedUrls: true,
+            })),
+        );
+    };
+
+    if (appletId) {
+        await appendPreparedFiles({
+            files: resolvedSharedFiles,
+            storageTarget: createAppletSharedStorageTarget(appletId),
+            fallbackStorageTargets: workspaceId
+                ? [createWorkspaceSharedStorageTarget(workspaceId)]
+                : [],
+        });
+
+        if (userContextId) {
+            await appendPreparedFiles({
+                files: resolvedUserFiles,
+                storageTarget: createAppletUserStorageTarget(
+                    userContextId,
+                    appletId,
+                ),
+                fallbackStorageTargets: workspaceId
+                    ? [
+                          createWorkspacePrivateStorageTarget(
+                              userContextId,
+                              workspaceId,
+                          ),
+                      ]
+                    : [],
+            });
+        }
+    } else {
+        await appendPreparedFiles({
+            files: resolvedSharedFiles,
+            storageTarget: workspaceId
+                ? createWorkspaceSharedStorageTarget(workspaceId)
+                : null,
+        });
+        await appendPreparedFiles({
+            files: resolvedUserFiles,
+            storageTarget: workspaceId
+                ? createWorkspacePrivateStorageTarget(
+                      userContextId,
+                      workspaceId,
+                  )
+                : createUserGlobalStorageTarget(userContextId),
+        });
+    }
 
     let finalChatHistory = [];
 
@@ -412,11 +681,12 @@ export async function buildWorkspacePromptVariables({
 
     const result = {
         chatHistory: finalChatHistory,
+        contextId: runContext.contextId,
+        contextKey: runContext.contextKey,
     };
 
-    // Include agentContext if we have any contexts
-    if (agentContext.length > 0) {
-        result.agentContext = agentContext;
+    if (fileAccessPlan.length > 0) {
+        result.fileAccessPlan = fileAccessPlan;
     }
 
     return result;

--- a/app/api/utils/media-service-utils.js
+++ b/app/api/utils/media-service-utils.js
@@ -1,6 +1,12 @@
-import { NextResponse } from "next/server";
+import { NextResponse } from "next/server.js";
 import xxhash from "xxhash-wasm";
-import config from "../../../config/index.js";
+import {
+    buildMediaHelperFileParams,
+    buildMediaHelperListParams,
+    getStorageContextId,
+    createSkillStorageTarget,
+    createAutomationStorageTarget,
+} from "../../../src/utils/storageTargets.js";
 
 /**
  * Hash a buffer using xxhash64
@@ -14,53 +20,144 @@ export async function hashBuffer(buffer) {
     return xxh64.digest().toString(16);
 }
 
+function getMediaHelperUrl() {
+    const mediaHelperUrl =
+        process.env.CORTEX_MEDIA_API_URL ||
+        (process.env.NODE_ENV === "test" ? "http://media-helper.test" : null);
+    if (!mediaHelperUrl) {
+        throw new Error("Media helper URL is not defined");
+    }
+    return mediaHelperUrl;
+}
+
+function appendRoutingParams(url, input = {}) {
+    const params = buildMediaHelperFileParams(input);
+    for (const [key, value] of Object.entries(params)) {
+        url.searchParams.set(key, value);
+    }
+    return params;
+}
+
+export function buildFileIdentifierAttempts({
+    blobPath,
+    hash,
+    fallbackToHash = true,
+} = {}) {
+    const attempts = [];
+
+    if (blobPath) {
+        attempts.push({ blobPath, identifier: blobPath });
+    }
+    if (hash && (fallbackToHash || !blobPath)) {
+        attempts.push({ hash, identifier: hash });
+    }
+
+    return attempts;
+}
+
 /**
- * Set file retention (temporary or permanent) via CFH API
- * @param {string} hash - File hash
- * @param {string} retention - 'temporary' or 'permanent'
- * @param {string} contextId - Context ID for scoping
- * @returns {Promise<Object|null>} Response data or null on error (best-effort)
+ * Check if a file exists in CFH.
+ * Prefers blobPath when available; falls back to hash.
+ * @param {Object} params
+ * @param {string} [params.blobPath] - Blob path within the container (preferred)
+ * @param {string} [params.hash] - File hash (fallback)
+ * @returns {Promise<Object|null>} Response data or null on miss/error
  */
-export async function setFileRetention(hash, retention, contextId) {
+export async function checkMediaFile({ blobPath, hash, ...routing } = {}) {
+    if (!blobPath && !hash) {
+        return null;
+    }
+
     try {
-        const mediaHelperUrl = config.endpoints.mediaHelperDirect();
-        if (!mediaHelperUrl) {
-            console.warn(
-                "Media helper URL not configured, skipping retention update",
-            );
-            return null;
+        for (const attempt of buildFileIdentifierAttempts({ blobPath, hash })) {
+            const url = new URL(getMediaHelperUrl());
+            if (attempt.blobPath) {
+                url.searchParams.set("blobPath", attempt.blobPath);
+            } else if (attempt.hash) {
+                url.searchParams.set("hash", attempt.hash);
+                url.searchParams.set("checkHash", "true");
+            }
+            appendRoutingParams(url, routing);
+
+            const response = await fetch(url.toString(), {
+                cache: "no-store",
+            });
+            if (!response.ok) {
+                continue;
+            }
+
+            const data = await response.json().catch(() => null);
+            if (data?.url) {
+                return data;
+            }
         }
 
-        const setRetentionUrl = new URL(mediaHelperUrl);
-        setRetentionUrl.searchParams.set("hash", hash);
-        setRetentionUrl.searchParams.set("retention", retention);
-        setRetentionUrl.searchParams.set("setRetention", "true");
-        if (contextId) {
-            setRetentionUrl.searchParams.set("contextId", contextId);
-        }
-
-        const response = await fetch(setRetentionUrl.toString(), {
-            method: "POST",
-            headers: {
-                "Content-Type": "application/json",
-            },
-        });
-
-        if (!response.ok) {
-            const errorBody = await response.text();
-            console.warn(
-                `Failed to set retention to ${retention} for file ${hash}: ${response.statusText}. Response: ${errorBody}`,
-            );
-            return null;
-        }
-
-        const result = await response.json();
-        console.log(
-            `Successfully set retention to ${retention} for file ${hash}`,
-        );
-        return result;
+        return null;
     } catch (error) {
-        console.error("Error setting file retention:", error);
+        console.error("Error checking file in media service:", error);
+        return null;
+    }
+}
+
+/**
+ * Delete a file from CFH.
+ * Prefers blobPath when available; falls back to hash.
+ * @param {Object} params
+ * @param {string} [params.blobPath] - Blob path within the container (preferred)
+ * @param {string} [params.hash] - File hash (fallback)
+ * @param {boolean} [params.fallbackToHash=true] - Whether to try hash after a blobPath miss
+ * @returns {Promise<Object|null>} Response data or null on error
+ */
+export async function deleteMediaFile({
+    blobPath,
+    hash,
+    fallbackToHash = true,
+    ...routing
+} = {}) {
+    if (!blobPath && !hash) {
+        return null;
+    }
+
+    try {
+        let lastError = null;
+
+        for (const attempt of buildFileIdentifierAttempts({
+            blobPath,
+            hash,
+            fallbackToHash,
+        })) {
+            const url = new URL(getMediaHelperUrl());
+            if (attempt.blobPath) {
+                url.searchParams.set("blobPath", attempt.blobPath);
+            } else if (attempt.hash) {
+                url.searchParams.set("hash", attempt.hash);
+            }
+            appendRoutingParams(url, routing);
+
+            const response = await fetch(url.toString(), {
+                method: "DELETE",
+                headers: {
+                    "Content-Type": "application/json",
+                },
+            });
+
+            if (response.ok) {
+                return response.json().catch(() => null);
+            }
+
+            const errorBody = await response.text().catch(() => "");
+            lastError = new Error(
+                `Delete failed for ${attempt.identifier}: ${response.statusText}. Response: ${errorBody}`,
+            );
+        }
+
+        if (lastError) {
+            throw lastError;
+        }
+
+        return null;
+    } catch (error) {
+        console.error("Error deleting file from media service:", error);
         return null;
     }
 }
@@ -69,35 +166,54 @@ export async function setFileRetention(hash, retention, contextId) {
  * Upload buffer to media service
  * @param {Buffer} fileBuffer - The file buffer
  * @param {Object} metadata - File metadata
- * @param {boolean} permanent - If true, file will be marked as permanent (via setRetention after upload)
- * @param {string} contextId - Optional context ID for per-user file scoping
+ * @param {Object} options - Upload options
+ * @param {string|null} options.userId - User ID for per-user container scoping
+ * @param {string|null} options.workspaceId - Workspace ID for workspace-artifact or applet scoping
+ * @param {string|null} options.chatId - Chat ID for chat-scoped files
+ * @param {string|null} options.fileScope - File scope: 'global', 'chat', 'applet', 'applets', 'profile', 'articles', 'workspace-artifact'
  * @returns {Object} Upload result with data or error
  */
 export async function uploadBufferToMediaService(
     fileBuffer,
     metadata,
-    permanent = false,
-    contextId = null,
+    { storageTarget = null, subPath = null, ...routing } = {},
 ) {
     try {
-        const mediaHelperUrl = config.endpoints.mediaHelperDirect();
-        if (!mediaHelperUrl) {
-            throw new Error("Media helper URL is not defined");
-        }
+        const mediaHelperUrl = getMediaHelperUrl();
+        const routingParams = buildMediaHelperFileParams({
+            storageTarget,
+            ...routing,
+        });
+        const contextId =
+            storageTarget || routingParams.fileScope
+                ? getStorageContextId({ storageTarget, ...routing })
+                : routing.contextId;
 
         // Create a Blob from the buffer to send as FormData
         const blob = new Blob([fileBuffer], { type: metadata.mimeType });
         const uploadFormData = new FormData();
-        uploadFormData.append("file", blob, metadata.filename);
 
-        // Add hash to FormData if provided
-        if (metadata.hash) {
-            uploadFormData.append("hash", metadata.hash);
+        // Routing fields MUST be appended before the file so that
+        // busboy has parsed them by the time the "file" event fires.
+        // Otherwise processFile reads userId/fileScope/subPath as null
+        // and the file lands in the wrong container/path.
+        for (const [key, value] of Object.entries(routingParams)) {
+            if (key === "contextId") continue;
+            uploadFormData.append(key, value);
         }
-
-        // Add contextId to FormData if provided
         if (contextId) {
             uploadFormData.append("contextId", contextId);
+        }
+        if (subPath) {
+            uploadFormData.append("subPath", subPath);
+        }
+
+        // File must come after routing fields (see above)
+        uploadFormData.append("file", blob, metadata.filename);
+
+        // Hash can come after the file — processFile awaits busboyFinished for it
+        if (metadata.hash) {
+            uploadFormData.append("hash", metadata.hash);
         }
 
         const uploadResponse = await fetch(mediaHelperUrl, {
@@ -119,11 +235,6 @@ export async function uploadBufferToMediaService(
             throw new Error("Media file upload failed: Missing URL");
         }
 
-        // If permanent flag is set, call setRetention API (best-effort)
-        if (permanent && uploadData.hash) {
-            await setFileRetention(uploadData.hash, "permanent", contextId);
-        }
-
         return { success: true, data: uploadData };
     } catch (error) {
         console.error("Error uploading to media service:", error);
@@ -136,5 +247,90 @@ export async function uploadBufferToMediaService(
                 { status: 500 },
             ),
         };
+    }
+}
+
+async function listScopedFiles({
+    userContextId,
+    subPath,
+    createStorageTarget,
+    label,
+}) {
+    try {
+        const url = new URL(getMediaHelperUrl());
+        url.searchParams.set("listFolder", "true");
+        const storageTarget = createStorageTarget(userContextId);
+        const listParams = buildMediaHelperListParams({ storageTarget });
+        for (const [key, value] of Object.entries(listParams)) {
+            url.searchParams.set(key, value);
+        }
+        if (subPath) {
+            url.searchParams.set("subPath", subPath);
+        }
+
+        const response = await fetch(url.toString());
+        if (!response.ok) {
+            return [];
+        }
+        const data = await response.json();
+        return data.files || [];
+    } catch (error) {
+        console.error(`Error listing ${label} files:`, error);
+        return [];
+    }
+}
+
+/**
+ * List files in a skill's directory in blob storage.
+ * @param {string} userContextId - The user's context ID
+ * @param {string} skillName - The skill name (used as subPath under skills/)
+ * @returns {Promise<Array>} Array of file objects { name, filename, url, size, contentType }
+ */
+export async function listSkillFiles(userContextId, skillName) {
+    return listScopedFiles({
+        userContextId,
+        subPath: skillName,
+        createStorageTarget: createSkillStorageTarget,
+        label: "skill",
+    });
+}
+
+/**
+ * List files in an automation's directory in blob storage.
+ * @param {string} userContextId - The user's context ID
+ * @param {string} automationSlug - The automation slug
+ * @returns {Promise<Array>} Array of file objects
+ */
+export async function listAutomationFiles(userContextId, automationSlug) {
+    return listScopedFiles({
+        userContextId,
+        subPath: automationSlug,
+        createStorageTarget: createAutomationStorageTarget,
+        label: "automation",
+    });
+}
+
+/**
+ * Read the text content of a blob by its path.
+ * @param {string} blobPath - The blob path within the container
+ * @param {Object} storageTarget - Storage target for routing
+ * @returns {Promise<string|null>} The file's text content or null
+ */
+export async function readBlobContent(blobPath, storageTarget) {
+    try {
+        const fileInfo = await checkMediaFile({ blobPath, storageTarget });
+        if (!fileInfo?.url) {
+            return null;
+        }
+        const response = await fetch(fileInfo.url, {
+            cache: "no-store",
+        });
+        if (!response.ok) {
+            return null;
+        }
+        return await response.text();
+    } catch (error) {
+        console.error("Error reading blob content:", error);
+        return null;
     }
 }

--- a/app/api/utils/upload-utils.js
+++ b/app/api/utils/upload-utils.js
@@ -1,5 +1,4 @@
 import { NextResponse } from "next/server";
-import config from "../../../config/index.js";
 import File from "../models/file.js";
 import { getCurrentUser } from "./auth.js";
 import {
@@ -7,12 +6,13 @@ import {
     FILE_VALIDATION_CONFIG,
     scanForMalware,
 } from "./fileValidation.js";
-import { determineFileContextId } from "./llm-file-utils.js";
+import { extractBlobPathFromUrl } from "./llm-file-utils.js";
 import {
+    checkMediaFile,
     hashBuffer,
     uploadBufferToMediaService,
-    setFileRetention,
 } from "./media-service-utils.js";
+import { resolveStorageTarget } from "../../../src/utils/storageTargets.js";
 
 import Busboy from "busboy";
 import { Readable } from "stream";
@@ -35,8 +35,7 @@ export { hashBuffer } from "./media-service-utils.js";
  * @param {Function} options.checkAuthorization - Function to check user authorization
  * @param {Function} options.associateFile - Function to associate file with workspace/applet
  * @param {string} options.errorPrefix - Prefix for error messages
- * @param {boolean} options.permanent - If true, file will be marked as permanent
- * @param {boolean} options.useCompoundContextId - If true, use compound contextId (workspaceId:userContextId) for file scoping
+ * @param {Object} options.storageTarget - Explicit storage target for routing
  * @returns {Object} Upload result with file data or error response
  */
 export async function handleStreamingFileUpload(request, options) {
@@ -45,8 +44,7 @@ export async function handleStreamingFileUpload(request, options) {
         checkAuthorization,
         associateFile,
         errorPrefix = "streaming file upload",
-        permanent = false,
-        useCompoundContextId = false,
+        storageTarget: storageTargetOverride = null,
     } = options;
 
     try {
@@ -80,101 +78,67 @@ export async function handleStreamingFileUpload(request, options) {
 
         const { fileBuffer, metadata } = result.data;
 
-        // Determine contextId based on file type:
-        // - Workspace/applet artifacts (permanent=true, useCompoundContextId=false): workspaceId (shared)
-        // - User files in workspace/applet (useCompoundContextId=true): compound contextId (workspaceId:userContextId)
-        // - User files elsewhere (permanent=false, useCompoundContextId=false): userContextId
-        // Note: workspace is guaranteed to exist here due to early return above
+        // Determine file routing: which container and folder the file goes to
         const workspaceIdStr = workspace._id?.toString() || null;
         const userContextIdStr = user?.contextId || null;
 
-        // When useCompoundContextId is true, this is a user file in workspace context (private per user)
-        // When permanent is true and not compound, this is a workspace artifact (shared)
-        const contextId = determineFileContextId({
-            isArtifact: permanent && !useCompoundContextId,
-            workspaceId: workspaceIdStr,
-            userContextId: userContextIdStr,
-            useCompoundContextId: useCompoundContextId && !!workspaceIdStr,
-        });
+        const storageTarget =
+            storageTargetOverride ||
+            resolveStorageTarget({
+                workspaceId: workspaceIdStr,
+                userId: userContextIdStr,
+            });
 
         // Check if file already exists using hash
         if (metadata.hash) {
             try {
-                const mediaHelperUrl = config.endpoints.mediaHelperDirect();
-                const checkUrl = new URL(mediaHelperUrl);
-                checkUrl.searchParams.set("hash", metadata.hash);
-                checkUrl.searchParams.set("checkHash", "true");
-                if (contextId) {
-                    checkUrl.searchParams.set("contextId", contextId);
-                }
+                const checkData = await checkMediaFile({
+                    hash: metadata.hash,
+                    storageTarget,
+                });
+                if (checkData?.url) {
+                    // Create a new File document with existing file data
+                    const fileUrl = checkData.converted
+                        ? checkData.converted.url
+                        : checkData.url;
+                    const newFile = new File({
+                        filename: checkData.filename || metadata.filename,
+                        originalName: metadata.filename,
+                        mimeType: metadata.mimeType,
+                        size: metadata.size,
+                        url: fileUrl,
+                        gcsUrl: checkData.converted
+                            ? checkData.converted.gcs
+                            : checkData.gcs,
+                        hash: metadata.hash,
+                        blobPath:
+                            checkData.blobPath ||
+                            extractBlobPathFromUrl(fileUrl),
+                        owner: user._id,
+                    });
 
-                const checkResponse = await fetch(checkUrl);
+                    await newFile.save();
 
-                if (checkResponse.ok) {
-                    const checkData = await checkResponse
-                        .json()
-                        .catch(() => null);
-                    if (checkData && checkData.url) {
-                        // If permanent flag is set, ensure existing file is also permanent
-                        if (permanent && metadata.hash) {
-                            try {
-                                await setFileRetention(
-                                    metadata.hash,
-                                    "permanent",
-                                    contextId,
-                                );
-                            } catch (retentionError) {
-                                // Log retention update failures so they are visible for debugging
-                                // This is best-effort, so we continue even if it fails
-                                console.error(
-                                    "Failed to update file retention to 'permanent' for hash",
-                                    metadata.hash,
-                                    "and contextId",
-                                    contextId,
-                                    retentionError,
-                                );
-                            }
-                        }
-
-                        // Create a new File document with existing file data
-                        const newFile = new File({
-                            filename: checkData.filename || metadata.filename,
-                            originalName: metadata.filename,
-                            mimeType: metadata.mimeType,
-                            size: metadata.size,
-                            url: checkData.converted
-                                ? checkData.converted.url
-                                : checkData.url,
-                            gcsUrl: checkData.converted
-                                ? checkData.converted.gcs
-                                : checkData.gcs,
-                            hash: metadata.hash,
-                            owner: user._id,
-                        });
-
-                        await newFile.save();
-
-                        // Associate file with workspace/applet
-                        const associationResult = await associateFile(
-                            newFile,
-                            workspace,
-                            user,
-                        );
-                        if (associationResult.error) {
-                            return { error: associationResult.error };
-                        }
-
-                        // Use the file from associationResult if provided (for duplicates), otherwise use newFile
-                        const fileToReturn = associationResult.file || newFile;
-
-                        const responseData = {
-                            success: true,
-                            file: fileToReturn,
-                            files: associationResult.files,
-                        };
-
-                        return { success: true, data: responseData };
+                    // Associate file with workspace/applet
+                    const associationResult = await associateFile(
+                        newFile,
+                        workspace,
+                        user,
+                    );
+                    if (associationResult.error) {
+                        return { error: associationResult.error };
                     }
+
+                    // Use the file from associationResult if provided (for duplicates), otherwise use newFile
+                    const fileToReturn = associationResult.file || newFile;
+
+                    const responseData = {
+                        success: true,
+                        file: fileToReturn,
+                        files: associationResult.files,
+                    };
+
+                    return { success: true, data: responseData };
                 }
             } catch (error) {
                 console.error("Error checking file hash:", error);
@@ -183,13 +147,10 @@ export async function handleStreamingFileUpload(request, options) {
         }
 
         // Upload file to media service using buffer
-        // Note: permanent flag is handled inside uploadBufferToMediaService via setRetention
-        // Use workspace ID as contextId for workspace/applet files, user contextId for user files
         const uploadResult = await uploadBufferToMediaService(
             fileBuffer,
             metadata,
-            permanent,
-            contextId,
+            { storageTarget },
         );
         if (uploadResult.error) {
             return { error: uploadResult.error };
@@ -214,6 +175,7 @@ export async function handleStreamingFileUpload(request, options) {
             url: url,
             gcsUrl: gcsUrl,
             hash: uploadResult.data.hash || metadata.hash, // Use hash from upload response or computed hash from file
+            blobPath: uploadResult.data.blobPath || extractBlobPathFromUrl(url),
             owner: user._id,
         });
 
@@ -485,7 +447,4 @@ export async function parseStreamingMultipart(request, user) {
 }
 
 // Re-export uploadBufferToMediaService for backward compatibility
-export {
-    uploadBufferToMediaService,
-    setFileRetention,
-} from "./media-service-utils.js";
+export { uploadBufferToMediaService } from "./media-service-utils.js";

--- a/app/api/workspaces/[id]/files/[fileId]/route.js
+++ b/app/api/workspaces/[id]/files/[fileId]/route.js
@@ -1,174 +1,43 @@
 import { NextResponse } from "next/server";
 import Workspace from "../../../../models/workspace.js";
+import AppletSharedFile from "../../../../models/applet-shared-file.js";
 import File from "../../../../models/file.js";
 import Prompt from "../../../../models/prompt.js";
 import { getCurrentUser } from "../../../../utils/auth.js";
-import config from "../../../../../../config/index.js";
+import { ensureAppletSharedFileStore } from "../../../../utils/applet-shared-file-utils.js";
+import { deleteMediaFile } from "../../../../utils/media-service-utils.js";
+import {
+    createAppletSharedStorageTarget,
+    createWorkspaceSharedStorageTarget,
+} from "../../../../../../src/utils/storageTargets.js";
 
-// DELETE: delete a specific file from a workspace by file ID
-export async function DELETE(request, { params }) {
-    const { id: workspaceId, fileId } = params;
-    const { searchParams } = new URL(request.url);
-    const force = searchParams.get("force") === "true";
+function getSharedStorageTarget(workspace) {
+    const appletId = workspace?.applet?.toString() || null;
+    if (appletId) {
+        return createAppletSharedStorageTarget(appletId);
+    }
+    return createWorkspaceSharedStorageTarget(
+        workspace?._id?.toString() || null,
+    );
+}
 
-    try {
-        // Get current user
-        const user = await getCurrentUser();
-        if (!user) {
-            return NextResponse.json(
-                { error: "Authentication required" },
-                { status: 401 },
-            );
-        }
+async function getSharedFilesDoc(workspace) {
+    if (workspace?.applet) {
+        return ensureAppletSharedFileStore(workspace);
+    }
+    return Workspace.findById(workspace._id).populate("files");
+}
 
-        // Find the workspace and populate files
-        const workspace =
-            await Workspace.findById(workspaceId).populate("files");
-        if (!workspace) {
-            return NextResponse.json(
-                { error: "Workspace not found" },
-                { status: 404 },
-            );
-        }
+async function removeSharedFileReference(workspaceId, workspace, fileId) {
+    if (workspace?.applet) {
+        await Workspace.findByIdAndUpdate(workspaceId, {
+            $pull: {
+                files: fileId,
+            },
+        });
 
-        // Check if user is owner
-        if (!workspace.owner?.equals(user._id)) {
-            return NextResponse.json(
-                { error: "Not authorized to delete files from this workspace" },
-                { status: 403 },
-            );
-        }
-
-        // Find the file to delete by ID
-        const fileToDelete = await File.findById(fileId);
-
-        // Verify the file belongs to this workspace
-        const fileInWorkspace = workspace.files.some(
-            (file) => file._id.toString() === fileId,
-        );
-
-        if (!fileToDelete) {
-            // File not found in database - still need to clean up workspace references
-            if (fileInWorkspace) {
-                // Remove the file reference from the workspace
-                const updatedWorkspace = await Workspace.findByIdAndUpdate(
-                    workspaceId,
-                    {
-                        $pull: {
-                            files: fileId,
-                        },
-                    },
-                    {
-                        new: true,
-                        runValidators: true,
-                    },
-                ).populate("files");
-
-                return NextResponse.json({
-                    success: true,
-                    message:
-                        "File already deleted, removed reference from workspace",
-                    files: updatedWorkspace.files || [],
-                });
-            } else {
-                // File not in database and not in workspace
-                return NextResponse.json({
-                    success: true,
-                    message: "File already deleted or does not exist",
-                    files: workspace.files || [],
-                });
-            }
-        }
-
-        if (!fileInWorkspace) {
-            // File exists in database but not in this workspace
-            return NextResponse.json({
-                success: true,
-                message: "File not found in this workspace",
-                files: workspace.files || [],
-            });
-        }
-
-        // Check if the file is attached to any prompts in the workspace
-        const promptsUsingFile = await Prompt.find({
-            _id: { $in: workspace.prompts },
-            files: fileId,
-        }).select("title _id");
-
-        if (promptsUsingFile.length > 0) {
-            if (force) {
-                // Force deletion: detach file from all prompts first
-                await Prompt.updateMany(
-                    { _id: { $in: promptsUsingFile.map((p) => p._id) } },
-                    { $pull: { files: fileId } },
-                );
-            } else {
-                // Normal deletion: return error if attached
-                return NextResponse.json(
-                    {
-                        error: "File is currently attached to one or more prompts",
-                        promptsUsingFile: promptsUsingFile.map((p) => ({
-                            id: p._id,
-                            title: p.title,
-                        })),
-                        code: "FILE_ATTACHED_TO_PROMPTS",
-                    },
-                    { status: 409 }, // Conflict status code
-                );
-            }
-        }
-
-        // Delete the file using the file handler
-        try {
-            if (fileToDelete.hash) {
-                const mediaHelperUrl = config.endpoints.mediaHelperDirect();
-                if (!mediaHelperUrl) {
-                    console.error(
-                        "CORTEX_MEDIA_API_URL is not set or mediaHelperUrl is undefined.",
-                    );
-                    return NextResponse.json(
-                        {
-                            error: "Media helper URL is not configured. Please set CORTEX_MEDIA_API_URL.",
-                        },
-                        { status: 500 },
-                    );
-                }
-
-                const deleteUrl = new URL(mediaHelperUrl);
-                deleteUrl.searchParams.set("hash", fileToDelete.hash);
-                // Workspace/applet artifacts use workspaceId (shared across all users)
-                deleteUrl.searchParams.set("contextId", workspaceId);
-
-                const deleteResponse = await fetch(deleteUrl.toString(), {
-                    method: "DELETE",
-                    headers: {
-                        "Content-Type": "application/json",
-                    },
-                });
-
-                if (!deleteResponse.ok) {
-                    const errorBody = await deleteResponse.text();
-                    console.warn(
-                        `Failed to delete file: ${deleteResponse.statusText}. Response: ${errorBody}`,
-                    );
-                    // Continue with database deletion even if file deletion fails
-                } else {
-                    console.log(
-                        `Successfully deleted file ${fileToDelete.hash}`,
-                    );
-                }
-            }
-        } catch (error) {
-            console.error("Error deleting file:", error);
-            // Continue with database deletion even if file deletion fails
-        }
-
-        // Remove the file document
-        await File.findByIdAndDelete(fileId);
-
-        // Remove the file reference from the workspace
-        const updatedWorkspace = await Workspace.findByIdAndUpdate(
-            workspaceId,
+        return AppletSharedFile.findOneAndUpdate(
+            { appletId: workspace.applet },
             {
                 $pull: {
                     files: fileId,
@@ -179,10 +48,138 @@ export async function DELETE(request, { params }) {
                 runValidators: true,
             },
         ).populate("files");
+    }
+
+    return Workspace.findByIdAndUpdate(
+        workspaceId,
+        {
+            $pull: {
+                files: fileId,
+            },
+        },
+        {
+            new: true,
+            runValidators: true,
+        },
+    ).populate("files");
+}
+
+// DELETE: delete a specific shared file from a workspace/applet by file ID
+export async function DELETE(request, { params }) {
+    const { id: workspaceId, fileId } = params;
+    const { searchParams } = new URL(request.url);
+    const force = searchParams.get("force") === "true";
+
+    try {
+        const user = await getCurrentUser();
+        if (!user) {
+            return NextResponse.json(
+                { error: "Authentication required" },
+                { status: 401 },
+            );
+        }
+
+        const workspace = await Workspace.findById(workspaceId);
+        if (!workspace) {
+            return NextResponse.json(
+                { error: "Workspace not found" },
+                { status: 404 },
+            );
+        }
+
+        if (!workspace.owner?.equals(user._id)) {
+            return NextResponse.json(
+                { error: "Not authorized to delete files from this workspace" },
+                { status: 403 },
+            );
+        }
+
+        const sharedFilesDoc = await getSharedFilesDoc(workspace);
+        const sharedFiles = Array.isArray(sharedFilesDoc?.files)
+            ? sharedFilesDoc.files
+            : [];
+
+        const fileInWorkspace = sharedFiles.some(
+            (file) => file._id.toString() === fileId,
+        );
+        const fileToDelete = await File.findById(fileId);
+
+        if (!fileToDelete) {
+            if (fileInWorkspace) {
+                const updatedSharedFiles = await removeSharedFileReference(
+                    workspaceId,
+                    workspace,
+                    fileId,
+                );
+
+                return NextResponse.json({
+                    success: true,
+                    message:
+                        "File already deleted, removed reference from workspace",
+                    files: updatedSharedFiles?.files || [],
+                });
+            }
+
+            return NextResponse.json({
+                success: true,
+                message: "File already deleted or does not exist",
+                files: sharedFiles,
+            });
+        }
+
+        if (!fileInWorkspace) {
+            return NextResponse.json({
+                success: true,
+                message: "File not found in this workspace",
+                files: sharedFiles,
+            });
+        }
+
+        const promptsUsingFile = await Prompt.find({
+            _id: { $in: workspace.prompts },
+            files: fileId,
+        }).select("title _id");
+
+        if (promptsUsingFile.length > 0) {
+            if (force) {
+                await Prompt.updateMany(
+                    { _id: { $in: promptsUsingFile.map((p) => p._id) } },
+                    { $pull: { files: fileId } },
+                );
+            } else {
+                return NextResponse.json(
+                    {
+                        error: "File is currently attached to one or more prompts",
+                        promptsUsingFile: promptsUsingFile.map((p) => ({
+                            id: p._id,
+                            title: p.title,
+                        })),
+                        code: "FILE_ATTACHED_TO_PROMPTS",
+                    },
+                    { status: 409 },
+                );
+            }
+        }
+
+        if (fileToDelete.hash || fileToDelete.blobPath) {
+            await deleteMediaFile({
+                blobPath: fileToDelete.blobPath,
+                hash: fileToDelete.hash,
+                storageTarget: getSharedStorageTarget(workspace),
+            });
+        }
+
+        await File.findByIdAndDelete(fileId);
+
+        const updatedSharedFiles = await removeSharedFileReference(
+            workspaceId,
+            workspace,
+            fileId,
+        );
 
         return NextResponse.json({
             success: true,
-            files: updatedWorkspace.files || [],
+            files: updatedSharedFiles?.files || [],
         });
     } catch (error) {
         console.error("Error deleting workspace file:", error);

--- a/app/api/workspaces/[id]/files/route.js
+++ b/app/api/workspaces/[id]/files/route.js
@@ -1,18 +1,107 @@
 import { NextResponse } from "next/server";
 import Workspace from "../../../models/workspace.js";
+import AppletSharedFile from "../../../models/applet-shared-file.js";
 import File from "../../../models/file.js";
 import { getCurrentUser } from "../../../utils/auth.js";
+import { ensureAppletSharedFileStore } from "../../../utils/applet-shared-file-utils.js";
 import { handleStreamingFileUpload } from "../../../utils/upload-utils.js";
+import { deleteMediaFile } from "../../../utils/media-service-utils.js";
+import {
+    createAppletSharedStorageTarget,
+    createWorkspaceSharedStorageTarget,
+} from "../../../../../src/utils/storageTargets.js";
 
-// POST: upload a file for a workspace with streaming support
+function getWorkspaceSharedStorageTarget(workspace) {
+    if (!workspace?._id) {
+        return null;
+    }
+    const appletId = workspace?.applet?.toString() || null;
+    if (appletId) {
+        return createAppletSharedStorageTarget(appletId);
+    }
+    return createWorkspaceSharedStorageTarget(
+        workspace?._id?.toString() || null,
+    );
+}
+
+async function getSharedFileDocument(workspace, match = null) {
+    if (workspace?.applet) {
+        return ensureAppletSharedFileStore(workspace, { match });
+    }
+
+    const query = Workspace.findById(workspace?._id);
+    if (match) {
+        query.populate({ path: "files", match });
+    } else {
+        query.populate("files");
+    }
+    return query;
+}
+
+async function addSharedFileReference(workspace, fileId) {
+    if (workspace?.applet) {
+        await Workspace.findByIdAndUpdate(workspace._id, {
+            $addToSet: {
+                files: fileId,
+            },
+        });
+
+        return AppletSharedFile.findOneAndUpdate(
+            { appletId: workspace.applet },
+            {
+                $addToSet: {
+                    files: fileId,
+                },
+            },
+            {
+                new: true,
+                upsert: true,
+                runValidators: true,
+            },
+        ).populate("files");
+    }
+
+    return Workspace.findByIdAndUpdate(
+        workspace._id,
+        {
+            $push: {
+                files: fileId,
+            },
+        },
+        {
+            new: true,
+            runValidators: true,
+        },
+    ).populate("files");
+}
+
+async function deleteDuplicateCloudFile(file, workspace) {
+    if ((!file?.blobPath && !file?.hash) || !workspace?._id) {
+        return;
+    }
+    await deleteMediaFile({
+        blobPath: file.blobPath,
+        hash: file.hash,
+        storageTarget: getWorkspaceSharedStorageTarget(workspace),
+    });
+}
+
+function getFilesFromSharedDocument(sharedDocument) {
+    if (!sharedDocument) {
+        return [];
+    }
+    return Array.isArray(sharedDocument.files) ? sharedDocument.files : [];
+}
+
+// POST: upload a shared file for a workspace/applet with streaming support
 export async function POST(request, { params }) {
     const { id } = params;
+    const workspace = await Workspace.findById(id);
 
     const result = await handleStreamingFileUpload(request, {
-        getWorkspace: async () => await Workspace.findById(id),
+        getWorkspace: async () => workspace,
 
         checkAuthorization: async (workspace, user) => {
-            // Check if user is owner or has permission
             if (!workspace.owner?.equals(user._id)) {
                 return {
                     error: NextResponse.json(
@@ -26,60 +115,56 @@ export async function POST(request, { params }) {
             return { success: true };
         },
 
-        associateFile: async (newFile, workspace, user) => {
-            // Check if a file with the same hash already exists in this workspace
+        storageTarget: getWorkspaceSharedStorageTarget(workspace),
+
+        associateFile: async (newFile, workspace) => {
+            const matchQuery = [];
+            if (newFile.blobPath) {
+                matchQuery.push({ blobPath: newFile.blobPath });
+            }
             if (newFile.hash) {
-                const existingWorkspace = await Workspace.findById(id).populate(
-                    {
-                        path: "files",
-                        match: { hash: newFile.hash },
-                    },
+                matchQuery.push({ hash: newFile.hash });
+            }
+
+            if (matchQuery.length > 0) {
+                const existingSharedFiles = await getSharedFileDocument(
+                    workspace,
+                    matchQuery.length === 1
+                        ? matchQuery[0]
+                        : { $or: matchQuery },
                 );
 
-                if (
-                    existingWorkspace &&
-                    existingWorkspace.files &&
-                    existingWorkspace.files.length > 0
-                ) {
-                    // File with this hash already exists, return existing file without adding
-                    const existingFile = existingWorkspace.files[0];
-                    const allFiles =
-                        await Workspace.findById(id).populate("files");
+                const existingFiles =
+                    getFilesFromSharedDocument(existingSharedFiles);
 
-                    // Delete the duplicate File document we just created
+                if (existingFiles.length > 0) {
+                    const existingFile = existingFiles[0];
+                    const allFilesDoc = await getSharedFileDocument(workspace);
+
+                    await deleteDuplicateCloudFile(newFile, workspace);
                     await File.findByIdAndDelete(newFile._id);
 
                     return {
                         success: true,
-                        file: existingFile, // Return the existing file, not the duplicate
-                        files: allFiles ? allFiles.files : [],
+                        file: existingFile,
+                        files: getFilesFromSharedDocument(allFilesDoc),
                     };
                 }
             }
 
-            // Add file reference to workspace
-            const updatedWorkspace = await Workspace.findByIdAndUpdate(
-                id,
-                {
-                    $push: {
-                        files: newFile._id,
-                    },
-                },
-                {
-                    new: true,
-                    runValidators: true,
-                },
-            ).populate("files");
+            const updatedSharedFiles = await addSharedFileReference(
+                workspace,
+                newFile._id,
+            );
 
             return {
                 success: true,
                 file: newFile,
-                files: updatedWorkspace.files,
+                files: getFilesFromSharedDocument(updatedSharedFiles),
             };
         },
 
         errorPrefix: "workspace file upload",
-        permanent: true,
     });
 
     if (result.error) {
@@ -92,12 +177,12 @@ export async function POST(request, { params }) {
     });
 }
 
-// GET: retrieve files for a workspace
+// GET: retrieve shared files for a workspace/applet
 export async function GET(request, { params }) {
     const { id } = params;
 
     try {
-        const workspace = await Workspace.findById(id).populate("files");
+        const workspace = await Workspace.findById(id);
         if (!workspace) {
             return NextResponse.json(
                 { error: "Workspace not found" },
@@ -105,10 +190,7 @@ export async function GET(request, { params }) {
             );
         }
 
-        // Get current user
         const user = await getCurrentUser();
-
-        // Check if user has access to this workspace
         if (!workspace.owner?.equals(user._id)) {
             return NextResponse.json(
                 { error: "Not authorized to view files for this workspace" },
@@ -116,8 +198,10 @@ export async function GET(request, { params }) {
             );
         }
 
+        const sharedFiles = await getSharedFileDocument(workspace);
+
         return NextResponse.json({
-            files: workspace.files || [],
+            files: getFilesFromSharedDocument(sharedFiles),
         });
     } catch (error) {
         console.error("Error retrieving workspace files:", error);

--- a/app/api/workspaces/[id]/files/validate/route.js
+++ b/app/api/workspaces/[id]/files/validate/route.js
@@ -2,8 +2,13 @@ import { NextResponse } from "next/server";
 import Workspace from "../../../../models/workspace";
 import File from "../../../../models/file";
 import { getCurrentUser } from "../../../../utils/auth";
+import { ensureAppletSharedFileStore } from "../../../../utils/applet-shared-file-utils";
 import config from "../../../../../../config";
 import { validateAndRefreshFile } from "../../../../utils/file-refresh-utils";
+import {
+    createAppletSharedStorageTarget,
+    createWorkspaceSharedStorageTarget,
+} from "../../../../../../src/utils/storageTargets";
 
 /**
  * Validate and refresh files attached to workspace prompts
@@ -38,6 +43,12 @@ export async function POST(request, { params }) {
             );
         }
 
+        if (workspace.applet) {
+            await ensureAppletSharedFileStore(workspace, {
+                populateFiles: false,
+            });
+        }
+
         // Collect all unique files from all prompts
         const fileIds = new Set();
         workspace.prompts.forEach((prompt) => {
@@ -54,12 +65,19 @@ export async function POST(request, { params }) {
 
         const files = await File.find({ _id: { $in: Array.from(fileIds) } });
         const mediaHelperUrl = config.endpoints.mediaHelperDirect();
-        // Use workspaceId as contextId for workspace artifacts
-        const contextId = workspaceId.toString();
+        const storageTarget = workspace.applet
+            ? createAppletSharedStorageTarget(workspace.applet.toString())
+            : createWorkspaceSharedStorageTarget(workspaceId.toString());
+        const fallbackStorageTargets =
+            workspace.applet && workspaceId
+                ? [createWorkspaceSharedStorageTarget(workspaceId.toString())]
+                : [];
 
         const results = await Promise.allSettled(
             files.map((file) =>
-                validateAndRefreshFile(file, contextId, mediaHelperUrl),
+                validateAndRefreshFile(file, storageTarget, mediaHelperUrl, {
+                    fallbackStorageTargets,
+                }),
             ),
         );
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -26,6 +26,7 @@ const projects = process.env.CI
               },
               moduleDirectories: ["node_modules", "__mocks__"],
               moduleNameMapper: {
+                  "^@/src/(.*)$": "<rootDir>/src/$1",
                   "^@/(.*)$": "<rootDir>/@/$1",
                   "^@components/(.*)$": "<rootDir>/@/components/$1",
                   "^@lib/(.*)$": "<rootDir>/app/lib/$1",
@@ -79,6 +80,7 @@ const projects = process.env.CI
               },
               moduleDirectories: ["node_modules", "__mocks__"],
               moduleNameMapper: {
+                  "^@/src/(.*)$": "<rootDir>/src/$1",
                   "^@/(.*)$": "<rootDir>/@/$1",
                   "^@components/(.*)$": "<rootDir>/@/components/$1",
                   "^@lib/(.*)$": "<rootDir>/app/lib/$1",
@@ -127,6 +129,7 @@ const projects = process.env.CI
               },
               moduleDirectories: ["node_modules", "__mocks__"],
               moduleNameMapper: {
+                  "^@/src/(.*)$": "<rootDir>/src/$1",
                   "^@/(.*)$": "<rootDir>/@/$1",
                   "^@components/(.*)$": "<rootDir>/@/components/$1",
                   "^@lib/(.*)$": "<rootDir>/app/lib/$1",

--- a/src/components/common/FilterInput.js
+++ b/src/components/common/FilterInput.js
@@ -3,7 +3,6 @@
 import { useRef, useEffect } from "react";
 import { Search, X } from "lucide-react";
 import { useTranslation } from "react-i18next";
-import i18next from "i18next";
 
 /**
  * Reusable filter input component with search icon and clear button
@@ -13,6 +12,7 @@ import i18next from "i18next";
  * @param {Function} props.onClear - Callback when clear button is clicked
  * @param {string} props.placeholder - Placeholder text
  * @param {string} props.className - Additional CSS classes
+ * @param {boolean} props.autoFocus - Focus the field when it appears
  */
 export default function FilterInput({
     value,
@@ -20,11 +20,23 @@ export default function FilterInput({
     onClear,
     placeholder,
     className = "",
+    dataTestId,
+    autoFocus = false,
 }) {
     const { t } = useTranslation();
     const filterInputRef = useRef(null);
     const wasInputFocusedRef = useRef(false);
-    const isRtl = i18next.language === "ar";
+    const clearLabel = t("Clear Filter");
+
+    const handleClear = () => {
+        if (onClear) {
+            onClear();
+        } else {
+            onChange("");
+        }
+        wasInputFocusedRef.current = true;
+        filterInputRef.current?.focus();
+    };
 
     // Restore focus to filter input after re-renders
     useEffect(() => {
@@ -33,14 +45,19 @@ export default function FilterInput({
         }
     }, [value]);
 
+    useEffect(() => {
+        if (autoFocus) {
+            filterInputRef.current?.focus();
+        }
+    }, [autoFocus]);
+
     return (
         <div className={`relative ${className}`}>
-            <Search
-                className={`absolute ${isRtl ? "right-3" : "left-3"} top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400`}
-            />
+            <Search className="absolute start-2 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
             <input
+                data-testid={dataTestId}
                 type="text"
-                className={`lb-input w-full ${isRtl ? "pr-10 pl-10" : "pl-10 pr-10"}`}
+                className="lb-input h-full min-h-0 w-full ps-10 pe-10"
                 placeholder={placeholder || t("Filter...")}
                 value={value}
                 onChange={(e) => onChange(e.target.value)}
@@ -54,8 +71,11 @@ export default function FilterInput({
             />
             {value && (
                 <button
-                    className={`absolute inset-y-0 ${isRtl ? "left-0 pl-3" : "right-0 pr-3"} flex items-center`}
-                    onClick={onClear}
+                    data-testid={dataTestId ? `${dataTestId}-clear` : undefined}
+                    className="absolute inset-y-0 end-2 flex items-center"
+                    onClick={handleClear}
+                    aria-label={clearLabel}
+                    title={clearLabel}
                     type="button"
                 >
                     <X className="h-4 w-4 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300" />

--- a/src/components/common/MediaThumbnail.js
+++ b/src/components/common/MediaThumbnail.js
@@ -1,0 +1,236 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { AlertCircle, Loader2, Music, Play } from "lucide-react";
+import { getFileIcon } from "@/src/utils/mediaUtils";
+import {
+    useFilePreview,
+    renderFilePreview,
+} from "@/src/components/chat/useFilePreview";
+import {
+    extractYoutubeVideoId,
+    getYoutubeThumbnailUrl,
+    isYoutubeUrl,
+} from "@/src/utils/urlUtils";
+import { getDownloadUrl } from "@/src/utils/fileDownloadUtils";
+
+/**
+ * Shared media thumbnail. Used wherever the app shows a small preview of a
+ * user file: file browser grid + list, hover preview, chat composer chips,
+ * media gallery tiles.
+ *
+ * Renders an inline preview (image / video / YouTube / PDF / text). Videos
+ * autoplay muted+looped so the thumbnail itself shows motion. Falls back to
+ * the file-type icon when no preview is possible. A loader sits over the
+ * preview until onLoad fires; a Play affordance overlays YouTube and any
+ * non-autoplaying video.
+ *
+ * The container is sized by the parent via `className` (e.g. "w-20 h-20",
+ * "w-full aspect-square"). Set `autoPlayVideo={false}` for very small
+ * thumbnails where motion would be distracting.
+ */
+export default function MediaThumbnail({
+    src,
+    filename,
+    mimeType,
+    mediaType,
+    className = "",
+    objectFit = "cover",
+    autoPlayVideo = true,
+    showVideoControls = true,
+    showPlayOverlay = true,
+    playIconSize = "w-8 h-8",
+    iconSize = "w-10 h-10",
+    mediaStatus,
+    mediaError,
+    thumbnailSrc,
+    compact = false,
+}) {
+    const { t } = useTranslation();
+    const normalizedStatus = String(mediaStatus || "").toLowerCase();
+    const isProcessingMedia = ["pending", "processing", "queued"].includes(
+        normalizedStatus,
+    );
+    const isFailedMedia = ["failed", "error"].includes(normalizedStatus);
+    const errorMessage =
+        typeof mediaError === "string"
+            ? mediaError
+            : mediaError?.message || mediaError?.error || "";
+
+    const displayThumbnailSrc = thumbnailSrc
+        ? getDownloadUrl(thumbnailSrc)
+        : null;
+    const isYouTube = src ? isYoutubeUrl(src) : false;
+    const youtubeVideoId = isYouTube && src ? extractYoutubeVideoId(src) : null;
+    const youtubeThumbnail = youtubeVideoId
+        ? getYoutubeThumbnailUrl(youtubeVideoId, "hqdefault")
+        : null;
+
+    const fileType = useFilePreview(src, filename, mimeType);
+    const isVideoMedia = mediaType === "video" || fileType.isVideo;
+    const isAudioMedia =
+        mediaType === "audio" ||
+        fileType.isAudio ||
+        String(mimeType || "").startsWith("audio/");
+
+    const [mediaLoaded, setMediaLoaded] = useState(false);
+    useEffect(() => {
+        setMediaLoaded(false);
+    }, [src, displayThumbnailSrc]);
+
+    const fitClass =
+        objectFit === "contain" ? "object-contain" : "object-cover";
+
+    let body;
+    if (isFailedMedia) {
+        body = (
+            <div
+                className={`flex h-full w-full flex-col items-center justify-center border border-red-200 bg-red-50 text-red-700 dark:border-red-900/60 dark:bg-red-950/40 dark:text-red-200 ${
+                    compact ? "p-0" : "gap-1.5 p-2"
+                }`}
+                title={errorMessage || t("Media generation failed")}
+            >
+                <AlertCircle className={`${iconSize} opacity-90`} />
+                {!compact && (
+                    <span className="max-w-full truncate text-xs font-medium">
+                        {t("Failed")}
+                    </span>
+                )}
+            </div>
+        );
+    } else if (isProcessingMedia) {
+        body = (
+            <div
+                className={`flex h-full w-full flex-col items-center justify-center bg-slate-900 text-sky-100 ${
+                    compact ? "p-0" : "gap-2 p-3"
+                }`}
+            >
+                <Loader2 className={`${iconSize} animate-spin opacity-90`} />
+                {!compact && (
+                    <span className="max-w-full truncate text-xs font-medium">
+                        {t("Processing")}
+                    </span>
+                )}
+            </div>
+        );
+    } else if (isAudioMedia) {
+        body = (
+            <div
+                className={`flex h-full w-full flex-col items-center justify-center bg-gradient-to-br from-cyan-900 via-slate-900 to-fuchsia-950 text-cyan-100 ${
+                    compact ? "p-0" : "gap-2 p-3"
+                }`}
+            >
+                <Music className={`${iconSize} opacity-90`} />
+                {!compact && (
+                    <div
+                        className="flex h-10 w-full max-w-32 items-end justify-center gap-0.5"
+                        aria-hidden="true"
+                    >
+                        {Array.from({ length: 18 }).map((_, index) => (
+                            <span
+                                key={index}
+                                className="w-1 rounded-full bg-cyan-200/80"
+                                style={{
+                                    height: `${20 + ((index * 17) % 64)}%`,
+                                }}
+                            />
+                        ))}
+                    </div>
+                )}
+            </div>
+        );
+    } else if (displayThumbnailSrc) {
+        body = (
+            <img
+                src={displayThumbnailSrc}
+                alt={filename || t("Video thumbnail")}
+                className={`w-full h-full ${fitClass}`}
+                loading="lazy"
+                decoding="async"
+                onLoad={() => setMediaLoaded(true)}
+            />
+        );
+    } else if (isYouTube && youtubeThumbnail) {
+        body = (
+            <img
+                src={youtubeThumbnail}
+                alt={filename || t("YouTube video")}
+                className={`w-full h-full ${fitClass}`}
+                loading="lazy"
+                decoding="async"
+                onLoad={() => setMediaLoaded(true)}
+                onError={(e) => {
+                    if (youtubeVideoId) {
+                        e.target.src = getYoutubeThumbnailUrl(
+                            youtubeVideoId,
+                            "hqdefault",
+                        );
+                    }
+                }}
+            />
+        );
+    } else if (isVideoMedia) {
+        body = (
+            <div className="flex h-full w-full items-center justify-center bg-gray-100 text-gray-400 dark:bg-gray-800 dark:text-gray-500">
+                <Play className={`${iconSize} opacity-70`} />
+            </div>
+        );
+    } else if (src && fileType.isPreviewable) {
+        body = renderFilePreview({
+            src,
+            filename,
+            fileType,
+            className:
+                fileType.isPdf || fileType.isDoc
+                    ? "w-full h-full"
+                    : `w-full h-full ${fitClass}`,
+            onLoad: () => setMediaLoaded(true),
+            autoPlay: autoPlayVideo && fileType.isVideo,
+            showVideoControls,
+            compact: true,
+            t,
+        });
+    } else {
+        const FileIcon = getFileIcon(filename || "");
+        body = (
+            <FileIcon
+                className={`${iconSize} text-gray-300 dark:text-gray-600`}
+            />
+        );
+    }
+
+    const needsLoading =
+        !isFailedMedia &&
+        !isProcessingMedia &&
+        !isAudioMedia &&
+        ((Boolean(displayThumbnailSrc) && !mediaLoaded) ||
+            fileType.isImage ||
+            isYouTube);
+    const showPlay =
+        !isFailedMedia &&
+        !isProcessingMedia &&
+        showPlayOverlay &&
+        (isYouTube || (fileType.isVideo && !autoPlayVideo));
+
+    return (
+        <div
+            className={`relative overflow-hidden flex items-center justify-center ${className}`}
+        >
+            {body}
+            {needsLoading && !mediaLoaded && (
+                <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
+                    <Loader2 className="w-6 h-6 animate-spin text-gray-300" />
+                </div>
+            )}
+            {showPlay && (
+                <div className="absolute inset-0 flex items-center justify-center bg-black/30 pointer-events-none">
+                    <Play
+                        className={`${playIconSize} text-white opacity-80`}
+                        fill="white"
+                    />
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/components/common/UnifiedFileManager/FileContentArea.js
+++ b/src/components/common/UnifiedFileManager/FileContentArea.js
@@ -1,0 +1,521 @@
+"use client";
+
+import { useState, useMemo, useCallback, useEffect, useRef } from "react";
+import { useTranslation } from "react-i18next";
+import { toast } from "react-toastify";
+import {
+    ArrowUpDown,
+    ChevronUp,
+    ChevronDown,
+    Check,
+    Trash2,
+} from "lucide-react";
+import {
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableHeader,
+    TableRow,
+} from "@/components/ui/table";
+import {
+    getFilename,
+    getFileDate,
+    getFilePreviewUrl,
+    getFileThumbnailUrl,
+    formatFileSize,
+    formatFileListDate,
+} from "@/src/components/common/FileManager";
+import MediaThumbnail from "@/src/components/common/MediaThumbnail";
+import { INVALID_FILENAME_CHARS } from "@/src/utils/fileDownloadUtils";
+
+/**
+ * Sortable column header.
+ */
+function SortableHeader({
+    children,
+    sortKey,
+    currentSort,
+    currentDirection,
+    onSort,
+    className = "",
+}) {
+    const isActive = currentSort === sortKey;
+    const Icon = isActive
+        ? currentDirection === "asc"
+            ? ChevronUp
+            : ChevronDown
+        : ArrowUpDown;
+
+    return (
+        <TableHead className={`h-9 px-2 text-start sm:px-3 ${className}`}>
+            <button
+                onClick={() => onSort(sortKey)}
+                className="flex items-center gap-1.5 text-gray-600 transition-colors hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100"
+            >
+                {children}
+                <Icon
+                    className={`h-3.5 w-3.5 ${isActive ? "text-sky-600 dark:text-sky-400" : ""}`}
+                />
+            </button>
+        </TableHead>
+    );
+}
+
+function getExtension(filename) {
+    const match = String(filename || "").match(/\.([^.]+)$/);
+    return match ? match[1].toLowerCase() : "";
+}
+
+function getFileTypeValue(file, filename = getFilename(file)) {
+    const explicitType = file?.type;
+    if (
+        explicitType &&
+        explicitType !== "file" &&
+        explicitType !== "image_url"
+    ) {
+        return String(explicitType).toLowerCase();
+    }
+
+    const mimeType = String(
+        file?.mimeType || file?.contentType || "",
+    ).toLowerCase();
+    if (mimeType.includes("/")) {
+        return mimeType.split("/")[0] || mimeType;
+    }
+
+    return getExtension(filename) || "file";
+}
+
+function getFileTypeLabel(file, t) {
+    const filename = getFilename(file);
+    const value = getFileTypeValue(file, filename);
+
+    if (value === "image") return t("Image");
+    if (value === "video") return t("Video");
+    if (value === "audio") return t("Audio");
+    if (value === "application") {
+        const extension = getExtension(filename);
+        return extension ? extension.toUpperCase() : t("Document");
+    }
+    if (value === "text") return t("Text");
+    if (value === "file") return t("File");
+
+    return value.toUpperCase();
+}
+
+/**
+ * FileContentArea - table/list view of files in the selected folder.
+ *
+ * @param {Object} props
+ * @param {Array} props.files - Files to display
+ * @param {Set} props.selectedIds - Currently selected file IDs
+ * @param {Function} props.getFileId - Get stable ID for a file
+ * @param {Function} props.onSelectFile - (file, orderedFiles, index, event) selection handler
+ * @param {Function} props.onSelectAll - Toggle select all
+ * @param {boolean} props.allSelected - Whether all files are selected
+ * @param {Function} props.onPreview - Open file preview
+ * @param {Function} props.onRename - Start inline rename
+ * @param {boolean} props.enableFilenameEdit - Enable inline filename editing
+ * @param {Function} props.onUpdateMetadata - Save renamed filename
+ * @param {Function} props.onDelete - Delete a file
+ * @param {string} props.filterText - Current filter text for highlighting
+ * @param {boolean} props.isMobile - Whether to use mobile-specific list behavior
+ */
+export default function FileContentArea({
+    files = [],
+    selectedIds = new Set(),
+    getFileId,
+    onSelectFile,
+    onSelectAll,
+    allSelected = false,
+    onPreview,
+    enableFilenameEdit = true,
+    onUpdateMetadata,
+    onDelete,
+    filterText = "",
+    isMobile = false,
+    renderFileStatus,
+}) {
+    const { t } = useTranslation();
+
+    // Sorting
+    const [sortKey, setSortKey] = useState("date");
+    const [sortDirection, setSortDirection] = useState("desc");
+
+    // Inline editing
+    const [editingFileId, setEditingFileId] = useState(null);
+    const [editingFilename, setEditingFilename] = useState("");
+    const filenameInputRef = useRef(null);
+    const savingRef = useRef(false);
+
+    // Sort handler
+    const handleSort = useCallback(
+        (key) => {
+            if (sortKey === key) {
+                setSortDirection(sortDirection === "asc" ? "desc" : "asc");
+            } else {
+                setSortKey(key);
+                setSortDirection(key === "date" ? "desc" : "asc");
+            }
+        },
+        [sortKey, sortDirection],
+    );
+
+    // Sort files
+    const sortedFiles = useMemo(() => {
+        const filesCopy = [...files];
+        filesCopy.sort((a, b) => {
+            if (sortKey === "filename") {
+                const nameA = getFilename(a).toLowerCase();
+                const nameB = getFilename(b).toLowerCase();
+                const comparison = nameA.localeCompare(nameB);
+                return sortDirection === "asc" ? comparison : -comparison;
+            } else if (sortKey === "size") {
+                const sizeA = a?.size || 0;
+                const sizeB = b?.size || 0;
+                const comparison = sizeB - sizeA;
+                return sortDirection === "asc" ? -comparison : comparison;
+            } else if (sortKey === "type") {
+                const typeA = getFileTypeValue(a);
+                const typeB = getFileTypeValue(b);
+                const comparison =
+                    typeA.localeCompare(typeB) ||
+                    getFilename(a)
+                        .toLowerCase()
+                        .localeCompare(getFilename(b).toLowerCase());
+                return sortDirection === "asc" ? comparison : -comparison;
+            } else {
+                const dateA = getFileDate(a);
+                const dateB = getFileDate(b);
+                if (!dateA && !dateB) return 0;
+                if (!dateA) return 1;
+                if (!dateB) return -1;
+                const comparison = dateB.getTime() - dateA.getTime();
+                return sortDirection === "asc" ? -comparison : comparison;
+            }
+        });
+        return filesCopy;
+    }, [files, sortKey, sortDirection]);
+
+    // Inline editing handlers
+    useEffect(() => {
+        if (editingFileId && filenameInputRef.current) {
+            filenameInputRef.current.focus();
+            filenameInputRef.current.select();
+        }
+    }, [editingFileId]);
+
+    const handleStartEdit = useCallback(
+        (file, e) => {
+            if (!enableFilenameEdit) return;
+            e?.stopPropagation();
+            setEditingFileId(getFileId(file));
+            setEditingFilename(getFilename(file));
+        },
+        [getFileId, enableFilenameEdit],
+    );
+
+    const handleSaveFilename = useCallback(
+        async (file) => {
+            // Guard against double-call: pressing Enter clears editingFileId,
+            // which unmounts the input and fires onBlur, calling this again.
+            if (savingRef.current) return;
+            if (!onUpdateMetadata) return;
+            const trimmed = editingFilename.trim();
+            if (!trimmed) {
+                setEditingFileId(null);
+                setEditingFilename("");
+                return;
+            }
+            if (INVALID_FILENAME_CHARS.test(trimmed)) {
+                toast.error(t("Filename contains invalid characters."));
+                return;
+            }
+            if (trimmed.length > 255) {
+                toast.error(t("Filename is too long."));
+                return;
+            }
+            savingRef.current = true;
+            setEditingFileId(null);
+            setEditingFilename("");
+            try {
+                await onUpdateMetadata(file, { displayFilename: trimmed });
+            } catch {
+                toast.error(t("Failed to save filename."));
+            } finally {
+                savingRef.current = false;
+            }
+        },
+        [editingFilename, onUpdateMetadata, t],
+    );
+
+    const handleCancelEdit = useCallback(() => {
+        setEditingFileId(null);
+        setEditingFilename("");
+    }, []);
+
+    const handleFilenameKeyDown = useCallback(
+        (e, file) => {
+            if (e.key === "Enter") {
+                e.preventDefault();
+                handleSaveFilename(file);
+            } else if (e.key === "Escape") {
+                e.preventDefault();
+                handleCancelEdit();
+            }
+        },
+        [handleSaveFilename, handleCancelEdit],
+    );
+
+    if (files.length === 0) {
+        return null; // Parent handles empty state
+    }
+
+    const showActionsColumn = !isMobile && !!onDelete;
+
+    return (
+        <div className="min-h-0 flex-1 overflow-auto overscroll-contain min-w-0">
+            <Table>
+                <TableHeader>
+                    <TableRow className="border-b border-gray-100 dark:border-gray-800">
+                        {/* Checkbox column */}
+                        <TableHead className="h-9 w-10 px-0.5 sm:px-3">
+                            <button
+                                onClick={onSelectAll}
+                                className="flex h-10 w-10 items-center justify-center rounded border border-transparent transition-colors hover:border-sky-500 dark:hover:border-sky-400 sm:h-4 sm:w-4 sm:border-gray-300 sm:dark:border-gray-600"
+                                aria-label={t("Select all")}
+                            >
+                                {allSelected && (
+                                    <Check className="w-3 h-3 text-sky-600 dark:text-sky-400" />
+                                )}
+                            </button>
+                        </TableHead>
+                        {/* Icon column */}
+                        <TableHead className="h-9 w-8 px-1" />
+                        {/* Filename */}
+                        <SortableHeader
+                            sortKey="filename"
+                            currentSort={sortKey}
+                            currentDirection={sortDirection}
+                            onSort={handleSort}
+                        >
+                            {t("Name")}
+                        </SortableHeader>
+                        {/* Type */}
+                        <SortableHeader
+                            sortKey="type"
+                            currentSort={sortKey}
+                            currentDirection={sortDirection}
+                            onSort={handleSort}
+                            className="hidden md:table-cell w-24"
+                        >
+                            {t("Type")}
+                        </SortableHeader>
+                        {/* Size */}
+                        <SortableHeader
+                            sortKey="size"
+                            currentSort={sortKey}
+                            currentDirection={sortDirection}
+                            onSort={handleSort}
+                            className="hidden sm:table-cell w-24"
+                        >
+                            {t("Size")}
+                        </SortableHeader>
+                        {/* Date */}
+                        <SortableHeader
+                            sortKey="date"
+                            currentSort={sortKey}
+                            currentDirection={sortDirection}
+                            onSort={handleSort}
+                            className="w-20 md:w-32"
+                        >
+                            {t("Date")}
+                        </SortableHeader>
+                        {showActionsColumn && (
+                            <TableHead className="h-9 w-10 px-2 sm:px-3" />
+                        )}
+                    </TableRow>
+                </TableHeader>
+                <TableBody>
+                    {sortedFiles.map((file, index) => {
+                        const fileId = getFileId(file);
+                        const isSelected = selectedIds.has(fileId);
+                        const filename = getFilename(file);
+                        const previewUrl = getFilePreviewUrl(file);
+                        const thumbnailUrl = getFileThumbnailUrl(file);
+                        const fileDate = getFileDate(file);
+                        const fileTypeLabel = getFileTypeLabel(file, t);
+                        const isEditing = editingFileId === fileId;
+
+                        return (
+                            <TableRow
+                                key={fileId}
+                                className={`group border-b border-gray-50 dark:border-gray-800/50 cursor-pointer transition-colors ${
+                                    isSelected
+                                        ? "bg-sky-50 dark:bg-sky-900/20"
+                                        : "hover:bg-gray-50 dark:hover:bg-gray-800/50"
+                                }`}
+                                onClick={(e) =>
+                                    onSelectFile(file, sortedFiles, index, e)
+                                }
+                                onDoubleClick={(e) => {
+                                    e.stopPropagation();
+                                    onPreview?.(file);
+                                }}
+                            >
+                                {/* Checkbox */}
+                                <TableCell className="w-10 px-0.5 py-1 sm:px-3">
+                                    <button
+                                        onClick={(e) => {
+                                            e.stopPropagation();
+                                            onSelectFile(
+                                                file,
+                                                sortedFiles,
+                                                index,
+                                                e,
+                                            );
+                                        }}
+                                        className={`flex h-10 w-10 items-center justify-center rounded border transition-colors sm:h-4 sm:w-4 ${
+                                            isSelected
+                                                ? "bg-sky-600 border-sky-600 dark:bg-sky-500 dark:border-sky-500"
+                                                : "border-transparent hover:border-sky-500 dark:hover:border-sky-400 sm:border-gray-300 sm:dark:border-gray-600"
+                                        }`}
+                                        aria-label={t("Select file")}
+                                    >
+                                        {isSelected && (
+                                            <Check className="w-3 h-3 text-white" />
+                                        )}
+                                    </button>
+                                </TableCell>
+                                {/* Icon */}
+                                <TableCell className="w-10 px-0 py-1 sm:w-8 sm:px-1">
+                                    <button
+                                        type="button"
+                                        className="flex h-10 w-10 items-center justify-center rounded focus:outline-none focus:ring-2 focus:ring-sky-500 sm:block sm:h-auto sm:w-auto"
+                                        onClick={(e) => {
+                                            e.stopPropagation();
+                                            onPreview?.(file);
+                                        }}
+                                        aria-label={t("Preview")}
+                                    >
+                                        <MediaThumbnail
+                                            src={previewUrl}
+                                            filename={filename}
+                                            mimeType={
+                                                file?.mimeType ||
+                                                file?.contentType
+                                            }
+                                            mediaType={
+                                                file?._mediaItem?.type ||
+                                                file?.type
+                                            }
+                                            mediaStatus={
+                                                file?._mediaItem?.status ||
+                                                file?.status
+                                            }
+                                            mediaError={
+                                                file?._mediaItem?.error ||
+                                                file?.error
+                                            }
+                                            thumbnailSrc={thumbnailUrl}
+                                            className="h-8 w-8 rounded sm:h-6 sm:w-6"
+                                            iconSize="w-4 h-4"
+                                            compact
+                                            autoPlayVideo={false}
+                                            showVideoControls={false}
+                                            showPlayOverlay={false}
+                                        />
+                                    </button>
+                                </TableCell>
+                                {/* Filename */}
+                                <TableCell className="px-1.5 py-1.5 sm:px-3">
+                                    {isEditing ? (
+                                        <input
+                                            ref={filenameInputRef}
+                                            type="text"
+                                            value={editingFilename}
+                                            onChange={(e) =>
+                                                setEditingFilename(
+                                                    e.target.value,
+                                                )
+                                            }
+                                            onKeyDown={(e) =>
+                                                handleFilenameKeyDown(e, file)
+                                            }
+                                            onBlur={() =>
+                                                handleSaveFilename(file)
+                                            }
+                                            onClick={(e) => e.stopPropagation()}
+                                            className="w-full text-sm bg-white dark:bg-gray-800 border border-sky-500 dark:border-sky-400 rounded px-2 py-0.5 focus:outline-none focus:ring-2 focus:ring-sky-500"
+                                        />
+                                    ) : (
+                                        <div
+                                            className={
+                                                isMobile
+                                                    ? "grid min-w-0 gap-0.5"
+                                                    : "flex min-w-0 items-center gap-2"
+                                            }
+                                        >
+                                            <button
+                                                className={`block max-w-full truncate text-start text-sm sm:max-w-[300px] ${
+                                                    enableFilenameEdit
+                                                        ? "hover:text-sky-600 dark:hover:text-sky-400 cursor-text"
+                                                        : ""
+                                                }`}
+                                                onClick={(e) => {
+                                                    if (enableFilenameEdit) {
+                                                        handleStartEdit(
+                                                            file,
+                                                            e,
+                                                        );
+                                                    }
+                                                }}
+                                                title={filename}
+                                            >
+                                                {filename}
+                                            </button>
+                                            {renderFileStatus?.(file)}
+                                        </div>
+                                    )}
+                                </TableCell>
+                                {/* Type */}
+                                <TableCell className="hidden md:table-cell px-2 sm:px-3 py-1.5 w-24 text-xs text-gray-500 dark:text-gray-400">
+                                    {fileTypeLabel}
+                                </TableCell>
+                                {/* Size */}
+                                <TableCell className="hidden sm:table-cell px-2 sm:px-3 py-1.5 w-24 text-xs text-gray-500 dark:text-gray-400 tabular-nums">
+                                    {file.size
+                                        ? formatFileSize(file.size)
+                                        : "—"}
+                                </TableCell>
+                                {/* Date */}
+                                <TableCell className="w-20 px-1.5 py-1.5 text-xs tabular-nums text-gray-500 dark:text-gray-400 sm:px-3 md:w-32">
+                                    {formatFileListDate(fileDate)}
+                                </TableCell>
+                                {showActionsColumn && (
+                                    <TableCell className="w-10 px-0.5 py-1 sm:px-3">
+                                        <div className="flex items-center justify-end gap-1">
+                                            <button
+                                                onClick={(e) => {
+                                                    e.stopPropagation();
+                                                    onDelete(file);
+                                                }}
+                                                className="flex h-6 w-6 items-center justify-center rounded text-gray-400 opacity-0 transition-all hover:bg-gray-100 hover:text-red-600 focus:opacity-100 group-hover:opacity-100 dark:hover:bg-gray-700 dark:hover:text-red-400"
+                                                title={t("Delete file")}
+                                                aria-label={t("Delete file")}
+                                                type="button"
+                                            >
+                                                <Trash2 className="w-4 h-4" />
+                                            </button>
+                                        </div>
+                                    </TableCell>
+                                )}
+                            </TableRow>
+                        );
+                    })}
+                </TableBody>
+            </Table>
+        </div>
+    );
+}

--- a/src/components/common/UnifiedFileManager/FileGridView.js
+++ b/src/components/common/UnifiedFileManager/FileGridView.js
@@ -1,0 +1,414 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import {
+    Check,
+    MoreVertical,
+    Eye,
+    Download,
+    Pencil,
+    Trash2,
+    Play,
+} from "lucide-react";
+import {
+    getFilePreviewUrl,
+    getFileThumbnailUrl,
+    getFilename,
+    formatFileSize,
+} from "@/src/components/common/FileManager";
+import MediaThumbnail from "@/src/components/common/MediaThumbnail";
+import {
+    DropdownMenu,
+    DropdownMenuTrigger,
+    DropdownMenuContent,
+    DropdownMenuItem,
+} from "@/components/ui/dropdown-menu";
+import { AUDIO_EXTENSIONS, VIDEO_EXTENSIONS } from "@/src/utils/mediaUtils";
+
+const CARD_SELECT_DELAY_MS = 220;
+const UNAVAILABLE_PREVIEW_STATUSES = new Set([
+    "pending",
+    "processing",
+    "queued",
+    "failed",
+    "error",
+]);
+
+function hasExtension(filename, extensions) {
+    const extension = String(filename || "")
+        .split(".")
+        .pop()
+        ?.toLowerCase();
+
+    return extensions.some(
+        (supportedExtension) =>
+            supportedExtension.replace(/^\./, "").toLowerCase() === extension,
+    );
+}
+
+function hasUnavailablePreviewStatus(file) {
+    const status = String(file?._mediaItem?.status || file?.status || "")
+        .trim()
+        .toLowerCase();
+    return UNAVAILABLE_PREVIEW_STATUSES.has(status);
+}
+
+function isPlayableFile(file, filename) {
+    return Boolean(getPlayableFileKind(file, filename));
+}
+
+function getPlayableFileKind(file, filename) {
+    const mediaType = String(file?._mediaItem?.type || file?.type || "")
+        .trim()
+        .toLowerCase();
+    if (mediaType === "video" || mediaType === "audio") return mediaType;
+
+    const mimeType = String(file?.mimeType || file?.contentType || "")
+        .trim()
+        .toLowerCase();
+    if (mimeType.startsWith("video/")) return "video";
+    if (mimeType.startsWith("audio/")) return "audio";
+
+    if (hasExtension(filename, VIDEO_EXTENSIONS)) return "video";
+    if (hasExtension(filename, AUDIO_EXTENSIONS)) return "audio";
+
+    return null;
+}
+
+/**
+ * Thumbnail card for a single file in grid view.
+ */
+function FileGridCard({
+    file,
+    index,
+    isSelected,
+    onSelect,
+    files,
+    onPreview,
+    onDownload,
+    onRename,
+    onDelete,
+    enableFilenameEdit,
+    renderFileOverlay,
+    renderFileStatus,
+}) {
+    const { t } = useTranslation();
+    const url = getFilePreviewUrl(file);
+    const thumbnailUrl = getFileThumbnailUrl(file);
+    const filename = getFilename(file);
+    const playableKind = getPlayableFileKind(file, filename);
+    const [isPlayingInline, setIsPlayingInline] = useState(false);
+    const showPlayCue =
+        !isPlayingInline &&
+        Boolean(url) &&
+        !hasUnavailablePreviewStatus(file) &&
+        isPlayableFile(file, filename);
+    const [menuOpen, setMenuOpen] = useState(false);
+    const selectTimerRef = useRef(null);
+    const inlinePlayerRef = useRef(null);
+    const clearPendingSelect = () => {
+        if (selectTimerRef.current) {
+            window.clearTimeout(selectTimerRef.current);
+            selectTimerRef.current = null;
+        }
+    };
+    const stopCardSelection = (event) => {
+        event.stopPropagation();
+    };
+    const runMenuAction = (event, action) => {
+        event.stopPropagation();
+        action?.(file);
+    };
+    const handlePlayCueClick = (event) => {
+        event.stopPropagation();
+        setIsPlayingInline(true);
+    };
+    const handleCardClick = (event) => {
+        if (event.shiftKey) {
+            event.preventDefault();
+        }
+        const selectionEvent = {
+            shiftKey: event.shiftKey,
+            preventDefault: () => {},
+        };
+
+        clearPendingSelect();
+        selectTimerRef.current = window.setTimeout(() => {
+            selectTimerRef.current = null;
+            onSelect(file, files, index, selectionEvent);
+        }, CARD_SELECT_DELAY_MS);
+    };
+    const handleCardDoubleClick = (event) => {
+        event.stopPropagation();
+        clearPendingSelect();
+        onPreview?.(file);
+    };
+
+    useEffect(
+        () => () => {
+            if (selectTimerRef.current) {
+                window.clearTimeout(selectTimerRef.current);
+            }
+        },
+        [],
+    );
+
+    useEffect(() => {
+        setIsPlayingInline(false);
+    }, [filename, url]);
+
+    useEffect(() => {
+        if (!isPlayingInline) return undefined;
+
+        const handleOutsidePointerDown = (event) => {
+            if (inlinePlayerRef.current?.contains(event.target)) return;
+            setIsPlayingInline(false);
+        };
+
+        document.addEventListener("pointerdown", handleOutsidePointerDown);
+        return () => {
+            document.removeEventListener(
+                "pointerdown",
+                handleOutsidePointerDown,
+            );
+        };
+    }, [isPlayingInline]);
+
+    return (
+        <div
+            className={`relative group rounded-lg border transition-all cursor-pointer overflow-hidden select-none ${
+                isSelected
+                    ? "border-sky-500 dark:border-sky-400 ring-2 ring-sky-200 dark:ring-sky-800"
+                    : "border-gray-200 dark:border-gray-700 hover:border-gray-300 dark:hover:border-gray-600"
+            }`}
+            data-testid={`file-grid-card-${index}`}
+            onClick={handleCardClick}
+            onDoubleClick={handleCardDoubleClick}
+        >
+            <div className="w-full aspect-square bg-gray-50 dark:bg-gray-800 relative">
+                <MediaThumbnail
+                    src={url}
+                    filename={filename}
+                    mimeType={file?.mimeType || file?.contentType}
+                    mediaType={file?._mediaItem?.type || file?.type}
+                    mediaStatus={file?._mediaItem?.status || file?.status}
+                    mediaError={file?._mediaItem?.error || file?.error}
+                    thumbnailSrc={thumbnailUrl}
+                    className="w-full h-full"
+                    showVideoControls={false}
+                />
+                {isPlayingInline && playableKind && url && (
+                    <div
+                        ref={inlinePlayerRef}
+                        className="absolute inset-0 z-10 flex items-center justify-center bg-black"
+                        onClick={stopCardSelection}
+                        onDoubleClick={stopCardSelection}
+                        onPointerDown={stopCardSelection}
+                    >
+                        {playableKind === "video" ? (
+                            <video
+                                data-testid="media-inline-video-player"
+                                src={url}
+                                className="h-full w-full object-contain"
+                                controls
+                                autoPlay
+                                playsInline
+                            />
+                        ) : (
+                            <div className="flex h-full w-full items-center justify-center bg-gradient-to-br from-cyan-900 via-slate-900 to-fuchsia-950 p-3">
+                                <audio
+                                    data-testid="media-inline-audio-player"
+                                    src={url}
+                                    className="w-full"
+                                    controls
+                                    autoPlay
+                                />
+                            </div>
+                        )}
+                    </div>
+                )}
+                {showPlayCue && (
+                    <div
+                        className={`pointer-events-none absolute inset-0 flex items-center justify-center transition-opacity ${
+                            isSelected
+                                ? "opacity-60"
+                                : "opacity-80 group-hover:opacity-100"
+                        }`}
+                    >
+                        <button
+                            type="button"
+                            data-testid="media-play-cue"
+                            className="pointer-events-auto flex h-10 w-10 items-center justify-center rounded-full border border-white/60 bg-black/35 text-white shadow-sm backdrop-blur-[1px] transition-colors hover:bg-black/50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white dark:border-white/40 dark:bg-black/45 dark:hover:bg-black/60"
+                            aria-label={`${t("Play")} ${filename}`}
+                            onClick={handlePlayCueClick}
+                            onDoubleClick={stopCardSelection}
+                            onPointerDown={stopCardSelection}
+                        >
+                            <Play className="ms-0.5 h-5 w-5 fill-white" />
+                        </button>
+                    </div>
+                )}
+                {renderFileOverlay?.(file)}
+
+                {/* Selection checkbox overlay */}
+                <div
+                    className={`absolute start-2 top-2 ${isSelected || "opacity-0 group-hover:opacity-100"} transition-opacity`}
+                >
+                    <button
+                        onClick={(e) => {
+                            e.stopPropagation();
+                            onSelect(file, files, index, e);
+                        }}
+                        className={`flex items-center justify-center w-5 h-5 rounded border-2 transition-colors ${
+                            isSelected
+                                ? "bg-sky-600 border-sky-600 dark:bg-sky-500 dark:border-sky-500"
+                                : "bg-white/80 dark:bg-gray-900/80 border-gray-300 dark:border-gray-500 hover:border-sky-500"
+                        }`}
+                    >
+                        {isSelected && <Check className="w-3 h-3 text-white" />}
+                    </button>
+                </div>
+
+                {/* Context menu overlay */}
+                <div
+                    className="absolute end-2 top-2 opacity-0 transition-opacity group-hover:opacity-100"
+                    onClick={stopCardSelection}
+                    onDoubleClick={stopCardSelection}
+                    onPointerDown={stopCardSelection}
+                >
+                    <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>
+                        <DropdownMenuTrigger asChild>
+                            <button
+                                onClick={stopCardSelection}
+                                onPointerDown={stopCardSelection}
+                                className="flex items-center justify-center w-6 h-6 rounded bg-white/80 dark:bg-gray-900/80 hover:bg-white dark:hover:bg-gray-800 border border-gray-200 dark:border-gray-600 transition-colors"
+                            >
+                                <MoreVertical className="w-3.5 h-3.5 text-gray-500" />
+                            </button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent
+                            align="end"
+                            sideOffset={4}
+                            onClick={stopCardSelection}
+                            onPointerDown={stopCardSelection}
+                        >
+                            {onPreview && (
+                                <DropdownMenuItem
+                                    onSelect={(event) =>
+                                        runMenuAction(event, onPreview)
+                                    }
+                                >
+                                    <Eye className="w-4 h-4 me-2" />
+                                    {t("Preview")}
+                                </DropdownMenuItem>
+                            )}
+                            {onDownload && (
+                                <DropdownMenuItem
+                                    onSelect={(event) =>
+                                        runMenuAction(event, onDownload)
+                                    }
+                                >
+                                    <Download className="w-4 h-4 me-2" />
+                                    {t("Download")}
+                                </DropdownMenuItem>
+                            )}
+                            {enableFilenameEdit && onRename && (
+                                <DropdownMenuItem
+                                    onSelect={(event) =>
+                                        runMenuAction(event, onRename)
+                                    }
+                                >
+                                    <Pencil className="w-4 h-4 me-2" />
+                                    {t("Rename")}
+                                </DropdownMenuItem>
+                            )}
+                            {onDelete && (
+                                <DropdownMenuItem
+                                    onSelect={(event) =>
+                                        runMenuAction(event, onDelete)
+                                    }
+                                    className="text-red-600 dark:text-red-400 focus:text-red-600 dark:focus:text-red-400"
+                                >
+                                    <Trash2 className="w-4 h-4 me-2" />
+                                    {t("Delete")}
+                                </DropdownMenuItem>
+                            )}
+                        </DropdownMenuContent>
+                    </DropdownMenu>
+                </div>
+            </div>
+
+            {/* File info */}
+            <div className="px-2 py-1.5 min-w-0">
+                <p
+                    className="text-xs font-medium text-gray-700 dark:text-gray-300 truncate"
+                    title={filename}
+                >
+                    {filename}
+                </p>
+                {renderFileStatus?.(file)}
+                <p className="text-[10px] text-gray-400 tabular-nums">
+                    {file.size ? formatFileSize(file.size) : ""}
+                </p>
+            </div>
+        </div>
+    );
+}
+
+/**
+ * FileGridView - grid/thumbnail view of files.
+ *
+ * @param {Object} props
+ * @param {Array} props.files - Files to display
+ * @param {Set} props.selectedIds - Currently selected file IDs
+ * @param {Function} props.getFileId - Get stable ID for a file
+ * @param {Function} props.onSelectFile - (file, orderedFiles, index, event) selection handler
+ * @param {Function} props.onPreview - Open file preview
+ * @param {Function} props.onDownload - Download a single file
+ * @param {Function} props.onRename - Start rename on a file
+ * @param {Function} props.onDelete - Request delete of a file
+ * @param {boolean} props.enableFilenameEdit - Enable rename action
+ */
+export default function FileGridView({
+    files = [],
+    selectedIds = new Set(),
+    getFileId,
+    onSelectFile,
+    onPreview,
+    onDownload,
+    onRename,
+    onDelete,
+    enableFilenameEdit = true,
+    renderFileOverlay,
+    renderFileStatus,
+}) {
+    if (files.length === 0) return null;
+
+    return (
+        <div className="min-h-0 flex-1 overflow-auto overscroll-contain min-w-0 p-3">
+            <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-3">
+                {files.map((file, index) => {
+                    const fileId = getFileId(file);
+                    return (
+                        <FileGridCard
+                            key={fileId}
+                            file={file}
+                            files={files}
+                            index={index}
+                            isSelected={selectedIds.has(fileId)}
+                            onSelect={onSelectFile}
+                            onPreview={onPreview}
+                            onDownload={onDownload}
+                            onRename={onRename}
+                            onDelete={onDelete}
+                            enableFilenameEdit={enableFilenameEdit}
+                            renderFileOverlay={renderFileOverlay}
+                            renderFileStatus={renderFileStatus}
+                        />
+                    );
+                })}
+            </div>
+        </div>
+    );
+}

--- a/src/components/common/UnifiedFileManager/FileStatusBar.js
+++ b/src/components/common/UnifiedFileManager/FileStatusBar.js
@@ -1,0 +1,50 @@
+"use client";
+
+import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import { formatFileSize } from "@/src/components/common/FileManager";
+
+/**
+ * FileStatusBar - displays file count, selection info, and total size.
+ *
+ * @param {Object} props
+ * @param {number} props.fileCount - Number of files in current view
+ * @param {number} props.totalFileCount - Total number of files across all folders
+ * @param {number} props.selectedCount - Number of selected files
+ * @param {Array} props.files - Files in current view (for computing total size)
+ * @param {string} props.selectedPath - Currently selected folder path
+ */
+export default function FileStatusBar({
+    fileCount = 0,
+    totalFileCount = 0,
+    selectedCount = 0,
+    files = [],
+    selectedPath = "",
+}) {
+    const { t } = useTranslation();
+
+    const totalSize = useMemo(() => {
+        return files.reduce((sum, f) => sum + (f?.size || 0), 0);
+    }, [files]);
+
+    return (
+        <div className="flex items-center gap-4 px-3 py-1 border-t border-gray-200 dark:border-gray-700 bg-gray-50/50 dark:bg-gray-900/50 text-[11px] text-gray-500 dark:text-gray-400 flex-shrink-0">
+            <span>
+                {fileCount} {fileCount === 1 ? t("file") : t("files")}
+                {selectedPath !== "" &&
+                    totalFileCount !== fileCount &&
+                    ` (${totalFileCount} ${t("total")})`}
+            </span>
+            {selectedCount > 0 && (
+                <span className="text-sky-600 dark:text-sky-400">
+                    {selectedCount} {t("selected")}
+                </span>
+            )}
+            {totalSize > 0 && (
+                <span className="ms-auto tabular-nums">
+                    {formatFileSize(totalSize)}
+                </span>
+            )}
+        </div>
+    );
+}

--- a/src/components/common/UnifiedFileManager/FileToolbar.js
+++ b/src/components/common/UnifiedFileManager/FileToolbar.js
@@ -1,0 +1,288 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import {
+    ChevronRight,
+    ChevronDown,
+    ChevronUp,
+    Folder,
+    List,
+    LayoutGrid,
+    Upload,
+    RefreshCw,
+    Search,
+} from "lucide-react";
+import FilterInput from "@/src/components/common/FilterInput";
+
+/**
+ * Get a human-readable breadcrumb label for a path segment.
+ */
+function getBreadcrumbLabel(segment, chatTitleMap, t) {
+    if (segment === "All Files") return t("All Files");
+    if (segment === "global") return t("Global Files");
+    if (segment === "chats") return t("Chat Files");
+    if (segment === "workspaces") return t("Workspaces");
+    if (chatTitleMap && chatTitleMap[segment]) {
+        return chatTitleMap[segment];
+    }
+    return segment;
+}
+
+/**
+ * FileToolbar - breadcrumb navigation, search, view toggle, upload, refresh.
+ *
+ * @param {Object} props
+ * @param {Array} props.breadcrumbs - Array of { label, path } from useFolderNavigation
+ * @param {Function} props.onNavigate - Navigate to a breadcrumb path
+ * @param {string} props.filterText - Current filter text
+ * @param {Function} props.onFilterChange - Set filter text
+ * @param {string} props.viewMode - "list" or "grid"
+ * @param {Function} props.onViewModeChange - Set view mode
+ * @param {Function} props.onUploadClick - Open upload dialog
+ * @param {Function} props.onRefresh - Reload files
+ * @param {Object} props.chatTitleMap - Map of chatId -> title
+ * @param {boolean} props.isMobile - Whether to use the mobile toolbar layout
+ * @param {boolean} props.showMobileFolders - Whether the mobile folder panel is open
+ * @param {Function} props.onToggleMobileFolders - Toggle the mobile folder panel
+ */
+export default function FileToolbar({
+    breadcrumbs = [],
+    onNavigate,
+    filterText = "",
+    onFilterChange,
+    viewMode = "list",
+    onViewModeChange,
+    onUploadClick,
+    onRefresh,
+    chatTitleMap = {},
+    isMobile = false,
+    showMobileFolders = false,
+    onToggleMobileFolders,
+}) {
+    const { t } = useTranslation();
+    const [isMobileFilterOpen, setIsMobileFilterOpen] = useState(false);
+    const [isRefreshing, setIsRefreshing] = useState(false);
+    const refreshTimerRef = useRef(null);
+    const currentCrumb = breadcrumbs[breadcrumbs.length - 1];
+    const currentLabel = currentCrumb
+        ? getBreadcrumbLabel(currentCrumb.label, chatTitleMap, t)
+        : t("All Files");
+    const getCrumbLabel = (crumb) =>
+        getBreadcrumbLabel(crumb.label, chatTitleMap, t);
+
+    useEffect(() => {
+        return () => {
+            if (refreshTimerRef.current) {
+                window.clearTimeout(refreshTimerRef.current);
+            }
+        };
+    }, []);
+
+    const handleRefreshClick = async () => {
+        if (!onRefresh || isRefreshing) return;
+
+        setIsRefreshing(true);
+        const startedAt = Date.now();
+        try {
+            await onRefresh();
+        } finally {
+            const elapsed = Date.now() - startedAt;
+            if (refreshTimerRef.current) {
+                window.clearTimeout(refreshTimerRef.current);
+            }
+            refreshTimerRef.current = window.setTimeout(
+                () => setIsRefreshing(false),
+                Math.max(0, 450 - elapsed),
+            );
+        }
+    };
+
+    if (isMobile) {
+        const showMobileFilter = isMobileFilterOpen || Boolean(filterText);
+
+        return (
+            <div className="flex flex-col gap-2 border-b border-gray-200 bg-gray-50/50 px-2.5 py-2.5 dark:border-gray-700 dark:bg-gray-900/50">
+                <div className="flex items-center gap-2 min-w-0">
+                    <button
+                        type="button"
+                        onClick={onToggleMobileFolders}
+                        className="flex h-10 min-w-0 flex-1 items-center gap-2 rounded-md border border-gray-200 bg-white px-3 text-sm text-gray-700 transition-colors hover:bg-gray-100 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
+                    >
+                        <Folder className="h-4 w-4 flex-shrink-0 text-gray-500 dark:text-gray-400" />
+                        <span className="min-w-0 truncate font-medium">
+                            {currentLabel}
+                        </span>
+                        {showMobileFolders ? (
+                            <ChevronUp className="h-4 w-4 flex-shrink-0 text-gray-400" />
+                        ) : (
+                            <ChevronDown className="h-4 w-4 flex-shrink-0 text-gray-400" />
+                        )}
+                    </button>
+
+                    <button
+                        onClick={() => setIsMobileFilterOpen((open) => !open)}
+                        className={`flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-md border transition-colors ${
+                            showMobileFilter
+                                ? "border-sky-200 bg-sky-50 text-sky-700 hover:bg-sky-100 dark:border-sky-800 dark:bg-sky-950/40 dark:text-sky-300 dark:hover:bg-sky-900/50"
+                                : "border-gray-200 bg-white text-gray-500 hover:bg-gray-100 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-400 dark:hover:bg-gray-700"
+                        }`}
+                        title={t("Search")}
+                        aria-label={t("Search")}
+                        aria-pressed={showMobileFilter}
+                        type="button"
+                    >
+                        <Search className="h-4 w-4" />
+                    </button>
+
+                    {onUploadClick && (
+                        <button
+                            onClick={onUploadClick}
+                            className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-md border border-gray-200 bg-white transition-colors hover:bg-gray-100 dark:border-gray-700 dark:bg-gray-800 dark:hover:bg-gray-700"
+                            title={t("Upload")}
+                            aria-label={t("Upload")}
+                            type="button"
+                        >
+                            <Upload className="w-4 h-4 text-gray-500" />
+                        </button>
+                    )}
+
+                    {onRefresh && (
+                        <button
+                            onClick={handleRefreshClick}
+                            className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-md border border-gray-200 bg-white transition-colors hover:bg-gray-100 dark:border-gray-700 dark:bg-gray-800 dark:hover:bg-gray-700"
+                            title={t("Refresh")}
+                            aria-label={t("Refresh")}
+                            aria-busy={isRefreshing}
+                            disabled={isRefreshing}
+                            type="button"
+                        >
+                            <RefreshCw
+                                className={`h-4 w-4 text-gray-500 ${
+                                    isRefreshing ? "animate-spin" : ""
+                                }`}
+                            />
+                        </button>
+                    )}
+                </div>
+
+                {showMobileFilter && (
+                    <FilterInput
+                        value={filterText}
+                        onChange={onFilterChange}
+                        onClear={() => {
+                            onFilterChange("");
+                            setIsMobileFilterOpen(false);
+                        }}
+                        placeholder={t("Filter files...")}
+                        className="h-10 text-sm"
+                        autoFocus
+                    />
+                )}
+            </div>
+        );
+    }
+
+    return (
+        <div className="flex items-center gap-2 px-3 py-2 border-b border-gray-200 dark:border-gray-700 bg-gray-50/50 dark:bg-gray-900/50 min-w-0 flex-shrink-0">
+            {/* Breadcrumb */}
+            <nav className="flex items-center gap-0.5 min-w-0 flex-shrink overflow-hidden text-sm">
+                {breadcrumbs.map((crumb, idx) => (
+                    <span
+                        key={crumb.path}
+                        className="flex items-center gap-0.5 min-w-0"
+                    >
+                        {idx > 0 && (
+                            <ChevronRight className="w-3 h-3 text-gray-400 flex-shrink-0" />
+                        )}
+                        {idx < breadcrumbs.length - 1 ? (
+                            <button
+                                onClick={() => onNavigate(crumb.path)}
+                                className="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 truncate max-w-[120px] transition-colors"
+                                title={getCrumbLabel(crumb)}
+                            >
+                                {getCrumbLabel(crumb)}
+                            </button>
+                        ) : (
+                            <span
+                                className="text-gray-700 dark:text-gray-200 font-medium truncate max-w-[160px]"
+                                title={getCrumbLabel(crumb)}
+                            >
+                                {getCrumbLabel(crumb)}
+                            </span>
+                        )}
+                    </span>
+                ))}
+            </nav>
+
+            {/* Spacer */}
+            <div className="flex-1 min-w-0" />
+
+            {/* Search */}
+            <div className="w-56 lg:w-72 flex-shrink-0">
+                <FilterInput
+                    value={filterText}
+                    onChange={onFilterChange}
+                    onClear={() => onFilterChange("")}
+                    placeholder={t("Filter files...")}
+                    className="h-10 text-base"
+                />
+            </div>
+
+            {/* View toggle */}
+            <div className="flex h-10 items-center border border-gray-200 dark:border-gray-700 rounded-md overflow-hidden flex-shrink-0">
+                <button
+                    onClick={() => onViewModeChange("list")}
+                    className={`flex h-full w-9 items-center justify-center transition-colors ${
+                        viewMode === "list"
+                            ? "bg-gray-100 dark:bg-gray-700 text-gray-900 dark:text-gray-100"
+                            : "text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800"
+                    }`}
+                    title={t("List view")}
+                >
+                    <List className="w-3.5 h-3.5" />
+                </button>
+                <button
+                    onClick={() => onViewModeChange("grid")}
+                    className={`flex h-full w-9 items-center justify-center transition-colors ${
+                        viewMode === "grid"
+                            ? "bg-gray-100 dark:bg-gray-700 text-gray-900 dark:text-gray-100"
+                            : "text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800"
+                    }`}
+                    title={t("Grid view")}
+                >
+                    <LayoutGrid className="w-3.5 h-3.5" />
+                </button>
+            </div>
+
+            {/* Upload */}
+            {onUploadClick && (
+                <button
+                    onClick={onUploadClick}
+                    className="flex h-10 w-10 items-center justify-center rounded transition-colors flex-shrink-0 hover:bg-gray-100 dark:hover:bg-gray-800"
+                    title={t("Upload")}
+                >
+                    <Upload className="w-4 h-4 text-gray-500" />
+                </button>
+            )}
+
+            {/* Refresh */}
+            {onRefresh && (
+                <button
+                    onClick={handleRefreshClick}
+                    className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded transition-colors hover:bg-gray-100 disabled:cursor-default dark:hover:bg-gray-800"
+                    title={t("Refresh")}
+                    aria-label={t("Refresh")}
+                    aria-busy={isRefreshing}
+                    disabled={isRefreshing}
+                >
+                    <RefreshCw
+                        className={`h-4 w-4 text-gray-500 ${
+                            isRefreshing ? "animate-spin" : ""
+                        }`}
+                    />
+                </button>
+            )}
+        </div>
+    );
+}

--- a/src/components/common/UnifiedFileManager/SidebarFolderTree.js
+++ b/src/components/common/UnifiedFileManager/SidebarFolderTree.js
@@ -1,0 +1,239 @@
+"use client";
+
+import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import {
+    ChevronRight,
+    ChevronDown,
+    Folder,
+    FolderOpen,
+    Globe,
+    MessageSquare,
+    FolderRoot,
+} from "lucide-react";
+import { countFiles } from "./useUnifiedFileData";
+
+/**
+ * Get a human-readable label for a folder segment.
+ */
+function getFolderLabel(segment, chatTitleMap, t) {
+    if (segment === "global") return t("Global Files");
+    if (segment === "chats") return t("Chat Files");
+    if (segment === "workspaces") return t("Workspaces");
+    if (chatTitleMap && chatTitleMap[segment]) {
+        return chatTitleMap[segment];
+    }
+    return segment;
+}
+
+/**
+ * Get the icon for a folder segment.
+ */
+function getFolderIcon(segment, isOpen) {
+    if (segment === "global")
+        return <Globe className="w-4 h-4 text-blue-500 flex-shrink-0" />;
+    if (segment === "chats")
+        return (
+            <MessageSquare className="w-4 h-4 text-green-500 flex-shrink-0" />
+        );
+    if (isOpen)
+        return <FolderOpen className="w-4 h-4 text-yellow-500 flex-shrink-0" />;
+    return <Folder className="w-4 h-4 text-yellow-500 flex-shrink-0" />;
+}
+
+/**
+ * Single folder node in the sidebar tree.
+ */
+function SidebarFolderNode({
+    segment,
+    node,
+    depth,
+    chatTitleMap,
+    isExpanded,
+    isSelected,
+    onToggleExpand,
+    onSelect,
+    expandedPaths,
+    selectedPath,
+}) {
+    const { t } = useTranslation();
+    const childFolders = useMemo(
+        () => Object.keys(node.children).sort(),
+        [node.children],
+    );
+    const hasChildren = childFolders.length > 0;
+    const expanded = isExpanded(node.path);
+    const selected = isSelected(node.path);
+    const fileCount = countFiles(node);
+    const label = getFolderLabel(segment, chatTitleMap, t);
+
+    return (
+        <div>
+            <button
+                onClick={(e) => {
+                    e.stopPropagation();
+                    onSelect(node.path);
+                    if (hasChildren && !expanded) {
+                        onToggleExpand(node.path);
+                    }
+                }}
+                className={`w-full flex items-center gap-1.5 py-1.5 px-2 rounded text-sm transition-colors min-w-0 overflow-hidden ${
+                    selected
+                        ? "bg-sky-100 dark:bg-sky-900/30 text-sky-700 dark:text-sky-300"
+                        : "hover:bg-gray-50 dark:hover:bg-gray-800 text-gray-700 dark:text-gray-300"
+                }`}
+                style={{ paddingInlineStart: `${depth * 14 + 8}px` }}
+            >
+                {hasChildren ? (
+                    <span
+                        onClick={(e) => {
+                            e.stopPropagation();
+                            onToggleExpand(node.path);
+                        }}
+                        className="flex-shrink-0 p-0.5 -m-0.5 hover:bg-gray-200 dark:hover:bg-gray-700 rounded"
+                    >
+                        {expanded ? (
+                            <ChevronDown className="w-3 h-3 text-gray-400" />
+                        ) : (
+                            <ChevronRight className="w-3 h-3 text-gray-400" />
+                        )}
+                    </span>
+                ) : (
+                    <span className="w-3 flex-shrink-0" />
+                )}
+                {getFolderIcon(segment, expanded)}
+                <span className="truncate font-medium" title={label}>
+                    {label}
+                </span>
+                <span className="text-[10px] text-gray-400 ms-auto flex-shrink-0 tabular-nums">
+                    {fileCount}
+                </span>
+            </button>
+
+            {expanded && hasChildren && (
+                <div>
+                    {childFolders.map((childKey) => (
+                        <SidebarFolderNode
+                            key={childKey}
+                            segment={childKey}
+                            node={node.children[childKey]}
+                            depth={depth + 1}
+                            chatTitleMap={chatTitleMap}
+                            isExpanded={isExpanded}
+                            isSelected={isSelected}
+                            onToggleExpand={onToggleExpand}
+                            onSelect={onSelect}
+                            expandedPaths={expandedPaths}
+                            selectedPath={selectedPath}
+                        />
+                    ))}
+                </div>
+            )}
+        </div>
+    );
+}
+
+/**
+ * SidebarFolderTree - folder navigation sidebar for the unified file manager.
+ *
+ * @param {Object} props
+ * @param {Object} props.tree - Folder tree from useUnifiedFileData
+ * @param {Object} props.chatTitleMap - Map of chatId -> chat title
+ * @param {number} props.totalFileCount - Total number of files
+ * @param {Function} props.isExpanded - Check if path is expanded
+ * @param {Function} props.isSelected - Check if path is selected
+ * @param {Function} props.onToggleExpand - Toggle expand on a path
+ * @param {Function} props.onSelect - Select a folder path
+ * @param {Set} props.expandedPaths - Set of expanded paths
+ * @param {string} props.selectedPath - Currently selected path
+ * @param {string|undefined} props.rootFolderLabel - Optional label for the real root folder
+ * @param {string} props.allFilesPath - Path token for recursive All Files
+ */
+export default function SidebarFolderTree({
+    tree,
+    chatTitleMap = {},
+    totalFileCount = 0,
+    isExpanded,
+    isSelected,
+    onToggleExpand,
+    onSelect,
+    expandedPaths,
+    selectedPath,
+    rootFolderLabel,
+    allFilesPath = "",
+}) {
+    const { t } = useTranslation();
+    const topFolders = useMemo(
+        () => Object.keys(tree.children).sort(),
+        [tree.children],
+    );
+    const rootSelected = isSelected("");
+    const allFilesSelected = isSelected(allFilesPath);
+    const rootFileCount = tree.files?.length || 0;
+    const allFilesLabel = t("All Files");
+
+    return (
+        <div className="flex flex-col overflow-y-auto overflow-x-hidden py-1 min-w-0">
+            {rootFolderLabel && (
+                <button
+                    onClick={() => onSelect("")}
+                    className={`w-full flex items-center gap-1.5 py-1.5 px-2 rounded text-sm transition-colors min-w-0 overflow-hidden ${
+                        rootSelected
+                            ? "bg-sky-100 dark:bg-sky-900/30 text-sky-700 dark:text-sky-300"
+                            : "hover:bg-gray-50 dark:hover:bg-gray-800 text-gray-700 dark:text-gray-300"
+                    }`}
+                    style={{ paddingInlineStart: "8px" }}
+                >
+                    <span className="w-3 flex-shrink-0" />
+                    <FolderRoot className="w-4 h-4 text-gray-500 flex-shrink-0" />
+                    <span
+                        className="truncate font-medium"
+                        title={rootFolderLabel}
+                    >
+                        {rootFolderLabel}
+                    </span>
+                    <span className="text-[10px] text-gray-400 ms-auto flex-shrink-0 tabular-nums">
+                        {rootFileCount}
+                    </span>
+                </button>
+            )}
+
+            {/* "All Files" recursive entry */}
+            <button
+                onClick={() => onSelect(allFilesPath)}
+                className={`w-full flex items-center gap-1.5 py-1.5 px-2 rounded text-sm transition-colors min-w-0 overflow-hidden ${
+                    allFilesSelected
+                        ? "bg-sky-100 dark:bg-sky-900/30 text-sky-700 dark:text-sky-300"
+                        : "hover:bg-gray-50 dark:hover:bg-gray-800 text-gray-700 dark:text-gray-300"
+                }`}
+                style={{ paddingInlineStart: rootFolderLabel ? "22px" : "8px" }}
+            >
+                <span className="w-3 flex-shrink-0" />
+                <FolderRoot className="w-4 h-4 text-gray-500 flex-shrink-0" />
+                <span className="truncate font-medium" title={allFilesLabel}>
+                    {allFilesLabel}
+                </span>
+                <span className="text-[10px] text-gray-400 ms-auto flex-shrink-0 tabular-nums">
+                    {totalFileCount}
+                </span>
+            </button>
+
+            {/* Top-level folders */}
+            {topFolders.map((folderKey) => (
+                <SidebarFolderNode
+                    key={folderKey}
+                    segment={folderKey}
+                    node={tree.children[folderKey]}
+                    depth={1}
+                    chatTitleMap={chatTitleMap}
+                    isExpanded={isExpanded}
+                    isSelected={isSelected}
+                    onToggleExpand={onToggleExpand}
+                    onSelect={onSelect}
+                    expandedPaths={expandedPaths}
+                    selectedPath={selectedPath}
+                />
+            ))}
+        </div>
+    );
+}

--- a/src/components/common/UnifiedFileManager/UnifiedFileManager.js
+++ b/src/components/common/UnifiedFileManager/UnifiedFileManager.js
@@ -1,0 +1,1329 @@
+"use client";
+
+import { useState, useCallback, useMemo, useEffect, useRef } from "react";
+import { useTranslation } from "react-i18next";
+import { toast } from "react-toastify";
+import { ArrowUp, Folder, FolderPlus } from "lucide-react";
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+    AlertDialog,
+    AlertDialogContent,
+    AlertDialogHeader,
+    AlertDialogTitle,
+    AlertDialogDescription,
+    AlertDialogFooter,
+    AlertDialogAction,
+    AlertDialogCancel,
+} from "@/components/ui/alert-dialog";
+import { Spinner } from "@/components/ui/spinner";
+import {
+    getFileUrl,
+    getFilename,
+    getFileDate,
+    createFileId,
+    FilePreviewDialog,
+} from "@/src/components/common/FileManager";
+import { getDownloadUrl } from "@/src/utils/fileDownloadUtils";
+import { useItemSelection } from "@/src/components/images/hooks/useItemSelection";
+import BulkActionsBar from "@/src/components/common/BulkActionsBar";
+import EmptyState from "@/src/components/common/EmptyState";
+
+import { useUnifiedFileData, collectAllFiles } from "./useUnifiedFileData";
+import { useFolderNavigation } from "./useFolderNavigation";
+import SidebarFolderTree from "./SidebarFolderTree";
+import FileContentArea from "./FileContentArea";
+import FileGridView from "./FileGridView";
+import FileToolbar from "./FileToolbar";
+import FileStatusBar from "./FileStatusBar";
+
+const SIDEBAR_MIN = 150;
+const SIDEBAR_MAX = 350;
+const SIDEBAR_DEFAULT = 220;
+const VIEW_MODE_KEY = "unified-file-manager-view-mode";
+const MOBILE_BREAKPOINT = 768;
+const ALL_FILES_PATH = "__all_files__";
+const PROCESSING_PREVIEW_STATUSES = new Set([
+    "pending",
+    "processing",
+    "queued",
+]);
+const INVALID_FOLDER_SEGMENT_CHARS = new Set([
+    "<",
+    ">",
+    ":",
+    '"',
+    "|",
+    "?",
+    "*",
+]);
+
+function isProcessingPreviewFile(file) {
+    const status = String(file?._mediaItem?.status || file?.status || "")
+        .trim()
+        .toLowerCase();
+    return PROCESSING_PREVIEW_STATUSES.has(status);
+}
+
+function hasInvalidFolderSegmentChars(segment) {
+    return Array.from(segment).some(
+        (character) =>
+            INVALID_FOLDER_SEGMENT_CHARS.has(character) ||
+            character.charCodeAt(0) < 32,
+    );
+}
+
+function normalizeFolderPath(value) {
+    return String(value || "")
+        .trim()
+        .replace(/\\/g, "/")
+        .replace(/^\/+|\/+$/g, "")
+        .replace(/\/+/g, "/");
+}
+
+function getFolderPathWithinBase(path, basePath) {
+    const normalizedPath = normalizeFolderPath(path);
+    const normalizedBase = normalizeFolderPath(basePath);
+    if (!normalizedBase) return normalizedPath;
+    if (normalizedPath === normalizedBase) return "";
+    if (normalizedPath.startsWith(`${normalizedBase}/`)) {
+        return normalizedPath.slice(normalizedBase.length + 1);
+    }
+    return null;
+}
+
+function getMoveOptionPath(path, basePath) {
+    const relativePath = getFolderPathWithinBase(path, basePath);
+    return relativePath ?? normalizeFolderPath(path);
+}
+
+function joinFolderPath(basePath, path) {
+    const normalizedBase = normalizeFolderPath(basePath);
+    const normalizedPath = normalizeFolderPath(path);
+    if (!normalizedBase) return normalizedPath;
+    return normalizedPath
+        ? `${normalizedBase}/${normalizedPath}`
+        : normalizedBase;
+}
+
+function getParentFolderPath(path) {
+    const normalizedPath = normalizeFolderPath(path);
+    if (!normalizedPath) return "";
+    const parts = normalizedPath.split("/").filter(Boolean);
+    parts.pop();
+    return parts.join("/");
+}
+
+function getLeafFilename(file) {
+    const source =
+        file?.filename ||
+        file?.displayFilename ||
+        file?.displayName ||
+        file?.blobPath ||
+        file?.name ||
+        "";
+    return String(source).split("/").filter(Boolean).pop() || "";
+}
+
+function collectFolderPaths(node) {
+    if (!node?.children) return [];
+
+    const paths = [];
+    const walk = (current) => {
+        for (const child of Object.values(current.children || {})) {
+            if (child?.path) {
+                paths.push(child.path);
+            }
+            walk(child);
+        }
+    };
+
+    walk(node);
+    return paths.sort((a, b) => a.localeCompare(b));
+}
+
+function getChildFolderPaths(folderPaths, parentPath) {
+    const normalizedParent = normalizeFolderPath(parentPath);
+    const parentDepth = normalizedParent
+        ? normalizedParent.split("/").filter(Boolean).length
+        : 0;
+    const prefix = normalizedParent ? `${normalizedParent}/` : "";
+
+    return folderPaths
+        .filter((path) => {
+            const normalizedPath = normalizeFolderPath(path);
+            if (!normalizedPath) return false;
+            if (normalizedParent && !normalizedPath.startsWith(prefix)) {
+                return false;
+            }
+            if (!normalizedParent && normalizedPath.includes("/")) {
+                return false;
+            }
+            const depth = normalizedPath.split("/").filter(Boolean).length;
+            return depth === parentDepth + 1;
+        })
+        .sort((a, b) => a.localeCompare(b));
+}
+
+function getFolderDisplayName(path, rootLabel) {
+    const normalizedPath = normalizeFolderPath(path);
+    if (!normalizedPath) return rootLabel || "Files";
+    return normalizedPath.split("/").filter(Boolean).pop() || normalizedPath;
+}
+
+function getFolderDisplayPath(path, rootLabel) {
+    const normalizedPath = normalizeFolderPath(path);
+    const root = rootLabel || "Files";
+    return normalizedPath ? `${root}/${normalizedPath}` : root;
+}
+
+function sortFilesByMostRecent(files) {
+    return [...files].sort((a, b) => {
+        const dateA = getFileDate(a);
+        const dateB = getFileDate(b);
+        if (dateA && dateB) {
+            const comparison = dateB.getTime() - dateA.getTime();
+            if (comparison !== 0) return comparison;
+        } else if (dateA) {
+            return -1;
+        } else if (dateB) {
+            return 1;
+        }
+        return getFilename(a).localeCompare(getFilename(b));
+    });
+}
+
+async function reloadFilesAfterMoveError(reloadFiles) {
+    try {
+        await reloadFiles?.();
+    } catch (error) {
+        console.error("Failed to refresh files after move error:", error);
+    }
+}
+
+function getSearchableFileText(file) {
+    return [
+        getFilename(file),
+        file?.displayFilename,
+        file?.displayName,
+        file?.filename,
+        file?.prompt,
+        file?._mediaItem?.prompt,
+        ...(Array.isArray(file?.tags) ? file.tags : []),
+        ...(Array.isArray(file?._mediaItem?.tags) ? file._mediaItem.tags : []),
+    ]
+        .filter(Boolean)
+        .join(" ")
+        .toLowerCase();
+}
+
+/**
+ * UnifiedFileManager - Mac Finder-style file manager with sidebar folder tree
+ * and main content area showing files in list or grid view.
+ *
+ * @param {Object} props
+ * @param {string} props.contextId - User context ID
+ * @param {string|null} props.chatId - Optional chat ID for auto-navigation
+ * @param {Array} props.legacyMessages - Chat messages to mine for legacy file references
+ * @param {Object} props.chatTitleMap - Map of chatId -> title
+ * @param {Function} props.onDelete - Delete files callback
+ * @param {Function} props.onDownload - Download files callback
+ * @param {Function} props.onMove - Move files callback (files, targetFolder)
+ * @param {Function} props.onUpdateMetadata - Update file metadata callback (rename)
+ * @param {Function} props.onUploadClick - Open upload dialog
+ * @param {Function} props.onAttach - When provided, adds an "Attach" bulk action that calls
+ *   onAttach(selectedObjects). Used by the chat composer's file collection picker.
+ * @param {string} props.attachLabel - Label for the attach action (default "Attach")
+ * @param {Function} props.getBulkActionVisibility - Optional callback that returns
+ *   per-action visibility for the current selection, e.g. { attach: false }.
+ * @param {string|undefined} props.defaultSelectedPath - Initial folder path; "" selects All Files
+ * @param {string|undefined} props.rootFolderLabel - Optional label for the real root folder
+ * @param {string|undefined} props.moveTargetBasePath - Optional base folder for relative move targets
+ * @param {Function} props.onFolderChange - Called when the selected folder changes
+ * @param {"list"|"grid"} props.defaultViewMode - Initial view mode when no saved preference exists
+ * @param {boolean} props.isDownloading - Whether download is in progress
+ * @param {string} props.containerHeight - CSS height for the container
+ * @param {Function|null} props.filterFile - Optional predicate for hiding implementation files
+ */
+export default function UnifiedFileManager({
+    contextId,
+    chatId = null,
+    legacyMessages = [],
+    chatTitleMap = {},
+    onDelete,
+    onDownload,
+    onMove,
+    onUpdateMetadata,
+    onUploadClick,
+    onAttach,
+    attachLabel,
+    getBulkActionVisibility,
+    extraBulkActions,
+    onSelectionChange,
+    renderPreviewDialog,
+    renderFileOverlay,
+    renderFileStatus,
+    augmentedFiles = [],
+    storageTarget = null,
+    defaultSelectedPath,
+    rootFolderLabel,
+    moveTargetBasePath,
+    onFolderChange,
+    defaultViewMode = "list",
+    isDownloading = false,
+    containerHeight = "60vh",
+    filterFile = null,
+}) {
+    const { t } = useTranslation();
+    const direction =
+        typeof document !== "undefined"
+            ? document.documentElement.dir || "ltr"
+            : "ltr";
+    const [isMobile, setIsMobile] = useState(false);
+    const [showMobileFolders, setShowMobileFolders] = useState(false);
+
+    // View mode (persisted in localStorage)
+    const [viewMode, setViewMode] = useState(() => {
+        try {
+            return localStorage.getItem(VIEW_MODE_KEY) || defaultViewMode;
+        } catch {
+            return defaultViewMode;
+        }
+    });
+
+    const handleViewModeChange = useCallback((mode) => {
+        setViewMode(mode);
+        try {
+            localStorage.setItem(VIEW_MODE_KEY, mode);
+        } catch {
+            // Ignore localStorage errors
+        }
+    }, []);
+
+    useEffect(() => {
+        if (typeof window === "undefined") return undefined;
+
+        const updateIsMobile = () => {
+            setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
+        };
+
+        updateIsMobile();
+        window.addEventListener("resize", updateIsMobile);
+
+        return () => {
+            window.removeEventListener("resize", updateIsMobile);
+        };
+    }, []);
+
+    useEffect(() => {
+        if (!isMobile) {
+            setShowMobileFolders(false);
+        }
+    }, [isMobile]);
+
+    // Sidebar width (resizable)
+    const [sidebarWidth, setSidebarWidth] = useState(SIDEBAR_DEFAULT);
+    const isDragging = useRef(false);
+    const dragStartX = useRef(0);
+    const dragStartWidth = useRef(0);
+
+    const handleDragStart = useCallback(
+        (e) => {
+            e.preventDefault();
+            isDragging.current = true;
+            dragStartX.current = e.clientX;
+            dragStartWidth.current = sidebarWidth;
+
+            const handleDragMove = (moveEvent) => {
+                if (!isDragging.current) return;
+                const diff =
+                    direction === "rtl"
+                        ? dragStartX.current - moveEvent.clientX
+                        : moveEvent.clientX - dragStartX.current;
+                const newWidth = Math.min(
+                    SIDEBAR_MAX,
+                    Math.max(SIDEBAR_MIN, dragStartWidth.current + diff),
+                );
+                setSidebarWidth(newWidth);
+            };
+
+            const handleDragEnd = () => {
+                isDragging.current = false;
+                document.removeEventListener("pointermove", handleDragMove);
+                document.removeEventListener("pointerup", handleDragEnd);
+            };
+
+            document.addEventListener("pointermove", handleDragMove);
+            document.addEventListener("pointerup", handleDragEnd);
+        },
+        [direction, sidebarWidth],
+    );
+
+    // Filter
+    const [filterText, setFilterText] = useState("");
+    const effectiveViewMode = isMobile ? "list" : viewMode;
+
+    // Data hook
+    const {
+        tree,
+        allFiles,
+        loading,
+        error,
+        reloadFiles,
+        totalFileCount,
+        getFilesForPath,
+        removeFileOptimistically,
+        renameFileOptimistically,
+        moveFilesOptimistically,
+        getSnapshot,
+        revertToSnapshot,
+    } = useUnifiedFileData({
+        contextId,
+        chatId,
+        legacyMessages,
+        augmentedFiles,
+        storageTarget,
+        filterFile,
+    });
+
+    // Navigation hook
+    const allFilesPath = rootFolderLabel ? ALL_FILES_PATH : "";
+    const {
+        selectedPath,
+        expandedPaths,
+        selectFolder,
+        toggleExpanded,
+        isExpanded,
+        isSelected,
+        breadcrumbs,
+    } = useFolderNavigation({
+        tree,
+        chatId,
+        defaultSelectedPath,
+        rootPathLabel: rootFolderLabel,
+        allFilesPath,
+    });
+
+    // Files for current view (deduplicated by blobPath > _id > hash > url)
+    const currentFiles = useMemo(() => {
+        const filesInFolder =
+            selectedPath == null
+                ? []
+                : selectedPath === allFilesPath
+                  ? collectAllFiles(tree)
+                  : getFilesForPath(selectedPath);
+
+        // Deduplicate — same content hash can appear in multiple scopes
+        const seen = new Set();
+        const deduped = filesInFolder.filter((file) => {
+            const key = file?.blobPath || file?._id || file?.hash || file?.url;
+            if (!key || seen.has(key)) return false;
+            seen.add(key);
+            return true;
+        });
+
+        const search = filterText.trim().toLowerCase();
+        const visibleFiles = !search
+            ? deduped
+            : deduped.filter((f) => {
+                  return getSearchableFileText(f).includes(search);
+              });
+
+        return sortFilesByMostRecent(visibleFiles);
+    }, [allFilesPath, tree, selectedPath, getFilesForPath, filterText]);
+
+    // File ID helper
+    const getFileId = useCallback((file) => createFileId(file), []);
+
+    // Selection
+    const {
+        selectedIds,
+        selectedObjects,
+        clearSelection,
+        toggleSelection,
+        selectRange,
+        setSelectedIds,
+        setSelectedObjects,
+        lastSelectedId,
+        setLastSelectedId,
+    } = useItemSelection(getFileId);
+
+    // Clear selection when folder changes
+    useEffect(() => {
+        clearSelection();
+    }, [selectedPath, clearSelection]);
+
+    useEffect(() => {
+        onSelectionChange?.(selectedObjects, selectedIds);
+    }, [onSelectionChange, selectedObjects, selectedIds]);
+
+    useEffect(() => {
+        if (!onFolderChange || selectedPath == null) return;
+        onFolderChange(selectedPath === allFilesPath ? "" : selectedPath, {
+            selectedPath,
+            allFilesPath,
+        });
+    }, [allFilesPath, onFolderChange, selectedPath]);
+
+    // Select all
+    const allSelected =
+        selectedIds.size === currentFiles.length && currentFiles.length > 0;
+    const bulkActionVisibility = useMemo(
+        () =>
+            getBulkActionVisibility?.({
+                selectedObjects,
+                selectedIds,
+            }) || {},
+        [getBulkActionVisibility, selectedObjects, selectedIds],
+    );
+
+    const handleSelectAll = useCallback(() => {
+        if (allSelected) {
+            clearSelection();
+        } else {
+            const newIds = new Set(currentFiles.map((f) => getFileId(f)));
+            setSelectedIds(newIds);
+            setSelectedObjects([...currentFiles]);
+        }
+    }, [
+        allSelected,
+        clearSelection,
+        currentFiles,
+        getFileId,
+        setSelectedIds,
+        setSelectedObjects,
+    ]);
+
+    // File selection handler with shift-click range
+    const handleSelectFile = useCallback(
+        (file, orderedFiles, index, e) => {
+            const visibleFiles =
+                Array.isArray(orderedFiles) && orderedFiles.length > 0
+                    ? orderedFiles
+                    : currentFiles;
+
+            if (e?.shiftKey) {
+                e.preventDefault();
+            }
+            const fileId = getFileId(file);
+
+            if (e?.shiftKey && lastSelectedId !== null) {
+                const lastIndex = visibleFiles.findIndex(
+                    (f) => getFileId(f) === lastSelectedId,
+                );
+                if (lastIndex !== -1 && index !== -1) {
+                    const start = Math.min(lastIndex, index);
+                    const end = Math.max(lastIndex, index);
+                    selectRange(visibleFiles, start, end);
+                    setLastSelectedId(fileId);
+                    return;
+                }
+            }
+            toggleSelection(file);
+            setLastSelectedId(fileId);
+        },
+        [
+            lastSelectedId,
+            toggleSelection,
+            selectRange,
+            getFileId,
+            setLastSelectedId,
+            currentFiles,
+        ],
+    );
+
+    // Preview
+    const [previewFile, setPreviewFile] = useState(null);
+    const [previewOptions, setPreviewOptions] = useState({});
+    const handlePreview = useCallback((file, options = {}) => {
+        if (isProcessingPreviewFile(file)) {
+            return;
+        }
+        setPreviewFile(file);
+        setPreviewOptions(options || {});
+    }, []);
+    const handleClosePreview = useCallback(() => {
+        setPreviewFile(null);
+        setPreviewOptions({});
+    }, []);
+
+    // Delete confirmation
+    const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+    const [filesToDelete, setFilesToDelete] = useState([]);
+    const [showMoveDialog, setShowMoveDialog] = useState(false);
+    const [moveDestinationPath, setMoveDestinationPath] = useState("");
+    const [moveNewFolderName, setMoveNewFolderName] = useState("");
+    const [moveError, setMoveError] = useState("");
+    const [isMoving, setIsMoving] = useState(false);
+
+    const handleDeleteRequest = useCallback((files) => {
+        const arr = Array.isArray(files) ? files : [files];
+        setFilesToDelete(arr);
+        setShowDeleteConfirm(true);
+    }, []);
+
+    const handleConfirmDelete = useCallback(async () => {
+        setShowDeleteConfirm(false);
+        if (!onDelete || filesToDelete.length === 0) return;
+
+        // Optimistic removal
+        const snapshot = getSnapshot();
+        for (const file of filesToDelete) {
+            removeFileOptimistically(file);
+        }
+        clearSelection();
+
+        try {
+            await onDelete(filesToDelete);
+        } catch {
+            revertToSnapshot(snapshot);
+            toast.error(t("Failed to delete file(s)."));
+        }
+        setFilesToDelete([]);
+    }, [
+        onDelete,
+        filesToDelete,
+        getSnapshot,
+        removeFileOptimistically,
+        clearSelection,
+        revertToSnapshot,
+        t,
+    ]);
+
+    const handleBulkDelete = useCallback(() => {
+        handleDeleteRequest(selectedObjects);
+    }, [selectedObjects, handleDeleteRequest]);
+
+    const folderPaths = useMemo(() => collectFolderPaths(tree), [tree]);
+    const moveFolderOptions = useMemo(() => {
+        const options = new Set();
+        for (const path of folderPaths) {
+            const optionPath = getMoveOptionPath(path, moveTargetBasePath);
+            if (optionPath) options.add(optionPath);
+        }
+        return Array.from(options).sort((a, b) => a.localeCompare(b));
+    }, [folderPaths, moveTargetBasePath]);
+    const moveRootLabel = rootFolderLabel || t("Files");
+    const moveChildFolderOptions = useMemo(
+        () => getChildFolderPaths(moveFolderOptions, moveDestinationPath),
+        [moveDestinationPath, moveFolderOptions],
+    );
+    const moveParentPath = useMemo(
+        () => getParentFolderPath(moveDestinationPath),
+        [moveDestinationPath],
+    );
+    const moveDestinationDisplayPath = useMemo(
+        () => getFolderDisplayPath(moveDestinationPath, moveRootLabel),
+        [moveDestinationPath, moveRootLabel],
+    );
+    const moveNewFolderNameTrimmed = normalizeFolderPath(moveNewFolderName);
+    const finalMoveDestinationDisplayPath = useMemo(() => {
+        const targetPath = moveNewFolderNameTrimmed
+            ? joinFolderPath(moveDestinationPath, moveNewFolderNameTrimmed)
+            : moveDestinationPath;
+        return getFolderDisplayPath(targetPath, moveRootLabel);
+    }, [moveDestinationPath, moveNewFolderNameTrimmed, moveRootLabel]);
+
+    const handleMoveRequest = useCallback(() => {
+        const initialPath =
+            selectedPath && selectedPath !== allFilesPath
+                ? getMoveOptionPath(selectedPath, moveTargetBasePath)
+                : "";
+        setMoveDestinationPath(initialPath);
+        setMoveNewFolderName("");
+        setMoveError("");
+        setShowMoveDialog(true);
+    }, [allFilesPath, moveTargetBasePath, selectedPath]);
+
+    const handleConfirmMove = useCallback(async () => {
+        if (!onMove || selectedObjects.length === 0) return;
+
+        const newFolder = normalizeFolderPath(moveNewFolderName);
+        const targetFolder = newFolder
+            ? joinFolderPath(moveDestinationPath, newFolder)
+            : normalizeFolderPath(moveDestinationPath);
+
+        const segments = targetFolder.split("/").filter(Boolean);
+        if (segments.some(hasInvalidFolderSegmentChars)) {
+            setMoveError(t("Folder name contains invalid characters."));
+            return;
+        }
+
+        setMoveError("");
+        setIsMoving(true);
+        const snapshot = getSnapshot();
+        moveFilesOptimistically(selectedObjects, targetFolder);
+
+        try {
+            const moveResult = await onMove(selectedObjects, targetFolder);
+            const movedCount =
+                typeof moveResult?.movedCount === "number"
+                    ? moveResult.movedCount
+                    : selectedObjects.length;
+            const skippedCount =
+                typeof moveResult?.skippedCount === "number"
+                    ? moveResult.skippedCount
+                    : 0;
+            clearSelection();
+            setShowMoveDialog(false);
+            setMoveNewFolderName("");
+            await reloadFiles();
+            toast.success(
+                skippedCount > 0
+                    ? t(
+                          "Moved {{count}} file(s) to {{folder}}. Skipped {{skipped}} item(s).",
+                          {
+                              count: movedCount,
+                              folder: getFolderDisplayPath(
+                                  targetFolder,
+                                  moveRootLabel,
+                              ),
+                              skipped: skippedCount,
+                          },
+                      )
+                    : t("Moved {{count}} file(s) to {{folder}}.", {
+                          count: movedCount,
+                          folder: getFolderDisplayPath(
+                              targetFolder,
+                              moveRootLabel,
+                          ),
+                      }),
+            );
+        } catch (error) {
+            revertToSnapshot(snapshot);
+            await reloadFilesAfterMoveError(reloadFiles);
+            setMoveError(error?.message || t("Failed to move files."));
+        } finally {
+            setIsMoving(false);
+        }
+    }, [
+        onMove,
+        selectedObjects,
+        moveNewFolderName,
+        moveDestinationPath,
+        t,
+        getSnapshot,
+        moveFilesOptimistically,
+        moveRootLabel,
+        clearSelection,
+        reloadFiles,
+        revertToSnapshot,
+    ]);
+
+    const handleSelectFolder = useCallback(
+        (path) => {
+            selectFolder(path);
+            if (isMobile) {
+                setShowMobileFolders(false);
+            }
+        },
+        [isMobile, selectFolder],
+    );
+
+    // Download (single file from grid context menu)
+    const handleSingleDownload = useCallback((file) => {
+        const url = file?.url;
+        if (url) {
+            const link = document.createElement("a");
+            link.href = url;
+            link.download = "";
+            link.style.display = "none";
+            document.body.appendChild(link);
+            link.click();
+            document.body.removeChild(link);
+        }
+    }, []);
+
+    // Preview download (inside preview dialog)
+    const handlePreviewDownload = useCallback(async (file) => {
+        const url = getFileUrl(file);
+        if (!url) return;
+        const proxyUrl = getDownloadUrl(url);
+        const name = getFilename(file) || "";
+        try {
+            const response = await fetch(proxyUrl);
+            if (!response.ok)
+                throw new Error(`Download failed: ${response.status}`);
+            const blob = await response.blob();
+            const blobUrl = URL.createObjectURL(blob);
+            const link = document.createElement("a");
+            link.href = blobUrl;
+            link.download = name;
+            link.style.display = "none";
+            document.body.appendChild(link);
+            link.click();
+            document.body.removeChild(link);
+            URL.revokeObjectURL(blobUrl);
+        } catch (err) {
+            console.error("Download error:", err);
+            window.open(proxyUrl, "_blank", "noopener,noreferrer");
+        }
+    }, []);
+
+    // Rename
+    const handleRenameRequest = useCallback(
+        async (file, metadata) => {
+            if (!onUpdateMetadata) return;
+            const snapshot = getSnapshot();
+            if (metadata?.displayFilename) {
+                renameFileOptimistically(file, metadata.displayFilename);
+            }
+            try {
+                await onUpdateMetadata(file, metadata);
+            } catch {
+                revertToSnapshot(snapshot);
+                toast.error(t("Failed to save filename."));
+            }
+        },
+        [
+            onUpdateMetadata,
+            getSnapshot,
+            renameFileOptimistically,
+            revertToSnapshot,
+            t,
+        ],
+    );
+
+    // Rename from grid context menu
+    const handleGridRename = useCallback(
+        (file) => {
+            // Trigger rename by switching to list view and setting up editing
+            // For simplicity, just prompt for a new name
+            const currentName = getFilename(file);
+            const newName = window.prompt(
+                t("Enter new filename:"),
+                currentName,
+            );
+            if (newName && newName.trim() && newName.trim() !== currentName) {
+                handleRenameRequest(file, {
+                    displayFilename: newName.trim(),
+                });
+            }
+        },
+        [handleRenameRequest, t],
+    );
+
+    // Loading state
+    if (loading && allFiles.length === 0) {
+        return (
+            <div
+                className="flex min-h-0 items-center justify-center overflow-hidden"
+                style={{ height: containerHeight }}
+            >
+                <Spinner className="w-6 h-6" />
+            </div>
+        );
+    }
+
+    // Error state
+    if (error && allFiles.length === 0) {
+        return (
+            <div
+                className="flex min-h-0 flex-col items-center justify-center gap-2 overflow-hidden"
+                style={{ height: containerHeight }}
+            >
+                <p className="text-sm text-red-500">
+                    {t("Failed to load files")}
+                </p>
+                <p className="text-xs text-gray-400">{error}</p>
+                <button
+                    onClick={reloadFiles}
+                    className="text-xs text-blue-500 hover:underline"
+                >
+                    {t("Retry")}
+                </button>
+            </div>
+        );
+    }
+
+    // Empty state (no files at all)
+    if (totalFileCount === 0 && !loading) {
+        return (
+            <div
+                className="flex min-h-0 flex-col items-center justify-center overflow-hidden"
+                style={{ height: containerHeight }}
+            >
+                <EmptyState
+                    icon={<Folder className="w-12 h-12" />}
+                    title={t("No files in storage")}
+                    description={t("Upload files to get started.")}
+                    action={onUploadClick}
+                    actionLabel={onUploadClick ? t("Upload") : undefined}
+                />
+            </div>
+        );
+    }
+
+    const deleteFilenames = filesToDelete.map((f) => getFilename(f)).join(", ");
+
+    return (
+        <div
+            className={`relative flex min-h-0 flex-col overflow-hidden overscroll-contain bg-white dark:bg-gray-900 ${
+                isMobile
+                    ? "border-0 rounded-none"
+                    : "border border-gray-200 dark:border-gray-700 rounded-lg"
+            }`}
+            dir={direction}
+            style={{ height: containerHeight }}
+        >
+            {/* Toolbar */}
+            <FileToolbar
+                breadcrumbs={breadcrumbs}
+                onNavigate={handleSelectFolder}
+                filterText={filterText}
+                onFilterChange={setFilterText}
+                viewMode={effectiveViewMode}
+                onViewModeChange={handleViewModeChange}
+                onUploadClick={onUploadClick}
+                onRefresh={reloadFiles}
+                chatTitleMap={chatTitleMap}
+                isMobile={isMobile}
+                showMobileFolders={showMobileFolders}
+                onToggleMobileFolders={() =>
+                    setShowMobileFolders((current) => !current)
+                }
+            />
+
+            {isMobile && showMobileFolders && (
+                <div className="max-h-64 flex-shrink-0 overflow-y-auto border-b border-gray-200 bg-white px-2 py-2 dark:border-gray-700 dark:bg-gray-900">
+                    <SidebarFolderTree
+                        tree={tree}
+                        chatTitleMap={chatTitleMap}
+                        totalFileCount={totalFileCount}
+                        isExpanded={isExpanded}
+                        isSelected={isSelected}
+                        onToggleExpand={toggleExpanded}
+                        onSelect={handleSelectFolder}
+                        expandedPaths={expandedPaths}
+                        selectedPath={selectedPath}
+                        rootFolderLabel={rootFolderLabel}
+                        allFilesPath={allFilesPath}
+                    />
+                </div>
+            )}
+
+            {/* Main body: sidebar + content */}
+            <div className="flex min-h-0 flex-1 overflow-hidden">
+                {!isMobile && (
+                    <>
+                        {/* Sidebar */}
+                        <div
+                            className="flex-shrink-0 overflow-y-auto overflow-x-hidden border-e border-gray-200 dark:border-gray-700"
+                            style={{ width: `${sidebarWidth}px` }}
+                        >
+                            <SidebarFolderTree
+                                tree={tree}
+                                chatTitleMap={chatTitleMap}
+                                totalFileCount={totalFileCount}
+                                isExpanded={isExpanded}
+                                isSelected={isSelected}
+                                onToggleExpand={toggleExpanded}
+                                onSelect={handleSelectFolder}
+                                expandedPaths={expandedPaths}
+                                selectedPath={selectedPath}
+                                rootFolderLabel={rootFolderLabel}
+                                allFilesPath={allFilesPath}
+                            />
+                        </div>
+
+                        {/* Resize handle */}
+                        <div
+                            className="w-1 flex-shrink-0 cursor-col-resize hover:bg-sky-200 dark:hover:bg-sky-800 active:bg-sky-300 dark:active:bg-sky-700 transition-colors"
+                            onPointerDown={handleDragStart}
+                        />
+                    </>
+                )}
+
+                {/* Content area */}
+                <div className="flex min-h-0 flex-1 flex-col overflow-hidden min-w-0">
+                    {currentFiles.length === 0 ? (
+                        <div className="flex min-h-0 flex-1 items-center justify-center overflow-hidden">
+                            <EmptyState
+                                icon={<Folder className="w-12 h-12" />}
+                                title={
+                                    filterText
+                                        ? t("No files match")
+                                        : t("No files in this folder")
+                                }
+                                description={
+                                    filterText
+                                        ? t(
+                                              "No files match your filter. Try a different search.",
+                                          )
+                                        : t("This folder is empty.")
+                                }
+                            />
+                        </div>
+                    ) : effectiveViewMode === "grid" ? (
+                        <FileGridView
+                            files={currentFiles}
+                            selectedIds={selectedIds}
+                            getFileId={getFileId}
+                            onSelectFile={handleSelectFile}
+                            onPreview={handlePreview}
+                            onDownload={handleSingleDownload}
+                            onRename={handleGridRename}
+                            onDelete={(file) => handleDeleteRequest(file)}
+                            enableFilenameEdit={!!onUpdateMetadata}
+                            renderFileOverlay={renderFileOverlay}
+                            renderFileStatus={renderFileStatus}
+                        />
+                    ) : (
+                        <FileContentArea
+                            files={currentFiles}
+                            selectedIds={selectedIds}
+                            getFileId={getFileId}
+                            onSelectFile={handleSelectFile}
+                            onSelectAll={handleSelectAll}
+                            allSelected={allSelected}
+                            onPreview={handlePreview}
+                            enableFilenameEdit={!!onUpdateMetadata}
+                            onUpdateMetadata={handleRenameRequest}
+                            onDelete={
+                                onDelete
+                                    ? (file) => handleDeleteRequest(file)
+                                    : undefined
+                            }
+                            filterText={filterText}
+                            isMobile={isMobile}
+                            renderFileStatus={renderFileStatus}
+                        />
+                    )}
+                </div>
+            </div>
+
+            {/* Status bar */}
+            <FileStatusBar
+                fileCount={currentFiles.length}
+                totalFileCount={totalFileCount}
+                selectedCount={selectedIds.size}
+                files={currentFiles}
+                selectedPath={selectedPath}
+            />
+
+            {/* Bulk actions bar */}
+            {selectedIds.size > 0 && (
+                <BulkActionsBar
+                    selectedCount={selectedIds.size}
+                    allSelected={allSelected}
+                    onSelectAll={handleSelectAll}
+                    onClearSelection={clearSelection}
+                    positionMode="container"
+                    actions={{
+                        ...(onAttach && bulkActionVisibility.attach !== false
+                            ? {
+                                  attach: {
+                                      onClick: () => {
+                                          onAttach(selectedObjects);
+                                      },
+                                      disabled: false,
+                                      label: attachLabel || t("Attach"),
+                                      ariaLabel: `${attachLabel || t("Attach")} (${selectedIds.size})`,
+                                  },
+                              }
+                            : {}),
+                        ...(onDownload &&
+                        bulkActionVisibility.download !== false
+                            ? {
+                                  download: {
+                                      onClick: async () => {
+                                          await onDownload(selectedObjects);
+                                          clearSelection();
+                                      },
+                                      disabled: isDownloading,
+                                      loadingLabel: t("Creating ZIP..."),
+                                      label:
+                                          selectedIds.size === 1
+                                              ? t("Download")
+                                              : t("Download ZIP"),
+                                      ariaLabel: `${t("Download")} (${selectedIds.size})`,
+                                  },
+                              }
+                            : {}),
+                        ...(onMove && bulkActionVisibility.move !== false
+                            ? {
+                                  move: {
+                                      onClick: handleMoveRequest,
+                                      disabled: isMoving,
+                                      loadingLabel: t("Moving..."),
+                                      label: t("Move"),
+                                      ariaLabel: `${t("Move")} (${selectedIds.size})`,
+                                  },
+                              }
+                            : {}),
+                        ...(onDelete
+                            ? {
+                                  delete: {
+                                      onClick: handleBulkDelete,
+                                      disabled: false,
+                                      label: t("Delete"),
+                                      ariaLabel: `${t("Delete")} (${selectedIds.size})`,
+                                  },
+                              }
+                            : {}),
+                        ...(typeof extraBulkActions === "function"
+                            ? extraBulkActions({
+                                  selectedObjects,
+                                  selectedIds,
+                                  clearSelection,
+                              })
+                            : extraBulkActions || {}),
+                    }}
+                />
+            )}
+
+            {/* File preview dialog */}
+            {previewFile && renderPreviewDialog ? (
+                renderPreviewDialog({
+                    file: previewFile,
+                    onClose: handleClosePreview,
+                    onDownload: handlePreviewDownload,
+                    autoPlay: previewOptions.autoPlay === true,
+                    t,
+                })
+            ) : previewFile ? (
+                <FilePreviewDialog
+                    file={previewFile}
+                    onClose={handleClosePreview}
+                    onDownload={handlePreviewDownload}
+                    autoPlay={previewOptions.autoPlay === true}
+                    t={t}
+                />
+            ) : null}
+
+            {/* Move dialog */}
+            <Dialog
+                open={showMoveDialog}
+                onOpenChange={(open) => {
+                    if (isMoving) return;
+                    setShowMoveDialog(open);
+                    if (!open) {
+                        setMoveError("");
+                        setMoveDestinationPath("");
+                        setMoveNewFolderName("");
+                    }
+                }}
+            >
+                <DialogContent
+                    className="flex max-h-[calc(100vh-1rem)] w-[calc(100vw-1rem)] max-w-lg flex-col gap-4 overflow-hidden p-4 sm:p-6"
+                    dir={direction}
+                >
+                    <DialogHeader className="space-y-1 text-start">
+                        <DialogTitle className="pe-8">
+                            {t("Move files")}
+                        </DialogTitle>
+                        <DialogDescription>
+                            {t("Choose where the selected files should go.")}
+                        </DialogDescription>
+                    </DialogHeader>
+                    {selectedObjects.length > 0 && (
+                        <div className="min-w-0 rounded-lg border border-gray-200 bg-gray-50 px-3 py-2 dark:border-gray-700 dark:bg-gray-900">
+                            <div className="mb-1 text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                                {t("Files to move")}
+                            </div>
+                            <div className="max-h-20 min-w-0 overflow-y-auto text-sm text-gray-800 dark:text-gray-100">
+                                {selectedObjects.map((file) => (
+                                    <div
+                                        key={getFileId(file)}
+                                        className="truncate"
+                                        title={getLeafFilename(file)}
+                                    >
+                                        {getLeafFilename(file)}
+                                    </div>
+                                ))}
+                            </div>
+                        </div>
+                    )}
+                    <div className="min-w-0 flex-1 space-y-4 overflow-y-auto overflow-x-hidden pe-1">
+                        <div className="min-w-0 space-y-2">
+                            <Label>{t("Destination folder")}</Label>
+                            <div className="overflow-hidden rounded-lg border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-900">
+                                <div className="flex min-w-0 items-center gap-2 border-b border-gray-200 px-3 py-2.5 dark:border-gray-700">
+                                    <button
+                                        type="button"
+                                        className="inline-flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-md border border-gray-200 text-gray-500 hover:bg-gray-100 disabled:opacity-40 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800"
+                                        onClick={() => {
+                                            setMoveDestinationPath(
+                                                moveParentPath,
+                                            );
+                                            setMoveError("");
+                                        }}
+                                        disabled={
+                                            isMoving || !moveDestinationPath
+                                        }
+                                        aria-label={t("Up one level")}
+                                        title={t("Up one level")}
+                                    >
+                                        <ArrowUp className="h-4 w-4" />
+                                    </button>
+                                    <div className="min-w-0 flex-1">
+                                        <div className="truncate text-sm font-semibold text-gray-900 dark:text-gray-100">
+                                            {getFolderDisplayName(
+                                                moveDestinationPath,
+                                                moveRootLabel,
+                                            )}
+                                        </div>
+                                        <div
+                                            className="truncate text-xs text-gray-500 dark:text-gray-400"
+                                            title={moveDestinationDisplayPath}
+                                        >
+                                            {moveDestinationDisplayPath}
+                                        </div>
+                                    </div>
+                                </div>
+                                <div className="max-h-48 min-h-24 min-w-0 overflow-y-auto overflow-x-hidden p-1.5">
+                                    {moveChildFolderOptions.length > 0 ? (
+                                        moveChildFolderOptions.map((path) => (
+                                            <button
+                                                key={path}
+                                                type="button"
+                                                className="flex w-full min-w-0 items-center gap-2 rounded-md px-2 py-2 text-start text-sm text-gray-700 hover:bg-gray-100 dark:text-gray-200 dark:hover:bg-gray-800"
+                                                title={getFolderDisplayPath(
+                                                    path,
+                                                    moveRootLabel,
+                                                )}
+                                                onClick={() => {
+                                                    setMoveDestinationPath(
+                                                        path,
+                                                    );
+                                                    setMoveError("");
+                                                }}
+                                                disabled={isMoving}
+                                            >
+                                                <Folder className="h-4 w-4 flex-shrink-0 text-yellow-500" />
+                                                <span className="truncate">
+                                                    {getFolderDisplayName(path)}
+                                                </span>
+                                            </button>
+                                        ))
+                                    ) : (
+                                        <div className="px-3 py-5 text-center text-sm text-gray-500 dark:text-gray-400">
+                                            {t(
+                                                "No subfolders here. You can still move files to this folder.",
+                                            )}
+                                        </div>
+                                    )}
+                                </div>
+                            </div>
+                        </div>
+
+                        <div className="min-w-0 space-y-2">
+                            <div>
+                                <Label htmlFor="move-new-folder-input">
+                                    {t("Create a new folder")}
+                                </Label>
+                                <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                                    {t(
+                                        "Optional. Leave blank to move directly into the destination folder.",
+                                    )}
+                                </p>
+                            </div>
+                            <div className="flex min-w-0 items-center gap-2 py-1">
+                                <div className="inline-flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-md border border-gray-200 text-gray-500 dark:border-gray-700 dark:text-gray-300">
+                                    <FolderPlus className="h-4 w-4" />
+                                </div>
+                                <Input
+                                    id="move-new-folder-input"
+                                    value={moveNewFolderName}
+                                    onChange={(event) => {
+                                        setMoveNewFolderName(
+                                            event.target.value,
+                                        );
+                                        setMoveError("");
+                                    }}
+                                    placeholder={t("New folder name")}
+                                    disabled={isMoving}
+                                />
+                            </div>
+                        </div>
+                        {moveError && (
+                            <p className="text-sm text-red-600 dark:text-red-400">
+                                {moveError}
+                            </p>
+                        )}
+                    </div>
+                    <div className="rounded-lg bg-sky-50 px-3 py-2 text-xs text-sky-800 dark:bg-sky-950/40 dark:text-sky-200">
+                        {t("Will move to {{folder}}", {
+                            folder: finalMoveDestinationDisplayPath,
+                        })}
+                    </div>
+                    <DialogFooter className="gap-2 sm:gap-2">
+                        <button
+                            type="button"
+                            className="lb-outline min-h-10 justify-center"
+                            onClick={() => setShowMoveDialog(false)}
+                            disabled={isMoving}
+                        >
+                            {t("Cancel")}
+                        </button>
+                        <button
+                            type="button"
+                            className="lb-primary inline-flex min-h-10 w-full items-center justify-center disabled:cursor-not-allowed disabled:opacity-50 sm:w-44"
+                            onClick={handleConfirmMove}
+                            disabled={isMoving}
+                            aria-label={isMoving ? t("Moving...") : undefined}
+                        >
+                            {isMoving ? (
+                                <Spinner size="sm" aria-hidden="true" />
+                            ) : (
+                                <span>
+                                    {moveNewFolderNameTrimmed
+                                        ? t("Move to new folder")
+                                        : t("Move Here")}
+                                </span>
+                            )}
+                        </button>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
+
+            {/* Delete confirmation dialog */}
+            <AlertDialog
+                open={showDeleteConfirm}
+                onOpenChange={(open) => {
+                    if (!open) {
+                        setShowDeleteConfirm(false);
+                        setFilesToDelete([]);
+                    }
+                }}
+            >
+                <AlertDialogContent>
+                    <AlertDialogHeader>
+                        <AlertDialogTitle>
+                            {filesToDelete.length === 1
+                                ? t("Delete File?")
+                                : t("Delete {{count}} Files?", {
+                                      count: filesToDelete.length,
+                                  })}
+                        </AlertDialogTitle>
+                        <AlertDialogDescription>
+                            {filesToDelete.length === 1
+                                ? t(
+                                      'Are you sure you want to delete "{{filename}}"? This action cannot be undone.',
+                                      { filename: deleteFilenames },
+                                  )
+                                : t(
+                                      "Are you sure you want to delete {{count}} files? This action cannot be undone.",
+                                      { count: filesToDelete.length },
+                                  )}
+                        </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                        <AlertDialogCancel>{t("Cancel")}</AlertDialogCancel>
+                        <AlertDialogAction onClick={handleConfirmDelete}>
+                            {t("Delete")}
+                        </AlertDialogAction>
+                    </AlertDialogFooter>
+                </AlertDialogContent>
+            </AlertDialog>
+        </div>
+    );
+}

--- a/src/components/common/UnifiedFileManager/__tests__/FileContentArea.test.js
+++ b/src/components/common/UnifiedFileManager/__tests__/FileContentArea.test.js
@@ -1,0 +1,367 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import FileContentArea from "../FileContentArea";
+
+jest.mock("react-i18next", () => ({
+    useTranslation: () => ({
+        t: (key) => key,
+    }),
+}));
+
+jest.mock("react-toastify", () => ({
+    toast: {
+        error: jest.fn(),
+    },
+}));
+
+jest.mock("i18next", () => ({
+    language: "en",
+}));
+
+jest.mock("lucide-react", () => {
+    const Icon = () => <span />;
+    return {
+        ArrowUpDown: Icon,
+        ChevronUp: Icon,
+        ChevronDown: Icon,
+        Check: Icon,
+        Eye: Icon,
+        Loader2: Icon,
+        Trash2: Icon,
+    };
+});
+
+jest.mock(
+    "@/src/components/common/MediaThumbnail",
+    () => ({
+        __esModule: true,
+        default: (props) => (
+            <span
+                data-testid="media-thumbnail"
+                data-media-type={props.mediaType || ""}
+                data-mime-type={props.mimeType || ""}
+                data-media-status={props.mediaStatus || ""}
+                data-thumbnail-src={props.thumbnailSrc || ""}
+                title={props.mediaError?.message || ""}
+                data-show-play-overlay={String(props.showPlayOverlay)}
+                data-show-video-controls={String(props.showVideoControls)}
+            />
+        ),
+    }),
+    { virtual: true },
+);
+
+jest.mock(
+    "@/components/ui/table",
+    () => ({
+        Table: ({ children }) => <table>{children}</table>,
+        TableBody: ({ children }) => <tbody>{children}</tbody>,
+        TableCell: ({ children, ...props }) => <td {...props}>{children}</td>,
+        TableHead: ({ children, ...props }) => <th {...props}>{children}</th>,
+        TableHeader: ({ children }) => <thead>{children}</thead>,
+        TableRow: ({ children, ...props }) => <tr {...props}>{children}</tr>,
+    }),
+    { virtual: true },
+);
+
+jest.mock(
+    "@/src/components/common/FileManager",
+    () => ({
+        __esModule: true,
+        getFilename: (file) => file.displayFilename || file.filename || "",
+        getFileDate: (file) => new Date(file.modifiedDate),
+        getFilePreviewUrl: (file) => file.url || null,
+        getFileThumbnailUrl: (file) => file._mediaItem?.thumbnailUrl || null,
+        formatFileSize: () => "1 KB",
+        formatFileListDate: (d) => (d ? d.toLocaleDateString("en") : "—"),
+    }),
+    { virtual: true },
+);
+
+jest.mock(
+    "@/src/utils/fileDownloadUtils",
+    () => ({
+        __esModule: true,
+        INVALID_FILENAME_CHARS: /[\\/:*?"<>|]/,
+    }),
+    { virtual: true },
+);
+
+describe("FileContentArea selection callbacks", () => {
+    it("passes the sorted visible file order back to the selection handler", () => {
+        const files = [
+            {
+                _id: "older",
+                displayFilename: "Older.txt",
+                modifiedDate: "2026-01-01T00:00:00.000Z",
+            },
+            {
+                _id: "newer",
+                displayFilename: "Newer.txt",
+                modifiedDate: "2026-03-01T00:00:00.000Z",
+            },
+        ];
+        const onSelectFile = jest.fn();
+
+        render(
+            <FileContentArea
+                files={files}
+                selectedIds={new Set()}
+                getFileId={(file) => file._id}
+                onSelectFile={onSelectFile}
+                onSelectAll={jest.fn()}
+            />,
+        );
+
+        const rows = screen.getAllByRole("row");
+        const newerRow = rows.find((row) =>
+            row.textContent.includes("Newer.txt"),
+        );
+        fireEvent.click(newerRow);
+
+        expect(onSelectFile).toHaveBeenCalledTimes(1);
+        expect(onSelectFile.mock.calls[0][0]).toBe(files[1]);
+        expect(onSelectFile.mock.calls[0][1].map((file) => file._id)).toEqual([
+            "newer",
+            "older",
+        ]);
+        expect(onSelectFile.mock.calls[0][2]).toBe(0);
+    });
+
+    it("suppresses video controls and play overlay in compact list thumbnails", () => {
+        render(
+            <FileContentArea
+                files={[
+                    {
+                        _id: "video",
+                        displayFilename: "Video.mp4",
+                        filename: "Video.mp4",
+                        mimeType: "video/mp4",
+                        url: "https://example.com/video.mp4",
+                        modifiedDate: "2026-03-01T00:00:00.000Z",
+                    },
+                ]}
+                selectedIds={new Set()}
+                getFileId={(file) => file._id}
+                onSelectFile={jest.fn()}
+                onSelectAll={jest.fn()}
+            />,
+        );
+
+        const thumbnail = screen.getByTestId("media-thumbnail");
+        expect(thumbnail).toHaveAttribute("data-show-play-overlay", "false");
+        expect(thumbnail).toHaveAttribute("data-show-video-controls", "false");
+    });
+
+    it("opens the full preview when a compact list thumbnail is clicked", () => {
+        const file = {
+            _id: "image",
+            displayFilename: "Image.png",
+            filename: "Image.png",
+            mimeType: "image/png",
+            url: "https://example.com/image.png",
+            modifiedDate: "2026-03-01T00:00:00.000Z",
+        };
+        const onPreview = jest.fn();
+        const onSelectFile = jest.fn();
+
+        render(
+            <FileContentArea
+                files={[file]}
+                selectedIds={new Set()}
+                getFileId={(item) => item._id}
+                onSelectFile={onSelectFile}
+                onSelectAll={jest.fn()}
+                onPreview={onPreview}
+            />,
+        );
+
+        fireEvent.click(screen.getByRole("button", { name: "Preview" }));
+
+        expect(onPreview).toHaveBeenCalledWith(file);
+        expect(onSelectFile).not.toHaveBeenCalled();
+    });
+
+    it("uses the mobile actions space for the date instead of delete controls", () => {
+        const file = {
+            _id: "image",
+            displayFilename: "Image.png",
+            filename: "Image.png",
+            mimeType: "image/png",
+            url: "https://example.com/image.png",
+            modifiedDate: "2026-03-01T00:00:00.000Z",
+        };
+
+        render(
+            <FileContentArea
+                files={[file]}
+                selectedIds={new Set()}
+                getFileId={(item) => item._id}
+                onSelectFile={jest.fn()}
+                onSelectAll={jest.fn()}
+                onPreview={jest.fn()}
+                onDelete={jest.fn()}
+                isMobile
+            />,
+        );
+
+        expect(
+            screen.getByText(
+                new Date(file.modifiedDate).toLocaleDateString("en"),
+            ),
+        ).toBeInTheDocument();
+        expect(
+            screen.queryByRole("button", { name: "Delete file" }),
+        ).not.toBeInTheDocument();
+    });
+
+    it("passes the explicit media type to compact list thumbnails", () => {
+        render(
+            <FileContentArea
+                files={[
+                    {
+                        _id: "audio",
+                        displayFilename: "Soundtrack",
+                        filename: "Soundtrack",
+                        type: "audio",
+                        url: "https://example.com/audio",
+                        modifiedDate: "2026-03-01T00:00:00.000Z",
+                    },
+                ]}
+                selectedIds={new Set()}
+                getFileId={(file) => file._id}
+                onSelectFile={jest.fn()}
+                onSelectAll={jest.fn()}
+            />,
+        );
+
+        expect(screen.getByTestId("media-thumbnail")).toHaveAttribute(
+            "data-media-type",
+            "audio",
+        );
+    });
+
+    it("passes contentType to compact list thumbnails when mimeType is missing", () => {
+        render(
+            <FileContentArea
+                files={[
+                    {
+                        _id: "audio",
+                        displayFilename: "Soundtrack",
+                        filename: "Soundtrack",
+                        type: "file",
+                        contentType: "audio/mpeg",
+                        url: "https://example.com/audio",
+                        modifiedDate: "2026-03-01T00:00:00.000Z",
+                    },
+                ]}
+                selectedIds={new Set()}
+                getFileId={(file) => file._id}
+                onSelectFile={jest.fn()}
+                onSelectAll={jest.fn()}
+            />,
+        );
+
+        expect(screen.getByTestId("media-thumbnail")).toHaveAttribute(
+            "data-mime-type",
+            "audio/mpeg",
+        );
+    });
+
+    it("passes media status and error details to compact list thumbnails", () => {
+        render(
+            <FileContentArea
+                files={[
+                    {
+                        _id: "failed",
+                        displayFilename: "Failed.mp4",
+                        filename: "Failed.mp4",
+                        url: "https://example.com/failed.mp4",
+                        modifiedDate: "2026-03-01T00:00:00.000Z",
+                        _mediaItem: {
+                            type: "video",
+                            status: "failed",
+                            error: { message: "Provider error" },
+                        },
+                    },
+                ]}
+                selectedIds={new Set()}
+                getFileId={(file) => file._id}
+                onSelectFile={jest.fn()}
+                onSelectAll={jest.fn()}
+            />,
+        );
+
+        const thumbnail = screen.getByTestId("media-thumbnail");
+        expect(thumbnail).toHaveAttribute("data-media-status", "failed");
+        expect(thumbnail).toHaveAttribute("title", "Provider error");
+    });
+
+    it("passes media thumbnail URLs to compact list thumbnails", () => {
+        render(
+            <FileContentArea
+                files={[
+                    {
+                        _id: "video",
+                        displayFilename: "Video.mp4",
+                        filename: "Video.mp4",
+                        url: "https://example.com/video.mp4",
+                        modifiedDate: "2026-03-01T00:00:00.000Z",
+                        _mediaItem: {
+                            type: "video",
+                            thumbnailUrl: "https://example.com/thumb.jpg",
+                        },
+                    },
+                ]}
+                selectedIds={new Set()}
+                getFileId={(file) => file._id}
+                onSelectFile={jest.fn()}
+                onSelectAll={jest.fn()}
+            />,
+        );
+
+        expect(screen.getByTestId("media-thumbnail")).toHaveAttribute(
+            "data-thumbnail-src",
+            "https://example.com/thumb.jpg",
+        );
+    });
+
+    it("sorts files by type from the Type column", () => {
+        const files = [
+            {
+                _id: "video",
+                displayFilename: "Video.mp4",
+                filename: "Video.mp4",
+                mimeType: "video/mp4",
+                modifiedDate: "2026-03-01T00:00:00.000Z",
+            },
+            {
+                _id: "audio",
+                displayFilename: "Audio.mp3",
+                filename: "Audio.mp3",
+                mimeType: "audio/mpeg",
+                modifiedDate: "2026-01-01T00:00:00.000Z",
+            },
+        ];
+
+        render(
+            <FileContentArea
+                files={files}
+                selectedIds={new Set()}
+                getFileId={(file) => file._id}
+                onSelectFile={jest.fn()}
+                onSelectAll={jest.fn()}
+            />,
+        );
+
+        fireEvent.click(screen.getByRole("button", { name: "Type" }));
+
+        const rows = screen.getAllByRole("row").slice(1);
+        expect(rows[0]).toHaveTextContent("Audio.mp3");
+        expect(rows[0]).toHaveTextContent("Audio");
+        expect(rows[1]).toHaveTextContent("Video.mp4");
+        expect(rows[1]).toHaveTextContent("Video");
+    });
+});

--- a/src/components/common/UnifiedFileManager/__tests__/FileGridView.test.js
+++ b/src/components/common/UnifiedFileManager/__tests__/FileGridView.test.js
@@ -1,0 +1,440 @@
+import React from "react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import FileGridView from "../FileGridView";
+
+jest.mock("react-i18next", () => ({
+    useTranslation: () => ({
+        t: (key) => key,
+    }),
+}));
+
+jest.mock(
+    "@/src/components/common/MediaThumbnail",
+    () => ({
+        __esModule: true,
+        default: (props) => (
+            <div
+                data-testid="media-thumbnail"
+                data-media-type={props.mediaType || ""}
+                data-mime-type={props.mimeType || ""}
+                data-media-status={props.mediaStatus || ""}
+                data-thumbnail-src={props.thumbnailSrc || ""}
+                title={props.mediaError?.message || ""}
+            />
+        ),
+    }),
+    { virtual: true },
+);
+
+jest.mock(
+    "@/src/components/common/FileManager",
+    () => ({
+        __esModule: true,
+        getFilePreviewUrl: (file) => file.url,
+        getFileThumbnailUrl: (file) => file._mediaItem?.thumbnailUrl || null,
+        getFilename: (file) => file.filename,
+        formatFileSize: () => "",
+    }),
+    { virtual: true },
+);
+
+jest.mock(
+    "@/components/ui/dropdown-menu",
+    () => ({
+        DropdownMenu: ({ children }) => <div>{children}</div>,
+        DropdownMenuTrigger: ({ children }) => children,
+        DropdownMenuContent: ({
+            children,
+            align: _align,
+            sideOffset: _sideOffset,
+            ...props
+        }) => <div {...props}>{children}</div>,
+        DropdownMenuItem: ({ children, onSelect, ...props }) => (
+            <button type="button" onClick={onSelect} {...props}>
+                {children}
+            </button>
+        ),
+    }),
+    { virtual: true },
+);
+
+describe("FileGridView", () => {
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    it("does not select a grid item when preview is clicked from the context menu", () => {
+        const file = {
+            _id: "file-1",
+            filename: "clip.mp4",
+            url: "https://example.com/clip.mp4",
+        };
+        const onSelectFile = jest.fn();
+        const onPreview = jest.fn();
+
+        render(
+            <FileGridView
+                files={[file]}
+                selectedIds={new Set()}
+                getFileId={(entry) => entry._id}
+                onSelectFile={onSelectFile}
+                onPreview={onPreview}
+            />,
+        );
+
+        fireEvent.click(screen.getByRole("button", { name: "Preview" }));
+
+        expect(onPreview).toHaveBeenCalledWith(file);
+        expect(onSelectFile).not.toHaveBeenCalled();
+    });
+
+    it("does not select a grid item before opening preview on double click", () => {
+        jest.useFakeTimers();
+
+        const file = {
+            _id: "file-1",
+            filename: "clip.mp4",
+            url: "https://example.com/clip.mp4",
+        };
+        const onSelectFile = jest.fn();
+        const onPreview = jest.fn();
+
+        render(
+            <FileGridView
+                files={[file]}
+                selectedIds={new Set()}
+                getFileId={(entry) => entry._id}
+                onSelectFile={onSelectFile}
+                onPreview={onPreview}
+            />,
+        );
+
+        const card = screen.getByTestId("file-grid-card-0");
+        fireEvent.click(card);
+        fireEvent.doubleClick(card);
+
+        act(() => {
+            jest.advanceTimersByTime(250);
+        });
+
+        expect(onPreview).toHaveBeenCalledWith(file);
+        expect(onSelectFile).not.toHaveBeenCalled();
+    });
+
+    it("suppresses browser text selection inside grid tiles", () => {
+        render(
+            <FileGridView
+                files={[
+                    {
+                        _id: "file-1",
+                        filename: "clip.mp4",
+                        url: "https://example.com/clip.mp4",
+                    },
+                ]}
+                selectedIds={new Set()}
+                getFileId={(entry) => entry._id}
+                onSelectFile={jest.fn()}
+            />,
+        );
+
+        expect(screen.getByTestId("file-grid-card-0")).toHaveClass(
+            "select-none",
+        );
+    });
+
+    it("passes the explicit media type to grid thumbnails", () => {
+        render(
+            <FileGridView
+                files={[
+                    {
+                        _id: "audio",
+                        filename: "soundtrack",
+                        url: "https://example.com/audio",
+                        type: "audio",
+                    },
+                ]}
+                selectedIds={new Set()}
+                getFileId={(entry) => entry._id}
+                onSelectFile={jest.fn()}
+            />,
+        );
+
+        expect(screen.getByTestId("media-thumbnail")).toHaveAttribute(
+            "data-media-type",
+            "audio",
+        );
+    });
+
+    it("passes contentType to grid thumbnails when mimeType is missing", () => {
+        render(
+            <FileGridView
+                files={[
+                    {
+                        _id: "audio",
+                        filename: "soundtrack",
+                        url: "https://example.com/audio",
+                        type: "file",
+                        contentType: "audio/mpeg",
+                    },
+                ]}
+                selectedIds={new Set()}
+                getFileId={(entry) => entry._id}
+                onSelectFile={jest.fn()}
+            />,
+        );
+
+        expect(screen.getByTestId("media-thumbnail")).toHaveAttribute(
+            "data-mime-type",
+            "audio/mpeg",
+        );
+    });
+
+    it("passes media status and error details to grid thumbnails", () => {
+        render(
+            <FileGridView
+                files={[
+                    {
+                        _id: "failed",
+                        filename: "Failed.mp4",
+                        url: "https://example.com/failed.mp4",
+                        _mediaItem: {
+                            type: "video",
+                            status: "failed",
+                            error: { message: "Provider error" },
+                        },
+                    },
+                ]}
+                selectedIds={new Set()}
+                getFileId={(entry) => entry._id}
+                onSelectFile={jest.fn()}
+            />,
+        );
+
+        const thumbnail = screen.getByTestId("media-thumbnail");
+        expect(thumbnail).toHaveAttribute("data-media-status", "failed");
+        expect(thumbnail).toHaveAttribute("title", "Provider error");
+    });
+
+    it("passes media thumbnail URLs to grid thumbnails", () => {
+        render(
+            <FileGridView
+                files={[
+                    {
+                        _id: "video",
+                        filename: "Video.mp4",
+                        url: "https://example.com/video.mp4",
+                        _mediaItem: {
+                            type: "video",
+                            thumbnailUrl: "https://example.com/thumb.jpg",
+                        },
+                    },
+                ]}
+                selectedIds={new Set()}
+                getFileId={(entry) => entry._id}
+                onSelectFile={jest.fn()}
+            />,
+        );
+
+        expect(screen.getByTestId("media-thumbnail")).toHaveAttribute(
+            "data-thumbnail-src",
+            "https://example.com/thumb.jpg",
+        );
+    });
+
+    it("plays video inline when the play cue is clicked", () => {
+        const file = {
+            _id: "video",
+            filename: "Video.mp4",
+            url: "https://example.com/video.mp4",
+            _mediaItem: {
+                type: "video",
+                thumbnailUrl: "https://example.com/thumb.jpg",
+            },
+        };
+        const onSelectFile = jest.fn();
+        const onPreview = jest.fn();
+
+        render(
+            <FileGridView
+                files={[file]}
+                selectedIds={new Set()}
+                getFileId={(entry) => entry._id}
+                onSelectFile={onSelectFile}
+                onPreview={onPreview}
+            />,
+        );
+
+        fireEvent.click(screen.getByTestId("media-play-cue"));
+
+        expect(screen.getByTestId("media-inline-video-player")).toHaveAttribute(
+            "src",
+            "https://example.com/video.mp4",
+        );
+        expect(onPreview).not.toHaveBeenCalled();
+        expect(onSelectFile).not.toHaveBeenCalled();
+    });
+
+    it("dismisses the inline player when clicking outside it", () => {
+        const file = {
+            _id: "video",
+            filename: "Video.mp4",
+            url: "https://example.com/video.mp4",
+            _mediaItem: {
+                type: "video",
+            },
+        };
+
+        render(
+            <FileGridView
+                files={[file]}
+                selectedIds={new Set()}
+                getFileId={(entry) => entry._id}
+                onSelectFile={jest.fn()}
+                onPreview={jest.fn()}
+            />,
+        );
+
+        fireEvent.click(screen.getByTestId("media-play-cue"));
+        expect(
+            screen.getByTestId("media-inline-video-player"),
+        ).toBeInTheDocument();
+
+        fireEvent.pointerDown(document.body);
+
+        expect(
+            screen.queryByTestId("media-inline-video-player"),
+        ).not.toBeInTheDocument();
+    });
+
+    it("keeps the inline player open when clicking inside it", () => {
+        const file = {
+            _id: "video",
+            filename: "Video.mp4",
+            url: "https://example.com/video.mp4",
+            _mediaItem: {
+                type: "video",
+            },
+        };
+
+        render(
+            <FileGridView
+                files={[file]}
+                selectedIds={new Set()}
+                getFileId={(entry) => entry._id}
+                onSelectFile={jest.fn()}
+                onPreview={jest.fn()}
+            />,
+        );
+
+        fireEvent.click(screen.getByTestId("media-play-cue"));
+        const player = screen.getByTestId("media-inline-video-player");
+
+        fireEvent.pointerDown(player);
+
+        expect(
+            screen.getByTestId("media-inline-video-player"),
+        ).toBeInTheDocument();
+    });
+
+    it("plays audio inline when the play cue is clicked", () => {
+        const file = {
+            _id: "audio",
+            filename: "Audio.mp3",
+            url: "https://example.com/audio.mp3",
+            _mediaItem: {
+                type: "audio",
+            },
+        };
+        const onSelectFile = jest.fn();
+        const onPreview = jest.fn();
+
+        render(
+            <FileGridView
+                files={[file]}
+                selectedIds={new Set()}
+                getFileId={(entry) => entry._id}
+                onSelectFile={onSelectFile}
+                onPreview={onPreview}
+            />,
+        );
+
+        fireEvent.click(screen.getByTestId("media-play-cue"));
+
+        expect(screen.getByTestId("media-inline-audio-player")).toHaveAttribute(
+            "src",
+            "https://example.com/audio.mp3",
+        );
+        expect(onPreview).not.toHaveBeenCalled();
+        expect(onSelectFile).not.toHaveBeenCalled();
+    });
+
+    it("does not show the play cue for image grid items", () => {
+        render(
+            <FileGridView
+                files={[
+                    {
+                        _id: "image",
+                        filename: "Image.png",
+                        url: "https://example.com/image.png",
+                        mimeType: "image/png",
+                    },
+                ]}
+                selectedIds={new Set()}
+                getFileId={(entry) => entry._id}
+                onSelectFile={jest.fn()}
+            />,
+        );
+
+        expect(screen.queryByTestId("media-play-cue")).not.toBeInTheDocument();
+    });
+
+    it("does not show the play cue for processing media grid items", () => {
+        render(
+            <FileGridView
+                files={[
+                    {
+                        _id: "video",
+                        filename: "Video.mp4",
+                        url: "https://example.com/video.mp4",
+                        _mediaItem: {
+                            type: "video",
+                            status: "processing",
+                        },
+                    },
+                ]}
+                selectedIds={new Set()}
+                getFileId={(entry) => entry._id}
+                onSelectFile={jest.fn()}
+                onPreview={jest.fn()}
+            />,
+        );
+
+        expect(screen.queryByTestId("media-play-cue")).not.toBeInTheDocument();
+    });
+
+    it("does not show the play cue for failed media grid items", () => {
+        render(
+            <FileGridView
+                files={[
+                    {
+                        _id: "video",
+                        filename: "Video.mp4",
+                        url: "https://example.com/video.mp4",
+                        _mediaItem: {
+                            type: "video",
+                            status: "failed",
+                        },
+                    },
+                ]}
+                selectedIds={new Set()}
+                getFileId={(entry) => entry._id}
+                onSelectFile={jest.fn()}
+                onPreview={jest.fn()}
+            />,
+        );
+
+        expect(screen.queryByTestId("media-play-cue")).not.toBeInTheDocument();
+    });
+});

--- a/src/components/common/UnifiedFileManager/__tests__/FileManager.fileId.test.js
+++ b/src/components/common/UnifiedFileManager/__tests__/FileManager.fileId.test.js
@@ -1,0 +1,22 @@
+import { createFileId } from "../../fileIdUtils";
+
+describe("createFileId", () => {
+    it("prefers blobPath when both blobPath and hash exist", () => {
+        const file = {
+            _id: "mongo-1",
+            hash: "legacy-hash",
+            blobPath: "applets/workspace-1/file.txt",
+        };
+
+        expect(createFileId(file)).toBe("bp-applets/workspace-1/file.txt");
+    });
+
+    it("falls back to _id before hash when blobPath is missing", () => {
+        const file = {
+            _id: "mongo-2",
+            hash: "legacy-hash-2",
+        };
+
+        expect(createFileId(file)).toBe("id-mongo-2");
+    });
+});

--- a/src/components/common/UnifiedFileManager/__tests__/FileToolbar.test.js
+++ b/src/components/common/UnifiedFileManager/__tests__/FileToolbar.test.js
@@ -1,0 +1,129 @@
+import React from "react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import FileToolbar from "../FileToolbar";
+
+jest.mock("react-i18next", () => ({
+    useTranslation: () => ({
+        t: (key) => key,
+    }),
+}));
+
+jest.mock("i18next", () => ({
+    language: "en",
+}));
+
+jest.mock("lucide-react", () => {
+    const Icon = () => <span />;
+    return {
+        ChevronRight: Icon,
+        ChevronDown: Icon,
+        ChevronUp: Icon,
+        Folder: Icon,
+        List: Icon,
+        LayoutGrid: Icon,
+        Upload: Icon,
+        RefreshCw: Icon,
+        Search: Icon,
+        X: Icon,
+    };
+});
+
+describe("FileToolbar", () => {
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    it("clears the file filter from the clear button", () => {
+        const onFilterChange = jest.fn();
+
+        render(
+            <FileToolbar
+                breadcrumbs={[{ label: "All Files", path: "" }]}
+                onNavigate={jest.fn()}
+                filterText="alpha"
+                onFilterChange={onFilterChange}
+                viewMode="list"
+                onViewModeChange={jest.fn()}
+            />,
+        );
+
+        fireEvent.click(screen.getByRole("button", { name: "Clear Filter" }));
+
+        expect(onFilterChange).toHaveBeenCalledWith("");
+    });
+
+    it("keeps the mobile filter collapsed until search is tapped", () => {
+        render(
+            <FileToolbar
+                breadcrumbs={[{ label: "All Files", path: "" }]}
+                onNavigate={jest.fn()}
+                filterText=""
+                onFilterChange={jest.fn()}
+                viewMode="list"
+                onViewModeChange={jest.fn()}
+                isMobile
+            />,
+        );
+
+        expect(
+            screen.queryByPlaceholderText("Filter files..."),
+        ).not.toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole("button", { name: "Search" }));
+
+        expect(
+            screen.getByPlaceholderText("Filter files..."),
+        ).toBeInTheDocument();
+        expect(screen.getByRole("textbox")).toHaveFocus();
+    });
+
+    it("shows the mobile filter when a filter is active", () => {
+        render(
+            <FileToolbar
+                breadcrumbs={[{ label: "All Files", path: "" }]}
+                onNavigate={jest.fn()}
+                filterText="frog"
+                onFilterChange={jest.fn()}
+                viewMode="list"
+                onViewModeChange={jest.fn()}
+                isMobile
+            />,
+        );
+
+        expect(screen.getByDisplayValue("frog")).toBeInTheDocument();
+    });
+
+    it("shows refresh feedback briefly after clicking reload", async () => {
+        jest.useFakeTimers();
+        const onRefresh = jest.fn();
+
+        render(
+            <FileToolbar
+                breadcrumbs={[{ label: "All Files", path: "" }]}
+                onNavigate={jest.fn()}
+                filterText=""
+                onFilterChange={jest.fn()}
+                viewMode="list"
+                onViewModeChange={jest.fn()}
+                onRefresh={onRefresh}
+            />,
+        );
+
+        const refreshButton = screen.getByRole("button", { name: "Refresh" });
+        fireEvent.click(refreshButton);
+
+        expect(onRefresh).toHaveBeenCalledTimes(1);
+        expect(refreshButton).toHaveAttribute("aria-busy", "true");
+        expect(refreshButton).toBeDisabled();
+
+        await act(async () => {
+            await Promise.resolve();
+            jest.advanceTimersByTime(450);
+        });
+
+        expect(refreshButton).toHaveAttribute("aria-busy", "false");
+        expect(refreshButton).not.toBeDisabled();
+    });
+});

--- a/src/components/common/UnifiedFileManager/__tests__/UnifiedFileManager.mobile.test.js
+++ b/src/components/common/UnifiedFileManager/__tests__/UnifiedFileManager.mobile.test.js
@@ -1,0 +1,217 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import UnifiedFileManager from "../UnifiedFileManager";
+
+jest.mock("react-i18next", () => ({
+    useTranslation: () => ({
+        t: (key) => key,
+    }),
+}));
+
+jest.mock("react-toastify", () => ({
+    toast: {
+        error: jest.fn(),
+        success: jest.fn(),
+    },
+}));
+
+jest.mock(
+    "@/src/components/images/hooks/useItemSelection",
+    () => {
+        const React = require("react");
+
+        return {
+            __esModule: true,
+            useItemSelection: () => {
+                const [selectedIds, setSelectedIds] = React.useState(
+                    () => new Set(),
+                );
+                const [selectedObjects, setSelectedObjects] = React.useState(
+                    [],
+                );
+
+                return {
+                    selectedIds,
+                    selectedObjects,
+                    clearSelection: jest.fn(),
+                    toggleSelection: jest.fn(),
+                    selectRange: jest.fn(),
+                    setSelectedIds,
+                    setSelectedObjects,
+                    lastSelectedId: null,
+                    setLastSelectedId: jest.fn(),
+                };
+            },
+        };
+    },
+    { virtual: true },
+);
+
+jest.mock(
+    "@/src/utils/fileDownloadUtils",
+    () => ({
+        __esModule: true,
+        getDownloadUrl: (url) => url,
+    }),
+    { virtual: true },
+);
+
+jest.mock("../useUnifiedFileData", () => {
+    const files = [
+        {
+            _id: "one",
+            displayFilename: "Alpha.txt",
+            modifiedDate: "2026-03-01T00:00:00.000Z",
+        },
+    ];
+
+    return {
+        __esModule: true,
+        collectAllFiles: (node) => node.files || [],
+        useUnifiedFileData: () => ({
+            tree: {
+                files,
+                children: {
+                    chats: {
+                        path: "chats",
+                        files: [],
+                        children: {},
+                    },
+                },
+            },
+            allFiles: files,
+            loading: false,
+            error: null,
+            reloadFiles: jest.fn(),
+            totalFileCount: files.length,
+            getFilesRecursive: () => files,
+            removeFileOptimistically: jest.fn(),
+            renameFileOptimistically: jest.fn(),
+            getSnapshot: jest.fn(() => files),
+            revertToSnapshot: jest.fn(),
+        }),
+    };
+});
+
+jest.mock("../useFolderNavigation", () => ({
+    __esModule: true,
+    useFolderNavigation: () => ({
+        selectedPath: "",
+        expandedPaths: new Set(),
+        selectFolder: jest.fn(),
+        toggleExpanded: jest.fn(),
+        isExpanded: jest.fn(() => false),
+        isSelected: jest.fn((path) => path === ""),
+        breadcrumbs: [{ label: "All Files", path: "" }],
+    }),
+}));
+
+jest.mock("../SidebarFolderTree", () => ({
+    __esModule: true,
+    default: () => <div data-testid="sidebar-tree" />,
+}));
+
+jest.mock("../FileGridView", () => ({
+    __esModule: true,
+    default: () => <div data-testid="file-grid-view" />,
+}));
+
+jest.mock("../FileStatusBar", () => ({
+    __esModule: true,
+    default: () => null,
+}));
+
+jest.mock(
+    "@/src/components/common/BulkActionsBar",
+    () => ({
+        __esModule: true,
+        default: () => null,
+    }),
+    { virtual: true },
+);
+
+jest.mock(
+    "@/src/components/common/EmptyState",
+    () => ({
+        __esModule: true,
+        default: () => <div data-testid="empty-state" />,
+    }),
+    { virtual: true },
+);
+
+jest.mock(
+    "@/components/ui/spinner",
+    () => ({
+        __esModule: true,
+        Spinner: () => <div data-testid="spinner" />,
+    }),
+    { virtual: true },
+);
+
+jest.mock(
+    "@/components/ui/alert-dialog",
+    () => ({
+        AlertDialog: ({ children }) => <div>{children}</div>,
+        AlertDialogContent: ({ children }) => <div>{children}</div>,
+        AlertDialogHeader: ({ children }) => <div>{children}</div>,
+        AlertDialogTitle: ({ children }) => <div>{children}</div>,
+        AlertDialogDescription: ({ children }) => <div>{children}</div>,
+        AlertDialogFooter: ({ children }) => <div>{children}</div>,
+        AlertDialogAction: ({ children, ...props }) => (
+            <button type="button" {...props}>
+                {children}
+            </button>
+        ),
+        AlertDialogCancel: ({ children, ...props }) => (
+            <button type="button" {...props}>
+                {children}
+            </button>
+        ),
+    }),
+    { virtual: true },
+);
+
+jest.mock(
+    "@/src/components/common/FileManager",
+    () => ({
+        __esModule: true,
+        getFileUrl: jest.fn(() => null),
+        getFilename: (file) =>
+            file.displayFilename || file.displayName || file.filename || "",
+        getFileDate: (file) =>
+            file.modifiedDate ? new Date(file.modifiedDate) : null,
+        createFileId: (file) => `id-${file._id}`,
+        FilePreviewDialog: () => null,
+    }),
+    { virtual: true },
+);
+
+jest.mock("../FileContentArea", () => ({
+    __esModule: true,
+    default: () => <div data-testid="file-content-area" />,
+}));
+
+describe("UnifiedFileManager mobile layout", () => {
+    beforeEach(() => {
+        window.localStorage.clear();
+        window.innerWidth = 375;
+    });
+
+    it("forces list view on mobile and keeps folders behind a toggle", () => {
+        window.localStorage.setItem("unified-file-manager-view-mode", "grid");
+
+        render(
+            <UnifiedFileManager contextId="ctx-1" containerHeight="400px" />,
+        );
+
+        expect(screen.getByTestId("file-content-area")).toBeInTheDocument();
+        expect(screen.queryByTestId("file-grid-view")).not.toBeInTheDocument();
+        expect(screen.queryByTestId("sidebar-tree")).not.toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole("button", { name: /all files/i }));
+
+        expect(screen.getByTestId("sidebar-tree")).toBeInTheDocument();
+    });
+});

--- a/src/components/common/UnifiedFileManager/__tests__/UnifiedFileManager.selection.test.js
+++ b/src/components/common/UnifiedFileManager/__tests__/UnifiedFileManager.selection.test.js
@@ -1,0 +1,510 @@
+import React from "react";
+import {
+    fireEvent,
+    render,
+    screen,
+    waitFor,
+    within,
+} from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import UnifiedFileManager from "../UnifiedFileManager";
+
+const mockReloadFiles = jest.fn();
+const mockMoveFilesOptimistically = jest.fn();
+const mockRevertToSnapshot = jest.fn();
+
+jest.mock("react-i18next", () => ({
+    useTranslation: () => ({
+        t: (key, params) =>
+            params
+                ? Object.entries(params).reduce(
+                      (value, [paramKey, paramValue]) =>
+                          value.replace(`{{${paramKey}}}`, paramValue),
+                      key,
+                  )
+                : key,
+    }),
+}));
+
+jest.mock("react-toastify", () => ({
+    toast: {
+        error: jest.fn(),
+        success: jest.fn(),
+    },
+}));
+
+jest.mock(
+    "@/src/components/images/hooks/useItemSelection",
+    () => {
+        const React = require("react");
+
+        return {
+            __esModule: true,
+            useItemSelection: (getItemId) => {
+                const [selectedIds, setSelectedIds] = React.useState(
+                    () => new Set(),
+                );
+                const [selectedObjects, setSelectedObjects] = React.useState(
+                    [],
+                );
+                const [lastSelectedId, setLastSelectedId] =
+                    React.useState(null);
+
+                const clearSelection = React.useCallback(() => {
+                    setSelectedIds(new Set());
+                    setSelectedObjects([]);
+                    setLastSelectedId(null);
+                }, []);
+
+                const toggleSelection = React.useCallback(
+                    (item) => {
+                        const id = getItemId(item);
+
+                        setSelectedIds((prev) => {
+                            const next = new Set(prev);
+                            if (next.has(id)) {
+                                next.delete(id);
+                            } else {
+                                next.add(id);
+                            }
+                            return next;
+                        });
+
+                        setSelectedObjects((prev) => {
+                            const exists = prev.some(
+                                (entry) => getItemId(entry) === id,
+                            );
+                            return exists
+                                ? prev.filter(
+                                      (entry) => getItemId(entry) !== id,
+                                  )
+                                : [...prev, item];
+                        });
+                    },
+                    [getItemId],
+                );
+
+                const selectRange = React.useCallback(
+                    (items, start, end) => {
+                        setSelectedIds((prev) => {
+                            const next = new Set(prev);
+                            for (let index = start; index <= end; index += 1) {
+                                const item = items[index];
+                                if (item) {
+                                    next.add(getItemId(item));
+                                }
+                            }
+                            return next;
+                        });
+
+                        setSelectedObjects((prev) => {
+                            const next = [...prev];
+                            const seen = new Set(
+                                prev.map((item) => getItemId(item)),
+                            );
+                            for (let index = start; index <= end; index += 1) {
+                                const item = items[index];
+                                if (item) {
+                                    const id = getItemId(item);
+                                    if (!seen.has(id)) {
+                                        seen.add(id);
+                                        next.push(item);
+                                    }
+                                }
+                            }
+                            return next;
+                        });
+                    },
+                    [getItemId],
+                );
+
+                return {
+                    selectedIds,
+                    selectedObjects,
+                    clearSelection,
+                    toggleSelection,
+                    selectRange,
+                    setSelectedIds,
+                    setSelectedObjects,
+                    lastSelectedId,
+                    setLastSelectedId,
+                };
+            },
+        };
+    },
+    { virtual: true },
+);
+
+jest.mock(
+    "@/src/utils/fileDownloadUtils",
+    () => ({
+        __esModule: true,
+        getDownloadUrl: (url) => url,
+    }),
+    { virtual: true },
+);
+
+jest.mock("../useUnifiedFileData", () => {
+    const files = [
+        {
+            _id: "middle",
+            displayFilename: "Middle.txt",
+            modifiedDate: "2026-02-15T00:00:00.000Z",
+            tags: ["whimsical"],
+        },
+        {
+            _id: "oldest",
+            displayFilename: "Oldest.txt",
+            modifiedDate: "2026-01-15T00:00:00.000Z",
+        },
+        {
+            _id: "newest",
+            displayFilename: "Newest.txt",
+            modifiedDate: "2026-03-01T00:00:00.000Z",
+        },
+    ];
+
+    return {
+        __esModule: true,
+        collectAllFiles: (node) => node.files || [],
+        useUnifiedFileData: () => ({
+            tree: { files },
+            allFiles: files,
+            loading: false,
+            error: null,
+            reloadFiles: mockReloadFiles,
+            totalFileCount: files.length,
+            getFilesRecursive: () => files,
+            removeFileOptimistically: jest.fn(),
+            renameFileOptimistically: jest.fn(),
+            moveFilesOptimistically: mockMoveFilesOptimistically,
+            getSnapshot: jest.fn(() => files),
+            revertToSnapshot: mockRevertToSnapshot,
+        }),
+    };
+});
+
+jest.mock("../useFolderNavigation", () => ({
+    __esModule: true,
+    useFolderNavigation: () => ({
+        selectedPath: "",
+        expandedPaths: new Set(),
+        selectFolder: jest.fn(),
+        toggleExpanded: jest.fn(),
+        isExpanded: jest.fn(() => false),
+        isSelected: jest.fn((path) => path === ""),
+        breadcrumbs: [{ label: "All Files", path: "" }],
+    }),
+}));
+
+jest.mock("../SidebarFolderTree", () => ({
+    __esModule: true,
+    default: () => <div data-testid="sidebar-tree" />,
+}));
+
+jest.mock("../FileToolbar", () => ({
+    __esModule: true,
+    default: ({ filterText, onFilterChange }) => (
+        <div data-testid="file-toolbar">
+            <input
+                aria-label="Filter files"
+                value={filterText}
+                onChange={(event) => onFilterChange(event.target.value)}
+            />
+        </div>
+    ),
+}));
+
+jest.mock("../FileGridView", () => ({
+    __esModule: true,
+    default: () => <div data-testid="file-grid-view" />,
+}));
+
+jest.mock("../FileStatusBar", () => ({
+    __esModule: true,
+    default: ({ selectedCount }) => (
+        <div data-testid="status-selected-count">{selectedCount}</div>
+    ),
+}));
+
+jest.mock(
+    "@/src/components/common/BulkActionsBar",
+    () => ({
+        __esModule: true,
+        default: ({ actions }) => (
+            <div data-testid="bulk-actions">
+                {Object.entries(actions || {}).map(([key, action]) => (
+                    <button
+                        key={key}
+                        type="button"
+                        onClick={action.onClick}
+                        disabled={action.disabled}
+                    >
+                        {action.label || key}
+                    </button>
+                ))}
+            </div>
+        ),
+    }),
+    { virtual: true },
+);
+
+jest.mock(
+    "@/src/components/common/EmptyState",
+    () => ({
+        __esModule: true,
+        default: () => <div data-testid="empty-state" />,
+    }),
+    { virtual: true },
+);
+
+jest.mock(
+    "@/components/ui/spinner",
+    () => ({
+        __esModule: true,
+        Spinner: () => <div data-testid="spinner" />,
+    }),
+    { virtual: true },
+);
+
+jest.mock(
+    "@/components/ui/alert-dialog",
+    () => ({
+        AlertDialog: ({ children }) => <div>{children}</div>,
+        AlertDialogContent: ({ children }) => <div>{children}</div>,
+        AlertDialogHeader: ({ children }) => <div>{children}</div>,
+        AlertDialogTitle: ({ children }) => <div>{children}</div>,
+        AlertDialogDescription: ({ children }) => <div>{children}</div>,
+        AlertDialogFooter: ({ children }) => <div>{children}</div>,
+        AlertDialogAction: ({ children, ...props }) => (
+            <button type="button" {...props}>
+                {children}
+            </button>
+        ),
+        AlertDialogCancel: ({ children, ...props }) => (
+            <button type="button" {...props}>
+                {children}
+            </button>
+        ),
+    }),
+    { virtual: true },
+);
+
+jest.mock(
+    "@/src/components/common/FileManager",
+    () => ({
+        __esModule: true,
+        getFileUrl: jest.fn(() => null),
+        getFilename: (file) =>
+            file.displayFilename || file.displayName || file.filename || "",
+        getFileDate: (file) =>
+            file.modifiedDate ? new Date(file.modifiedDate) : null,
+        createFileId: (file) => `id-${file._id}`,
+        FilePreviewDialog: () => null,
+    }),
+    { virtual: true },
+);
+
+jest.mock("../FileContentArea", () => ({
+    __esModule: true,
+    default: ({ files, selectedIds, onSelectFile }) => {
+        const orderedFiles = [...files].sort(
+            (a, b) =>
+                new Date(b.modifiedDate).getTime() -
+                new Date(a.modifiedDate).getTime(),
+        );
+
+        return (
+            <div>
+                <div data-testid="content-selected-count">
+                    {selectedIds.size}
+                </div>
+                {orderedFiles.map((file, index) => (
+                    <button
+                        key={file._id}
+                        type="button"
+                        onClick={(event) =>
+                            onSelectFile(file, orderedFiles, index, event)
+                        }
+                    >
+                        {file.displayFilename}
+                    </button>
+                ))}
+            </div>
+        );
+    },
+}));
+
+describe("UnifiedFileManager shift selection", () => {
+    beforeEach(() => {
+        window.localStorage.clear();
+        mockReloadFiles.mockClear();
+        mockMoveFilesOptimistically.mockClear();
+        mockRevertToSnapshot.mockClear();
+    });
+
+    it("selects the full visible range in list order", () => {
+        render(
+            <UnifiedFileManager
+                contextId="ctx-1"
+                onDownload={jest.fn()}
+                containerHeight="400px"
+            />,
+        );
+
+        expect(screen.getByTestId("content-selected-count")).toHaveTextContent(
+            "0",
+        );
+
+        fireEvent.click(screen.getByRole("button", { name: "Newest.txt" }));
+        expect(screen.getByTestId("content-selected-count")).toHaveTextContent(
+            "1",
+        );
+
+        fireEvent.click(screen.getByRole("button", { name: "Oldest.txt" }), {
+            shiftKey: true,
+        });
+
+        expect(screen.getByTestId("content-selected-count")).toHaveTextContent(
+            "3",
+        );
+        expect(screen.getByTestId("status-selected-count")).toHaveTextContent(
+            "3",
+        );
+    });
+
+    it("uses defaultViewMode only when there is no saved view preference", () => {
+        const { unmount } = render(
+            <UnifiedFileManager
+                contextId="ctx-1"
+                defaultViewMode="grid"
+                containerHeight="400px"
+            />,
+        );
+
+        expect(screen.getByTestId("file-grid-view")).toBeInTheDocument();
+        unmount();
+
+        window.localStorage.setItem("unified-file-manager-view-mode", "list");
+        render(
+            <UnifiedFileManager
+                contextId="ctx-1"
+                defaultViewMode="grid"
+                containerHeight="400px"
+            />,
+        );
+
+        expect(
+            screen.getByTestId("content-selected-count"),
+        ).toBeInTheDocument();
+    });
+
+    it("filters media files by tags", () => {
+        render(
+            <UnifiedFileManager
+                contextId="ctx-1"
+                onDownload={jest.fn()}
+                containerHeight="400px"
+            />,
+        );
+
+        fireEvent.change(screen.getByLabelText("Filter files"), {
+            target: { value: "whimsical" },
+        });
+
+        expect(
+            screen.getByRole("button", { name: "Middle.txt" }),
+        ).toBeVisible();
+        expect(
+            screen.queryByRole("button", { name: "Newest.txt" }),
+        ).not.toBeInTheDocument();
+        expect(
+            screen.queryByRole("button", { name: "Oldest.txt" }),
+        ).not.toBeInTheDocument();
+    });
+
+    it("hides unavailable bulk actions for the current selection", () => {
+        render(
+            <UnifiedFileManager
+                contextId="ctx-1"
+                onAttach={jest.fn()}
+                onDownload={jest.fn()}
+                onMove={jest.fn()}
+                onDelete={jest.fn()}
+                getBulkActionVisibility={() => ({
+                    attach: false,
+                    download: false,
+                    move: false,
+                })}
+                containerHeight="400px"
+            />,
+        );
+
+        fireEvent.click(screen.getByRole("button", { name: "Newest.txt" }));
+
+        expect(
+            screen.queryByRole("button", { name: "Attach" }),
+        ).not.toBeInTheDocument();
+        expect(
+            screen.queryByRole("button", { name: "Download" }),
+        ).not.toBeInTheDocument();
+        expect(
+            screen.queryByRole("button", { name: "Move" }),
+        ).not.toBeInTheDocument();
+        expect(
+            within(screen.getByTestId("bulk-actions")).getByRole("button", {
+                name: "Delete",
+            }),
+        ).toBeVisible();
+    });
+
+    it("explains the move destination clearly", () => {
+        render(
+            <UnifiedFileManager
+                contextId="ctx-1"
+                onMove={jest.fn()}
+                containerHeight="400px"
+            />,
+        );
+
+        fireEvent.click(screen.getByRole("button", { name: "Newest.txt" }));
+        fireEvent.click(screen.getByRole("button", { name: "Move" }));
+
+        const moveDialog = screen.getByRole("dialog");
+
+        expect(moveDialog).toHaveTextContent("Move files");
+        expect(screen.getByText("Files to move")).toBeInTheDocument();
+        expect(moveDialog).toHaveTextContent("Newest.txt");
+        expect(screen.getByText("Destination folder")).toBeInTheDocument();
+        expect(
+            screen.getByText(
+                "No subfolders here. You can still move files to this folder.",
+            ),
+        ).toBeInTheDocument();
+        expect(screen.getByText("Create a new folder")).toBeInTheDocument();
+        expect(screen.getByText("Will move to Files")).toBeInTheDocument();
+    });
+
+    it("refreshes files after a failed move so partial server success is reconciled", async () => {
+        const onMove = jest.fn().mockRejectedValue(new Error("Move failed"));
+
+        render(
+            <UnifiedFileManager
+                contextId="ctx-1"
+                onMove={onMove}
+                containerHeight="400px"
+            />,
+        );
+
+        fireEvent.click(screen.getByRole("button", { name: "Newest.txt" }));
+        fireEvent.click(screen.getByRole("button", { name: "Move" }));
+        fireEvent.click(screen.getByRole("button", { name: "Move Here" }));
+
+        await waitFor(() => expect(onMove).toHaveBeenCalledTimes(1));
+        await waitFor(() => expect(mockReloadFiles).toHaveBeenCalledTimes(1));
+
+        expect(mockRevertToSnapshot).toHaveBeenCalledTimes(1);
+        expect(await screen.findByText("Move failed")).toBeInTheDocument();
+    });
+});

--- a/src/components/common/UnifiedFileManager/__tests__/useFolderNavigation.test.js
+++ b/src/components/common/UnifiedFileManager/__tests__/useFolderNavigation.test.js
@@ -1,0 +1,123 @@
+import { renderHook, waitFor, act } from "@testing-library/react";
+import { useFolderNavigation } from "../useFolderNavigation";
+
+describe("useFolderNavigation", () => {
+    test("defaults to a top-level folder instead of All Files", async () => {
+        const tree = {
+            children: {
+                chats: { children: {}, files: [], path: "chats" },
+                global: { children: {}, files: [], path: "global" },
+            },
+        };
+
+        const { result } = renderHook(() => useFolderNavigation({ tree }));
+
+        await waitFor(() => {
+            expect(result.current.selectedPath).toBe("global");
+        });
+    });
+
+    test("keeps All Files as an explicit user selection", async () => {
+        const tree = {
+            children: {
+                global: { children: {}, files: [], path: "global" },
+            },
+        };
+
+        const { result } = renderHook(() => useFolderNavigation({ tree }));
+
+        await waitFor(() => {
+            expect(result.current.selectedPath).toBe("global");
+        });
+
+        act(() => {
+            result.current.selectFolder("");
+        });
+
+        expect(result.current.selectedPath).toBe("");
+    });
+
+    test("can default to All Files", () => {
+        const tree = {
+            children: {
+                global: { children: {}, files: [], path: "global" },
+            },
+        };
+
+        const { result } = renderHook(() =>
+            useFolderNavigation({ tree, defaultSelectedPath: "" }),
+        );
+
+        expect(result.current.selectedPath).toBe("");
+        expect(result.current.breadcrumbs).toEqual([
+            { label: "All Files", path: "" },
+        ]);
+    });
+
+    test("does not force the chat folder again after user navigation", async () => {
+        const createTree = () => ({
+            children: {
+                chats: {
+                    children: {
+                        "chat-1": {
+                            children: {},
+                            files: [],
+                            path: "chats/chat-1",
+                        },
+                    },
+                    files: [],
+                    path: "chats",
+                },
+                global: { children: {}, files: [], path: "global" },
+            },
+        });
+
+        const { result, rerender } = renderHook(
+            ({ tree }) => useFolderNavigation({ tree, chatId: "chat-1" }),
+            { initialProps: { tree: createTree() } },
+        );
+
+        await waitFor(() => {
+            expect(result.current.selectedPath).toBe("chats/chat-1");
+        });
+
+        act(() => {
+            result.current.selectFolder("chats");
+        });
+        expect(result.current.selectedPath).toBe("chats");
+
+        rerender({ tree: createTree() });
+
+        expect(result.current.selectedPath).toBe("chats");
+    });
+
+    test("can label the real root separately from recursive All Files", () => {
+        const tree = {
+            children: {
+                nested: { children: {}, files: [], path: "nested" },
+            },
+        };
+
+        const { result } = renderHook(() =>
+            useFolderNavigation({
+                tree,
+                defaultSelectedPath: "",
+                rootPathLabel: "media",
+                allFilesPath: "__all_files__",
+            }),
+        );
+
+        expect(result.current.selectedPath).toBe("");
+        expect(result.current.breadcrumbs).toEqual([
+            { label: "media", path: "" },
+        ]);
+
+        act(() => {
+            result.current.selectFolder("__all_files__");
+        });
+
+        expect(result.current.breadcrumbs).toEqual([
+            { label: "All Files", path: "__all_files__" },
+        ]);
+    });
+});

--- a/src/components/common/UnifiedFileManager/__tests__/useUnifiedFileData.test.js
+++ b/src/components/common/UnifiedFileManager/__tests__/useUnifiedFileData.test.js
@@ -1,0 +1,93 @@
+import "@testing-library/jest-dom";
+import {
+    buildFolderTree,
+    countFiles,
+    extractLegacyFilesFromMessages,
+} from "../useUnifiedFileData";
+
+jest.mock("@/src/App", () => ({
+    AuthContext: require("react").createContext({
+        user: { contextId: "user-1" },
+    }),
+}));
+
+// Mock i18n — transitive import chain reaches src/i18n.js which loads
+// locale JSON files that only exist after prebuild.
+jest.mock("../../../../i18n", () => ({}));
+
+describe("buildFolderTree", () => {
+    it("adds the current chat folder even when it has no files yet", () => {
+        const tree = buildFolderTree(
+            [
+                {
+                    name: "users/user-1/global/hash_report.pdf",
+                    filename: "report.pdf",
+                },
+            ],
+            "users/user-1/",
+            "chat-123",
+        );
+
+        /* eslint-disable testing-library/no-node-access -- tree is a plain JS object, not a DOM node */
+        expect(tree.children.global).toBeDefined();
+        expect(tree.children.chats).toBeDefined();
+        expect(tree.children.chats.children["chat-123"]).toEqual({
+            name: "chat-123",
+            children: {},
+            files: [],
+            path: "chats/chat-123",
+        });
+        expect(countFiles(tree.children.chats.children["chat-123"])).toBe(0);
+        /* eslint-enable testing-library/no-node-access */
+    });
+});
+
+describe("extractLegacyFilesFromMessages", () => {
+    it("recovers old URL-only chat attachments for the file manager", () => {
+        const files = extractLegacyFilesFromMessages(
+            [
+                {
+                    _id: "message-1",
+                    createdAt: "2026-04-26T10:00:00.000Z",
+                    payload: [
+                        JSON.stringify({
+                            type: "image_url",
+                            image_url: {
+                                url: "https://storage.example.blob.core.windows.net/cortexfiles-user-1/chats/chat-123/abc123_report.pdf?sv=old&sig=expired",
+                            },
+                        }),
+                    ],
+                },
+            ],
+            "chat-123",
+        );
+
+        expect(files).toHaveLength(1);
+        expect(files[0]).toEqual(
+            expect.objectContaining({
+                url: "https://storage.example.blob.core.windows.net/cortexfiles-user-1/chats/chat-123/abc123_report.pdf?sv=old&sig=expired",
+                blobPath: "chats/chat-123/abc123_report.pdf",
+                hash: "abc123",
+                filename: "abc123_report.pdf",
+                _legacyMessageFile: true,
+                _messageId: "message-1",
+            }),
+        );
+    });
+
+    it("ignores hidden placeholders", () => {
+        const files = extractLegacyFilesFromMessages([
+            {
+                payload: [
+                    JSON.stringify({
+                        type: "text",
+                        hideFromClient: true,
+                        isDeletedFile: true,
+                    }),
+                ],
+            },
+        ]);
+
+        expect(files).toEqual([]);
+    });
+});

--- a/src/components/common/UnifiedFileManager/index.js
+++ b/src/components/common/UnifiedFileManager/index.js
@@ -1,0 +1,1 @@
+export { default } from "./UnifiedFileManager";

--- a/src/components/common/UnifiedFileManager/useFolderNavigation.js
+++ b/src/components/common/UnifiedFileManager/useFolderNavigation.js
@@ -1,0 +1,144 @@
+"use client";
+
+import { useState, useCallback, useMemo, useEffect, useRef } from "react";
+
+/**
+ * Hook: manages folder navigation state — selected folder, expand/collapse, breadcrumb.
+ *
+ * @param {Object} options
+ * @param {Object} options.tree - The folder tree from useUnifiedFileData
+ * @param {string|null} options.chatId - If provided, auto-select chats/{chatId} on mount
+ * @param {string|undefined} options.defaultSelectedPath - Initial folder path; "" selects All Files
+ * @param {string|undefined} options.rootPathLabel - Optional label for the real root folder
+ * @param {string} options.allFilesPath - Path token for the recursive All Files view
+ * @returns {Object} Navigation state and actions
+ */
+export function useFolderNavigation({
+    tree,
+    chatId = null,
+    defaultSelectedPath,
+    rootPathLabel,
+    allFilesPath = "",
+}) {
+    // null means "choose a sensible default once data loads"; "" is the
+    // explicit "All Files" root, otherwise a path like "global" or "chats/abc123".
+    const [selectedPath, setSelectedPath] = useState(
+        defaultSelectedPath === undefined ? null : defaultSelectedPath,
+    );
+    const [expandedPaths, setExpandedPaths] = useState(new Set());
+    const initializedChatIdRef = useRef(null);
+
+    // Auto-expand and select chat folder on mount when chatId is provided
+    useEffect(() => {
+        if (!chatId || !tree || initializedChatIdRef.current === chatId) {
+            return;
+        }
+
+        const chatPath = `chats/${chatId}`;
+        // Check if the path exists in the tree
+        const hasChats = !!tree.children?.chats;
+        const hasChatFolder =
+            hasChats && !!tree.children.chats.children?.[chatId];
+
+        if (hasChatFolder) {
+            initializedChatIdRef.current = chatId;
+            setSelectedPath(chatPath);
+            setExpandedPaths((prev) => new Set([...prev, "chats", chatPath]));
+        } else if (hasChats) {
+            // Chat folder doesn't exist yet, but chats does — expand chats
+            setExpandedPaths((prev) => new Set([...prev, "chats"]));
+        }
+    }, [chatId, tree]);
+
+    // Default to a real folder instead of the recursive "All Files" root so
+    // the main pane starts scoped to one directory. Users can still click
+    // All Files explicitly when they want the cross-folder view.
+    useEffect(() => {
+        if (!tree || selectedPath !== null || chatId) return;
+        if (defaultSelectedPath !== undefined) {
+            setSelectedPath(defaultSelectedPath);
+            return;
+        }
+        const topLevelPaths = Object.keys(tree.children || {}).sort();
+        if (topLevelPaths.includes("global")) {
+            setSelectedPath("global");
+        } else {
+            setSelectedPath(topLevelPaths[0] || "");
+        }
+    }, [tree, selectedPath, chatId, defaultSelectedPath]);
+
+    // Auto-expand top-level folders on first load
+    useEffect(() => {
+        if (tree && expandedPaths.size === 0) {
+            const topLevelPaths = Object.keys(tree.children);
+            if (topLevelPaths.length > 0) {
+                setExpandedPaths(new Set(topLevelPaths));
+            }
+        }
+    }, [tree]); // eslint-disable-line react-hooks/exhaustive-deps
+
+    const selectFolder = useCallback((path) => {
+        setSelectedPath(path);
+    }, []);
+
+    const toggleExpanded = useCallback((path) => {
+        setExpandedPaths((prev) => {
+            const next = new Set(prev);
+            if (next.has(path)) {
+                next.delete(path);
+            } else {
+                next.add(path);
+            }
+            return next;
+        });
+    }, []);
+
+    const expandFolder = useCallback((path) => {
+        setExpandedPaths((prev) => {
+            if (prev.has(path)) return prev;
+            return new Set([...prev, path]);
+        });
+    }, []);
+
+    const isExpanded = useCallback(
+        (path) => expandedPaths.has(path),
+        [expandedPaths],
+    );
+
+    const isSelected = useCallback(
+        (path) => selectedPath === path,
+        [selectedPath],
+    );
+
+    /**
+     * Breadcrumb segments for the current path.
+     * Returns array of { label, path } from root to current.
+     */
+    const breadcrumbs = useMemo(() => {
+        if (selectedPath === allFilesPath) {
+            return [{ label: "All Files", path: allFilesPath }];
+        }
+
+        const crumbs = [{ label: rootPathLabel || "All Files", path: "" }];
+        if (!selectedPath) return crumbs;
+
+        const parts = selectedPath.split("/");
+        let currentPath = "";
+        for (const part of parts) {
+            currentPath = currentPath ? `${currentPath}/${part}` : part;
+            crumbs.push({ label: part, path: currentPath });
+        }
+        return crumbs;
+    }, [allFilesPath, rootPathLabel, selectedPath]);
+
+    return {
+        selectedPath,
+        expandedPaths,
+        selectFolder,
+        toggleExpanded,
+        expandFolder,
+        isExpanded,
+        isSelected,
+        breadcrumbs,
+    };
+}

--- a/src/components/common/UnifiedFileManager/useUnifiedFileData.js
+++ b/src/components/common/UnifiedFileManager/useUnifiedFileData.js
@@ -1,0 +1,592 @@
+"use client";
+
+import { useCallback, useMemo, useContext, useState } from "react";
+import {
+    useQuery,
+    useQueryClient,
+    keepPreviousData,
+} from "@tanstack/react-query";
+import { listUserFolder } from "@/src/utils/fileUploadUtils";
+import { AuthContext } from "@/src/App";
+
+function safeDecode(value) {
+    if (!value || typeof value !== "string") return value;
+    try {
+        return decodeURIComponent(value);
+    } catch {
+        return value;
+    }
+}
+
+function extractBlobPathFromUrl(url) {
+    try {
+        const urlObj = new URL(url);
+        const segments = urlObj.pathname.split("/").filter(Boolean);
+        const isAzurite =
+            urlObj.hostname === "127.0.0.1" || urlObj.hostname === "localhost";
+        const skip = isAzurite ? 2 : 1;
+        if (segments.length <= skip) return null;
+        return segments.slice(skip).map(safeDecode).join("/");
+    } catch {
+        return null;
+    }
+}
+
+function extractHashFromBlobPath(blobPath) {
+    const filename = blobPath?.split("/").pop();
+    if (!filename) return null;
+    const decoded = safeDecode(filename);
+    const idx = decoded.indexOf("_");
+    if (idx <= 0) return null;
+    const prefix = decoded.substring(0, idx);
+    return /^[0-9a-f]+$/i.test(prefix) ? prefix : null;
+}
+
+function getStableUrlKey(url) {
+    if (!url) return null;
+    try {
+        const urlObj = new URL(url);
+        return `${urlObj.origin}${urlObj.pathname}`;
+    } catch {
+        return url;
+    }
+}
+
+function getAttachmentUrl(fileObj) {
+    return (
+        fileObj?.converted?.url ||
+        fileObj?.url ||
+        fileObj?.image_url?.url ||
+        fileObj?.file ||
+        null
+    );
+}
+
+function getAttachmentFilename(fileObj, blobPath, url) {
+    const explicitName =
+        fileObj?.displayFilename ||
+        fileObj?.originalFilename ||
+        fileObj?.originalName ||
+        fileObj?.filename ||
+        null;
+
+    if (explicitName) return safeDecode(explicitName);
+    if (blobPath) return safeDecode(blobPath.split("/").pop());
+
+    try {
+        const urlObj = new URL(url);
+        const lastSegment = urlObj.pathname.split("/").filter(Boolean).pop();
+        if (lastSegment) return safeDecode(lastSegment);
+    } catch {
+        // ignore
+    }
+
+    return "file";
+}
+
+function readMessagePayloadItems(message) {
+    const payload = message?.payload || message?.content || [];
+    if (Array.isArray(payload)) return payload;
+    return payload ? [payload] : [];
+}
+
+function parsePayloadItem(item) {
+    if (!item) return null;
+    if (typeof item === "object") return item;
+    if (typeof item !== "string") return null;
+    try {
+        return JSON.parse(item);
+    } catch {
+        return null;
+    }
+}
+
+export function extractLegacyFilesFromMessages(messages = [], chatId = null) {
+    if (!Array.isArray(messages)) return [];
+
+    const files = [];
+    for (const message of messages) {
+        readMessagePayloadItems(message).forEach(
+            (payloadItem, payloadIndex) => {
+                const fileObj = parsePayloadItem(payloadItem);
+                if (
+                    !fileObj ||
+                    fileObj.hideFromClient ||
+                    (fileObj.type !== "image_url" && fileObj.type !== "file")
+                ) {
+                    return;
+                }
+
+                const url = getAttachmentUrl(fileObj);
+                const blobPath =
+                    fileObj.converted?.blobPath ||
+                    fileObj.blobPath ||
+                    extractBlobPathFromUrl(url);
+                const filename = getAttachmentFilename(fileObj, blobPath, url);
+                const hash =
+                    fileObj.converted?.hash ||
+                    fileObj.hash ||
+                    extractHashFromBlobPath(blobPath);
+
+                if (!url && !blobPath && !hash) {
+                    return;
+                }
+
+                files.push({
+                    ...fileObj,
+                    type: fileObj.type,
+                    url,
+                    image_url: fileObj.image_url,
+                    hash,
+                    blobPath,
+                    name:
+                        blobPath ||
+                        (chatId
+                            ? `chats/${chatId}/${filename}`
+                            : `legacy/${filename}`),
+                    filename,
+                    displayFilename: fileObj.displayFilename || filename,
+                    originalName: fileObj.originalName || filename,
+                    mimeType:
+                        fileObj.converted?.mimeType ||
+                        fileObj.mimeType ||
+                        fileObj.contentType,
+                    lastAccessed:
+                        message?.updatedAt ||
+                        message?.createdAt ||
+                        message?.timestamp ||
+                        null,
+                    _legacyMessageFile: true,
+                    _messageId: message?.id || message?._id || null,
+                    _payloadIndex: payloadIndex,
+                });
+            },
+        );
+    }
+
+    return files;
+}
+
+function getFileIdentityKeys(file) {
+    return [
+        file?.blobPath || file?.name || null,
+        file?.hash || null,
+        getStableUrlKey(file?.url || file?.image_url?.url || file?.file),
+    ].filter(Boolean);
+}
+
+function mergeFileSources(
+    listedFiles,
+    legacyFiles,
+    augmentedFiles,
+    hiddenKeys,
+) {
+    const merged = [];
+    const seen = new Set();
+    const mergedByKey = new Map();
+
+    const remember = (file) => {
+        const keys = getFileIdentityKeys(file);
+        keys.forEach((key) => mergedByKey.set(key, file));
+    };
+
+    const append = (file) => {
+        const keys = getFileIdentityKeys(file);
+        if (keys.some((key) => hiddenKeys?.has(key) || seen.has(key))) {
+            return;
+        }
+        keys.forEach((key) => seen.add(key));
+        merged.push(file);
+        remember(file);
+    };
+
+    listedFiles.forEach(append);
+    legacyFiles.forEach(append);
+
+    augmentedFiles.forEach((file) => {
+        const keys = getFileIdentityKeys(file);
+        if (keys.some((key) => hiddenKeys?.has(key))) {
+            return;
+        }
+        const existing = keys.map((key) => mergedByKey.get(key)).find(Boolean);
+        if (existing) {
+            Object.assign(existing, {
+                ...file,
+                name: existing.name || file.name,
+                blobPath: existing.blobPath || file.blobPath,
+                url: existing.url || file.url,
+                filename: file.filename || existing.filename,
+                displayFilename:
+                    file.displayFilename || existing.displayFilename,
+                mimeType: file.mimeType || existing.mimeType,
+                type: file.type || existing.type,
+                size: existing.size || file.size,
+                lastModified: existing.lastModified || file.lastModified,
+                lastAccessed: existing.lastAccessed || file.lastAccessed,
+            });
+            remember(existing);
+            return;
+        }
+        append(file);
+    });
+
+    return merged;
+}
+
+/**
+ * Build a folder tree from a flat file list.
+ * Files have `name` like "users/{userId}/global/{hash}_{filename}"
+ * We strip the user prefix and group by remaining path segments.
+ *
+ * Returns a tree where each node has { name, children: {}, files: [], path }
+ */
+function ensureFolderPath(tree, path) {
+    if (!path) return tree;
+
+    const parts = path.split("/").filter(Boolean);
+    let current = tree;
+    let currentPath = "";
+
+    for (const part of parts) {
+        currentPath = currentPath ? `${currentPath}/${part}` : part;
+        if (!current.children[part]) {
+            current.children[part] = {
+                name: part,
+                children: {},
+                files: [],
+                path: currentPath,
+            };
+        }
+        current = current.children[part];
+    }
+
+    return current;
+}
+
+export function buildFolderTree(files, userPrefix, currentChatId = null) {
+    const tree = { name: "/", children: {}, files: [], path: "" };
+
+    for (const file of files) {
+        let relativePath = file.name;
+        if (relativePath.startsWith(userPrefix)) {
+            relativePath = relativePath.slice(userPrefix.length);
+        }
+        if (relativePath.startsWith("/")) {
+            relativePath = relativePath.slice(1);
+        }
+
+        const parts = relativePath.split("/");
+        const fileName = parts.pop();
+
+        let current = tree;
+        let currentPath = "";
+        for (const part of parts) {
+            currentPath = currentPath ? `${currentPath}/${part}` : part;
+            if (!current.children[part]) {
+                current.children[part] = {
+                    name: part,
+                    children: {},
+                    files: [],
+                    path: currentPath,
+                };
+            }
+            current = current.children[part];
+        }
+
+        current.files.push({
+            ...file,
+            displayName: safeDecode(file.filename || fileName),
+        });
+    }
+
+    if (currentChatId) {
+        ensureFolderPath(tree, `chats/${currentChatId}`);
+    }
+
+    return tree;
+}
+
+/**
+ * Count total files in a tree node recursively.
+ */
+export function countFiles(node) {
+    let count = node.files.length;
+    for (const child of Object.values(node.children)) {
+        count += countFiles(child);
+    }
+    return count;
+}
+
+/**
+ * Collect all files from a node recursively.
+ */
+export function collectAllFiles(node) {
+    let result = [...node.files];
+    for (const child of Object.values(node.children)) {
+        result = result.concat(collectAllFiles(child));
+    }
+    return result;
+}
+
+/**
+ * Find a node in the tree by its path string (e.g. "chats/abc123").
+ */
+function findNodeByPath(tree, path) {
+    if (!path) return tree;
+    const parts = path.split("/");
+    let current = tree;
+    for (const part of parts) {
+        if (!current.children[part]) return null;
+        current = current.children[part];
+    }
+    return current;
+}
+
+const EMPTY_FOLDER = { folderPath: "", files: [] };
+const FILE_BROWSER_REFETCH_INTERVAL_MS = 30_000;
+
+function joinFolderAndFilename(folderPath, filename) {
+    const folder = String(folderPath || "").replace(/^\/+|\/+$/g, "");
+    return folder ? `${folder}/${filename}` : filename;
+}
+
+function getFilenameFromPath(path) {
+    return safeDecode(
+        String(path || "")
+            .split("/")
+            .filter(Boolean)
+            .pop(),
+    );
+}
+
+export function userFolderKey(userId) {
+    return ["userFolder", userId];
+}
+
+function storageTargetKey(storageTarget) {
+    if (!storageTarget) return "all";
+    return JSON.stringify(storageTarget);
+}
+
+/**
+ * Hook: loads all files from cloud storage, builds a folder tree, and provides
+ * path-based file retrieval.
+ *
+ * Backed by React Query with `staleTime: Infinity` so the file list is fetched
+ * once per user and reused across mounts — opening the file browser feels
+ * instant after the first load. Mutations write straight to the query cache
+ * so the UI stays in sync without refetching the full list.
+ *
+ * @param {Object} options
+ * @param {string} options.contextId - User context ID for listing
+ * @param {string|null} options.chatId - Current chat ID for synthetic empty chat folders
+ * @param {Function|null} options.filterFile - Optional predicate for hiding implementation files
+ * @returns {Object} { tree, allFiles, loading, error, reloadFiles, userPrefix, folderPath }
+ */
+export function useUnifiedFileData({
+    contextId,
+    chatId = null,
+    legacyMessages = [],
+    augmentedFiles = [],
+    storageTarget = null,
+    filterFile = null,
+}) {
+    const { user } = useContext(AuthContext);
+    const userId = user?.contextId || contextId;
+    const queryClient = useQueryClient();
+    const queryKey = useMemo(
+        () => [...userFolderKey(userId), storageTargetKey(storageTarget)],
+        [userId, storageTarget],
+    );
+    const [hiddenLegacyKeys, setHiddenLegacyKeys] = useState(() => new Set());
+
+    const { data, isLoading, error, refetch } = useQuery({
+        queryKey,
+        enabled: Boolean(userId),
+        staleTime: FILE_BROWSER_REFETCH_INTERVAL_MS,
+        gcTime: Infinity,
+        refetchInterval: FILE_BROWSER_REFETCH_INTERVAL_MS,
+        refetchIntervalInBackground: false,
+        refetchOnWindowFocus: true,
+        placeholderData: keepPreviousData,
+        queryFn: async () => {
+            const result = await listUserFolder(userId, { storageTarget });
+            return {
+                folderPath: result.folderPath || "",
+                files: (result.files || []).map((f) => ({
+                    ...f,
+                    blobPath: f.blobPath || f.name || null,
+                })),
+            };
+        },
+    });
+
+    const { folderPath, files } = data || EMPTY_FOLDER;
+
+    const userPrefix = useMemo(() => {
+        if (folderPath) {
+            return folderPath.endsWith("/") ? folderPath : `${folderPath}/`;
+        }
+        return `users/${userId}/`;
+    }, [folderPath, userId]);
+
+    const legacyFiles = useMemo(
+        () => extractLegacyFilesFromMessages(legacyMessages, chatId),
+        [legacyMessages, chatId],
+    );
+
+    const visibleFiles = useMemo(() => {
+        const mergedFiles = mergeFileSources(
+            files,
+            legacyFiles,
+            augmentedFiles,
+            hiddenLegacyKeys,
+        );
+
+        return typeof filterFile === "function"
+            ? mergedFiles.filter(filterFile)
+            : mergedFiles;
+    }, [files, legacyFiles, augmentedFiles, hiddenLegacyKeys, filterFile]);
+
+    const tree = useMemo(
+        () => buildFolderTree(visibleFiles, userPrefix, chatId),
+        [visibleFiles, userPrefix, chatId],
+    );
+
+    const getFilesForPath = useCallback(
+        (path) => {
+            if (!path && path !== "") return visibleFiles;
+            const node = findNodeByPath(tree, path);
+            if (!node) return [];
+            return node.files;
+        },
+        [tree, visibleFiles],
+    );
+
+    const getFilesRecursive = useCallback(
+        (path) => {
+            if (!path && path !== "") return visibleFiles;
+            if (path === "") return collectAllFiles(tree);
+            const node = findNodeByPath(tree, path);
+            if (!node) return [];
+            return collectAllFiles(node);
+        },
+        [tree, visibleFiles],
+    );
+
+    const updateFiles = useCallback(
+        (mapper) => {
+            queryClient.setQueryData(queryKey, (old) => {
+                const current = old || EMPTY_FOLDER;
+                return { ...current, files: mapper(current.files) };
+            });
+        },
+        [queryClient, queryKey],
+    );
+
+    const removeFileOptimistically = useCallback(
+        (file) => {
+            const keys = getFileIdentityKeys(file);
+            if (keys.length > 0) {
+                setHiddenLegacyKeys((prev) => {
+                    const next = new Set(prev);
+                    keys.forEach((key) => next.add(key));
+                    return next;
+                });
+            }
+            updateFiles((prev) => prev.filter((f) => f.name !== file.name));
+        },
+        [updateFiles],
+    );
+
+    const renameFileOptimistically = useCallback(
+        (file, newName) =>
+            updateFiles((prev) =>
+                prev.map((f) =>
+                    f.name === file.name ? { ...f, filename: newName } : f,
+                ),
+            ),
+        [updateFiles],
+    );
+
+    const moveFilesOptimistically = useCallback(
+        (filesToMove, targetFolder) => {
+            const filesArray = Array.isArray(filesToMove)
+                ? filesToMove
+                : [filesToMove];
+            const targetByName = new Map();
+
+            for (const file of filesArray) {
+                const currentName = file?.name || file?.blobPath;
+                if (!currentName) continue;
+                const filename = getFilenameFromPath(
+                    file?.filename || file?.displayFilename || currentName,
+                );
+                if (!filename) continue;
+                const relativeTarget = joinFolderAndFilename(
+                    targetFolder,
+                    filename,
+                );
+                const nextName = userPrefix
+                    ? `${userPrefix}${relativeTarget}`
+                    : relativeTarget;
+                targetByName.set(currentName, {
+                    nextName,
+                    filename,
+                });
+            }
+
+            if (targetByName.size === 0) return;
+
+            updateFiles((prev) =>
+                prev.map((file) => {
+                    const target = targetByName.get(file.name);
+                    if (!target) return file;
+                    return {
+                        ...file,
+                        name: target.nextName,
+                        blobPath: target.nextName,
+                        filename: target.filename,
+                        displayFilename:
+                            file.displayFilename || target.filename,
+                    };
+                }),
+            );
+        },
+        [updateFiles, userPrefix],
+    );
+
+    const getSnapshot = useCallback(
+        () => ({
+            data: queryClient.getQueryData(queryKey),
+            hiddenLegacyKeys: new Set(hiddenLegacyKeys),
+        }),
+        [queryClient, queryKey, hiddenLegacyKeys],
+    );
+
+    const revertToSnapshot = useCallback(
+        (snapshot) => {
+            queryClient.setQueryData(queryKey, snapshot?.data);
+            setHiddenLegacyKeys(snapshot?.hiddenLegacyKeys || new Set());
+        },
+        [queryClient, queryKey],
+    );
+
+    return {
+        tree,
+        allFiles: visibleFiles,
+        loading: isLoading,
+        error: error?.message || null,
+        reloadFiles: refetch,
+        userPrefix,
+        folderPath,
+        getFilesForPath,
+        getFilesRecursive,
+        removeFileOptimistically,
+        renameFileOptimistically,
+        moveFilesOptimistically,
+        getSnapshot,
+        revertToSnapshot,
+        totalFileCount: visibleFiles.length,
+    };
+}

--- a/src/components/common/fileIdUtils.js
+++ b/src/components/common/fileIdUtils.js
@@ -1,0 +1,25 @@
+import { getFilename as getFilenameFromUtils } from "@/src/utils/fileDownloadUtils";
+
+const fileIdMap = new WeakMap();
+let fileIdCounter = 0;
+
+export function createFileId(file) {
+    if (typeof file === "object" && file !== null) {
+        if (file.blobPath) return `bp-${file.blobPath}`;
+        if (file._id) return `id-${file._id}`;
+        if (file.hash) return `hash-${file.hash}`;
+        if (file.id) return `id-${file.id}`;
+        if (file.url) return `url-${file.url}`;
+
+        const existingId = fileIdMap.get(file);
+        if (existingId) return existingId;
+
+        const filename = getFilenameFromUtils(file) || "Unnamed file";
+        const size = file.size ?? file.bytes ?? "unknown";
+        const newId = `file-${filename}-${size}-${++fileIdCounter}`;
+        fileIdMap.set(file, newId);
+        return newId;
+    }
+
+    return `file-${getFilenameFromUtils(file) || "Unnamed file"}`;
+}

--- a/src/utils/__tests__/fileUploadUtils.test.js
+++ b/src/utils/__tests__/fileUploadUtils.test.js
@@ -1,0 +1,57 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { listUserFolder } from "../fileUploadUtils";
+import {
+    createAppletUserStorageTarget,
+    createWorkspacePrivateStorageTarget,
+} from "../storageTargets";
+
+global.fetch = jest.fn();
+
+describe("listUserFolder", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        global.fetch.mockResolvedValue({
+            ok: true,
+            json: async () => ({ files: [], count: 0 }),
+        });
+    });
+
+    it("serializes appletId for applet-user storage targets", async () => {
+        await listUserFolder("user-ctx-1", {
+            serverUrl: "http://localhost:3000/media-helper",
+            storageTarget: createAppletUserStorageTarget(
+                "user-ctx-1",
+                "applet-123",
+            ),
+        });
+
+        const [requestUrl] = global.fetch.mock.calls[0];
+        const url = new URL(requestUrl);
+
+        expect(url.pathname).toBe("/media-helper");
+        expect(url.searchParams.get("listFolder")).toBe("true");
+        expect(url.searchParams.get("userId")).toBe("user-ctx-1");
+        expect(url.searchParams.get("fileScope")).toBe("applet-user");
+        expect(url.searchParams.get("appletId")).toBe("applet-123");
+    });
+
+    it("serializes workspace-private targets with the legacy workspace scope name", async () => {
+        await listUserFolder("user-ctx-1", {
+            serverUrl: "http://localhost:3000/media-helper",
+            storageTarget: createWorkspacePrivateStorageTarget(
+                "user-ctx-1",
+                "workspace-123",
+            ),
+        });
+
+        const [requestUrl] = global.fetch.mock.calls[0];
+        const url = new URL(requestUrl);
+
+        expect(url.searchParams.get("userId")).toBe("user-ctx-1");
+        expect(url.searchParams.get("workspaceId")).toBe("workspace-123");
+        expect(url.searchParams.get("fileScope")).toBe("workspace-user-legacy");
+    });
+});

--- a/src/utils/fileAccessPlanUtils.js
+++ b/src/utils/fileAccessPlanUtils.js
@@ -1,0 +1,204 @@
+import { buildAppletUserContextId } from "./storageTargets.js";
+
+export const FILE_ACCESS_TARGET_KINDS = Object.freeze({
+    CHAT: "chat",
+    USER_FILES: "user-files",
+    USER_GLOBAL: "user-global",
+    APP_PRIVATE: "app-private",
+    APP_SHARED: "app-shared",
+});
+
+function createFileAccessTarget({
+    kind,
+    userContextId = null,
+    workspaceId = null,
+    appletId = null,
+    chatId = null,
+    contextKey = null,
+    write = false,
+}) {
+    return {
+        kind,
+        ...(userContextId ? { userContextId } : {}),
+        ...(workspaceId ? { workspaceId } : {}),
+        ...(appletId ? { appletId } : {}),
+        ...(chatId ? { chatId } : {}),
+        ...(contextKey ? { contextKey } : {}),
+        ...(write ? { write: true } : {}),
+    };
+}
+
+export function buildFileAccessPlan({
+    appletId = null,
+    workspaceId = null,
+    userContextId = null,
+    userContextKey = null,
+    workspaceContextKey = null,
+    chatId = null,
+    includeUserGlobal = true,
+    includeUserFiles = includeUserGlobal,
+}) {
+    const targets = [];
+
+    const addUserFilesReadTarget = () => {
+        if (!includeUserFiles || !userContextId) {
+            return;
+        }
+        targets.push(
+            createFileAccessTarget({
+                kind: FILE_ACCESS_TARGET_KINDS.USER_FILES,
+                userContextId,
+                contextKey: userContextKey,
+            }),
+        );
+    };
+
+    if (chatId && userContextId) {
+        targets.push(
+            createFileAccessTarget({
+                kind: FILE_ACCESS_TARGET_KINDS.CHAT,
+                userContextId,
+                chatId,
+                contextKey: userContextKey,
+                write: true,
+            }),
+        );
+
+        addUserFilesReadTarget();
+
+        if (includeUserGlobal && !includeUserFiles) {
+            targets.push(
+                createFileAccessTarget({
+                    kind: FILE_ACCESS_TARGET_KINDS.USER_GLOBAL,
+                    userContextId,
+                    contextKey: userContextKey,
+                }),
+            );
+        }
+
+        return targets;
+    }
+
+    if (appletId) {
+        if (!userContextId) {
+            return targets;
+        }
+
+        targets.push(
+            createFileAccessTarget({
+                kind: FILE_ACCESS_TARGET_KINDS.APP_PRIVATE,
+                userContextId,
+                workspaceId,
+                appletId,
+                contextKey: userContextKey,
+                write: true,
+            }),
+        );
+
+        targets.push(
+            createFileAccessTarget({
+                kind: FILE_ACCESS_TARGET_KINDS.APP_SHARED,
+                workspaceId,
+                appletId,
+                contextKey: workspaceContextKey,
+            }),
+        );
+
+        if (includeUserGlobal) {
+            if (includeUserFiles) {
+                addUserFilesReadTarget();
+            } else {
+                targets.push(
+                    createFileAccessTarget({
+                        kind: FILE_ACCESS_TARGET_KINDS.USER_GLOBAL,
+                        userContextId,
+                        contextKey: userContextKey,
+                    }),
+                );
+            }
+        }
+
+        return targets;
+    }
+
+    if (workspaceId) {
+        targets.push(
+            createFileAccessTarget({
+                kind: FILE_ACCESS_TARGET_KINDS.APP_SHARED,
+                workspaceId,
+                contextKey: workspaceContextKey,
+                write: true,
+            }),
+        );
+
+        if (includeUserGlobal && userContextId) {
+            if (includeUserFiles) {
+                addUserFilesReadTarget();
+            } else {
+                targets.push(
+                    createFileAccessTarget({
+                        kind: FILE_ACCESS_TARGET_KINDS.USER_GLOBAL,
+                        userContextId,
+                        contextKey: userContextKey,
+                    }),
+                );
+            }
+        }
+
+        return targets;
+    }
+
+    if (userContextId) {
+        targets.push(
+            createFileAccessTarget({
+                kind: FILE_ACCESS_TARGET_KINDS.USER_GLOBAL,
+                userContextId,
+                contextKey: userContextKey,
+                write: true,
+            }),
+        );
+    }
+
+    return targets;
+}
+
+export function buildRunContext({
+    appletId = null,
+    workspaceId = null,
+    workspaceContextKey = null,
+    userContextId = null,
+    userContextKey = null,
+}) {
+    if (appletId) {
+        if (!userContextId) {
+            return {
+                contextId: "",
+                contextKey: "",
+            };
+        }
+
+        return {
+            contextId: buildAppletUserContextId(userContextId, appletId),
+            contextKey: userContextKey || "",
+        };
+    }
+
+    if (workspaceId) {
+        return {
+            contextId: workspaceId,
+            contextKey: workspaceContextKey || "",
+        };
+    }
+
+    if (userContextId) {
+        return {
+            contextId: userContextId,
+            contextKey: userContextKey || "",
+        };
+    }
+
+    return {
+        contextId: "",
+        contextKey: "",
+    };
+}

--- a/src/utils/fileDownloadUtils.js
+++ b/src/utils/fileDownloadUtils.js
@@ -2,29 +2,122 @@
  * Utility functions for downloading files, including bulk ZIP downloads
  */
 
+/** Characters that are invalid in filenames (cross-platform). */
+// eslint-disable-next-line no-control-regex
+export const INVALID_FILENAME_CHARS = /[<>:"|?*\x00-\x1f]/;
+
 /**
  * Get file URL from a file object
  * Supports multiple file formats: media items, user files, etc.
  */
 export function getFileUrl(file) {
     if (typeof file === "string") return file;
-    return file?.azureUrl || file?.url || file?.gcs || null;
+    return file?.azureUrl || file?.url || null;
+}
+
+/**
+ * Strip blob hash prefix from a filename.
+ * Blob names are stored as "{hexHash}_{filename}" where hash is a hex string (xxHash64).
+ * Also extracts just the basename from any path.
+ */
+function stripBlobHash(filename) {
+    if (!filename) return filename;
+    // Extract just the filename from any path
+    const basename = filename.split("/").pop();
+    const idx = basename.indexOf("_");
+    if (idx > 0) {
+        const prefix = basename.substring(0, idx);
+        // Only strip if the prefix looks like a hex hash
+        if (/^[0-9a-f]+$/i.test(prefix)) {
+            return basename.substring(idx + 1);
+        }
+    }
+    return basename;
+}
+
+/**
+ * Wrap a blob storage URL through the image proxy for downloads.
+ * This ensures SAS token refresh on expiry and makes the URL same-origin
+ * so the anchor download attribute works.
+ */
+/**
+ * Check if a hostname belongs to a known blob storage domain.
+ */
+function isBlobStorageHost(hostname) {
+    return (
+        hostname.endsWith(".blob.core.windows.net") ||
+        hostname === "storage.googleapis.com" ||
+        hostname.endsWith(".storage.googleapis.com") ||
+        hostname === "storage.cloud.google.com" ||
+        hostname.endsWith(".storage.cloud.google.com") ||
+        hostname === "127.0.0.1" ||
+        hostname === "localhost"
+    );
+}
+
+/**
+ * Module-level cache: blob pathname → first proxy URL seen.
+ * Ensures the same blob always maps to the same proxy URL so the browser
+ * can cache the response long-term (proxy sets Cache-Control: immutable).
+ * SAS tokens rotate on each listing, but we lock in the first one seen
+ * per blob path so the browser URL stays stable across re-renders.
+ */
+const proxyUrlCache = new Map();
+
+/**
+ * Wrap a blob storage URL through the image proxy for downloads.
+ * This ensures SAS token refresh on expiry and makes the URL same-origin
+ * so the anchor download attribute works.
+ *
+ * Uses a per-pathname cache so that even when the SAS token changes between
+ * file listings, the proxy URL stays stable and the browser can serve from
+ * its HTTP cache (the proxy returns Cache-Control: immutable for 30 days).
+ */
+export function getDownloadUrl(url) {
+    if (!url) return url;
+    // Already proxied
+    if (url.includes("/api/image-proxy")) return url;
+    // Only proxy blob storage URLs
+    try {
+        const urlObj = new URL(url, window.location.origin);
+        if (isBlobStorageHost(urlObj.hostname)) {
+            // Use the pathname (without query params) as a stable cache key.
+            // This means the same blob path always returns the same proxy URL,
+            // even when the SAS token (query params) rotates between listings.
+            const cacheKey = urlObj.origin + urlObj.pathname;
+            const cached = proxyUrlCache.get(cacheKey);
+            if (cached) return cached;
+
+            const proxyUrl = `/api/image-proxy?url=${encodeURIComponent(url)}`;
+            proxyUrlCache.set(cacheKey, proxyUrl);
+            return proxyUrl;
+        }
+    } catch {
+        // not a valid URL, return as-is
+    }
+    return url;
 }
 
 /**
  * Get filename from a file object
  * Supports multiple file formats: media items, user files, etc.
+ * Returns the clean filename: URL-decoded and with blob hash prefix stripped.
  */
 export function getFilename(file) {
     if (typeof file === "string") return file;
-    return (
+    const raw =
         file?.displayFilename ||
         file?.originalName ||
         file?.filename ||
         file?.name ||
         file?.path ||
-        null
-    );
+        null;
+    if (!raw) return null;
+    try {
+        return stripBlobHash(decodeURIComponent(raw));
+    } catch {
+        return stripBlobHash(raw);
+    }
 }
 
 /**
@@ -40,8 +133,6 @@ export async function downloadFilesAsZip(files, options = {}) {
     const { onError, onProgress, filenamePrefix = "files_download" } = options;
 
     try {
-        console.log("Creating ZIP with", files.length, "files");
-
         // Extract URLs and filenames from files
         const fileData = files
             .map((file) => {
@@ -54,8 +145,6 @@ export async function downloadFilesAsZip(files, options = {}) {
         if (fileData.length === 0) {
             throw new Error("No valid URLs found");
         }
-
-        console.log("Requesting server-side ZIP creation...");
 
         // Notify that download is starting
         if (onProgress) {
@@ -85,10 +174,6 @@ export async function downloadFilesAsZip(files, options = {}) {
                 throw new Error("Server did not return a ZIP file");
             }
 
-            console.log(
-                "ZIP file received from server, initiating download...",
-            );
-
             // Create blob from response and trigger download
             const zipBlob = await response.blob();
             const link = document.createElement("a");
@@ -113,7 +198,6 @@ export async function downloadFilesAsZip(files, options = {}) {
 
             // Clean up the object URL
             URL.revokeObjectURL(link.href);
-            console.log("ZIP download initiated successfully");
         } finally {
             // Notify that download is complete
             if (onProgress) {
@@ -130,13 +214,12 @@ export async function downloadFilesAsZip(files, options = {}) {
             onError(error);
         } else {
             // Fallback to individual downloads if ZIP fails
-            console.log("Falling back to individual downloads...");
             files.forEach((file) => {
                 const url = getFileUrl(file);
                 if (url) {
                     const link = document.createElement("a");
-                    link.href = url;
-                    link.download = "";
+                    link.href = getDownloadUrl(url);
+                    link.download = getFilename(file) || "";
                     link.style.display = "none";
                     document.body.appendChild(link);
                     link.click();
@@ -144,7 +227,6 @@ export async function downloadFilesAsZip(files, options = {}) {
                 }
             });
         }
-        throw error;
     }
 }
 

--- a/src/utils/fileUploadUtils.js
+++ b/src/utils/fileUploadUtils.js
@@ -1,27 +1,124 @@
 import { hashMediaFile } from "./mediaUtils";
+import {
+    buildMediaHelperFileParams,
+    buildMediaHelperListParams,
+    getStorageContextId,
+} from "./storageTargets";
+
+/**
+ * Build folder-storage query/form params for file uploads.
+ * @param {string|null} userId - The user's contextId (used as userId)
+ * @param {string|null} chatId - The active chat ID (null for global scope)
+ * @param {Object} options - Additional routing options
+ * @param {string|null} options.workspaceId - Workspace ID for applet or workspace-artifact scope
+ * @param {string|null} options.fileScope - File scope override (default: derived from chatId)
+ * @returns {Object} Folder storage params
+ */
+export function buildFolderParams(
+    userIdOrStorageTarget,
+    chatId,
+    { workspaceId, fileScope, storageTarget, contextId } = {},
+) {
+    const target =
+        storageTarget ||
+        (typeof userIdOrStorageTarget === "object" &&
+        userIdOrStorageTarget !== null
+            ? userIdOrStorageTarget
+            : null);
+
+    return buildMediaHelperFileParams({
+        storageTarget: target,
+        userId: target ? null : userIdOrStorageTarget,
+        chatId,
+        workspaceId,
+        fileScope,
+        contextId,
+    });
+}
+
+/**
+ * List all files in a user's folder storage tree.
+ * Returns flat array of file objects with full blob paths.
+ * @param {string} userId - The user's contextId (used as userId)
+ * @param {Object} options - Options
+ * @param {string} options.serverUrl - Server URL (default: "/media-helper")
+ * @param {string} options.fileScope - Scope filter: 'all', 'global', 'chat', 'workspace' (default: 'all')
+ * @param {string} options.chatId - Chat ID (required when fileScope='chat')
+ * @returns {Promise<{folderPath: string, files: Array, count: number}>}
+ */
+export async function listUserFolder(userId, options = {}) {
+    const {
+        serverUrl = "/media-helper",
+        storageTarget = null,
+        fileScope = "all",
+        chatId = null,
+        workspaceId = null,
+        appletId = null,
+    } = options;
+    const listParams = buildMediaHelperListParams({
+        storageTarget,
+        userContextId: userId,
+        contextId: userId,
+        fileScope,
+        chatId,
+        workspaceId,
+        appletId,
+    });
+
+    const url = new URL(serverUrl, window.location.origin);
+    url.searchParams.set("listFolder", "true");
+    if (listParams.userId) {
+        url.searchParams.set("userId", listParams.userId);
+    }
+    if (listParams.fileScope) {
+        url.searchParams.set("fileScope", listParams.fileScope);
+    }
+    if (listParams.chatId) {
+        url.searchParams.set("chatId", listParams.chatId);
+    }
+    if (listParams.workspaceId) {
+        url.searchParams.set("workspaceId", listParams.workspaceId);
+    }
+    if (listParams.appletId) {
+        url.searchParams.set("appletId", listParams.appletId);
+    }
+
+    const response = await fetch(url.toString());
+    if (!response.ok) {
+        throw new Error(`Failed to list folder: ${response.statusText}`);
+    }
+    return response.json();
+}
 
 /**
  * Check if a file exists by hash
  * @param {string} fileHash - The file hash
  * @param {Object} options - Options
  * @param {string} options.contextId - Optional contextId for file scoping
+ * @param {string} options.userId - Optional userId for folder-based storage
+ * @param {string} options.chatId - Optional chatId for chat-scoped storage
+ * @param {string} options.fileScope - Optional file scope ('chat' or 'global')
  * @param {string} options.serverUrl - Server URL (default: "/media-helper")
  * @param {AbortSignal} options.signal - Optional abort signal
  * @returns {Promise<Object|null>} File data if exists, null otherwise
  */
 export async function checkFileByHash(fileHash, options = {}) {
     const {
-        contextId = null,
+        storageTarget = null,
         serverUrl = "/media-helper",
         signal = null,
     } = options;
+    const routingParams = buildMediaHelperFileParams({
+        storageTarget,
+        ...options,
+    });
 
     try {
         const checkUrl = new URL(serverUrl, window.location.origin);
         checkUrl.searchParams.set("hash", fileHash);
         checkUrl.searchParams.set("checkHash", "true");
-        if (contextId) {
-            checkUrl.searchParams.set("contextId", contextId);
+        for (const [key, value] of Object.entries(routingParams)) {
+            checkUrl.searchParams.set(key, value);
         }
 
         const checkResponse = await fetch(checkUrl.toString(), {
@@ -51,28 +148,85 @@ export async function checkFileByHash(fileHash, options = {}) {
     return null;
 }
 
+export async function checkFileByBlobPath(blobPath, options = {}) {
+    if (!blobPath) return null;
+
+    const {
+        storageTarget = null,
+        serverUrl = "/media-helper",
+        signal = null,
+    } = options;
+    const routingParams = buildMediaHelperFileParams({
+        storageTarget,
+        ...options,
+    });
+
+    try {
+        const checkUrl = new URL(serverUrl, window.location.origin);
+        checkUrl.searchParams.set("blobPath", blobPath);
+        for (const [key, value] of Object.entries(routingParams)) {
+            checkUrl.searchParams.set(key, value);
+        }
+
+        const checkResponse = await fetch(checkUrl.toString(), {
+            signal,
+        });
+
+        if (checkResponse.ok) {
+            const data = await checkResponse.json().catch(() => null);
+            if (data && data.url) {
+                return data;
+            }
+        }
+    } catch (error) {
+        if (error.name === "AbortError") {
+            throw error;
+        }
+        if (error.response?.status !== 404) {
+            console.error("Error checking file blob path:", error);
+        }
+    }
+
+    return null;
+}
+
 /**
  * Upload a file to the media helper service
  * @param {File} file - The file to upload
  * @param {Object} options - Upload options
- * @param {string} options.contextId - Optional contextId for file scoping
+ * @param {string} options.userId - Optional userId for folder-based storage
+ * @param {string} options.chatId - Optional chatId for chat-scoped storage
+ * @param {string} options.workspaceId - Optional workspaceId for workspace-scoped storage
+ * @param {string} options.fileScope - Optional file scope ('chat' or 'global')
  * @param {boolean} options.checkHash - Whether to check if file exists by hash first (default: true)
  * @param {Function} options.onProgress - Progress callback (percentage: number) => void
  * @param {AbortSignal} options.signal - Optional abort signal
  * @param {string} options.serverUrl - Server URL (default: "/media-helper")
  * @param {Function} options.getXHR - Optional callback to get the XHR object for custom handling
- * @returns {Promise<Object>} Upload result with url, gcs, hash, converted, displayFilename, etc.
+ * @returns {Promise<Object>} Upload result with url, hash, converted, displayFilename, etc.
  * @throws {Error} If upload fails
  */
 export async function uploadFileToMediaHelper(file, options = {}) {
     const {
-        contextId = null,
+        storageTarget = null,
         checkHash = true,
         onProgress = null,
         signal = null,
         serverUrl = "/media-helper",
         getXHR = null,
+        subPath = null,
     } = options;
+    const routingParams = buildMediaHelperFileParams({
+        storageTarget,
+        ...options,
+    });
+    const targetContextId =
+        storageTarget || routingParams.fileScope
+            ? getStorageContextId({
+                  storageTarget,
+                  ...options,
+              })
+            : options.contextId;
 
     // Generate file hash
     const fileHash = await hashMediaFile(file);
@@ -80,7 +234,8 @@ export async function uploadFileToMediaHelper(file, options = {}) {
     // Check if file already exists by hash
     if (checkHash) {
         const existingFile = await checkFileByHash(fileHash, {
-            contextId,
+            storageTarget,
+            ...routingParams,
             serverUrl,
             signal,
         });
@@ -90,18 +245,27 @@ export async function uploadFileToMediaHelper(file, options = {}) {
     }
 
     // File doesn't exist or hash check disabled, proceed with upload
+    // IMPORTANT: Append metadata fields BEFORE the file.
+    // Busboy processes multipart parts in order, so fields must come first
+    // to be available when the file event fires in the handler.
     const formData = new FormData();
     formData.append("hash", fileHash);
-    formData.append("file", file, file.name);
-    if (contextId) {
-        formData.append("contextId", contextId);
+    if (targetContextId) {
+        formData.append("contextId", targetContextId);
     }
+    // Folder-based storage fields
+    for (const [key, value] of Object.entries(routingParams)) {
+        if (key === "contextId") continue;
+        formData.append(key, value);
+    }
+    if (subPath) {
+        formData.append("subPath", subPath);
+    }
+    // File stream must be last so busboy field events fire first
+    formData.append("file", file, file.name);
 
     const uploadUrl = new URL(serverUrl, window.location.origin);
     uploadUrl.searchParams.set("hash", fileHash);
-    if (contextId) {
-        uploadUrl.searchParams.set("contextId", contextId);
-    }
 
     return new Promise((resolve, reject) => {
         const xhr = new XMLHttpRequest();
@@ -112,11 +276,13 @@ export async function uploadFileToMediaHelper(file, options = {}) {
         }
 
         // Handle abort signal
+        let abortHandler;
         if (signal) {
-            signal.addEventListener("abort", () => {
+            abortHandler = () => {
                 xhr.abort();
                 reject(new Error("Upload aborted"));
-            });
+            };
+            signal.addEventListener("abort", abortHandler);
         }
 
         // Monitor upload progress
@@ -133,8 +299,15 @@ export async function uploadFileToMediaHelper(file, options = {}) {
             };
         }
 
+        const cleanup = () => {
+            if (signal && abortHandler) {
+                signal.removeEventListener("abort", abortHandler);
+            }
+        };
+
         // Handle upload response
         xhr.onload = () => {
+            cleanup();
             if (xhr.status === 200) {
                 try {
                     const data = JSON.parse(xhr.responseText);
@@ -160,11 +333,13 @@ export async function uploadFileToMediaHelper(file, options = {}) {
 
         // Handle upload errors
         xhr.onerror = () => {
+            cleanup();
             reject(new Error("File upload failed"));
         };
 
         // Handle abort
         xhr.onabort = () => {
+            cleanup();
             reject(new Error("Upload aborted"));
         };
 

--- a/src/utils/storageTargets.js
+++ b/src/utils/storageTargets.js
@@ -1,0 +1,346 @@
+export const STORAGE_TARGET_KINDS = Object.freeze({
+    USER_GLOBAL: "user-global",
+    MEDIA: "media",
+    CHAT: "chat",
+    APPLET_USER: "applet-user",
+    APPLET_SHARED: "applet-shared",
+    APPLET_GLOBAL: "applet-global",
+    APPLET_PUBLISHED: "applet-published",
+    WORKSPACE_PRIVATE: "workspace-private",
+    WORKSPACE_SHARED: "workspace-shared",
+    PROFILE: "profile",
+    ARTICLE: "article",
+    SKILL: "skill",
+    AUTOMATION: "automation",
+});
+
+const USER_SCOPED_KINDS = new Set([
+    STORAGE_TARGET_KINDS.USER_GLOBAL,
+    STORAGE_TARGET_KINDS.MEDIA,
+    STORAGE_TARGET_KINDS.CHAT,
+    STORAGE_TARGET_KINDS.APPLET_USER,
+    STORAGE_TARGET_KINDS.APPLET_GLOBAL,
+    STORAGE_TARGET_KINDS.WORKSPACE_PRIVATE,
+    STORAGE_TARGET_KINDS.PROFILE,
+    STORAGE_TARGET_KINDS.ARTICLE,
+    STORAGE_TARGET_KINDS.SKILL,
+    STORAGE_TARGET_KINDS.AUTOMATION,
+]);
+
+const APPLET_SCOPED_KINDS = new Set([
+    STORAGE_TARGET_KINDS.APPLET_USER,
+    STORAGE_TARGET_KINDS.APPLET_SHARED,
+]);
+
+const FILE_SCOPE_BY_KIND = Object.freeze({
+    [STORAGE_TARGET_KINDS.USER_GLOBAL]: "global",
+    [STORAGE_TARGET_KINDS.MEDIA]: "media",
+    [STORAGE_TARGET_KINDS.CHAT]: "chat",
+    [STORAGE_TARGET_KINDS.APPLET_USER]: "applet-user",
+    [STORAGE_TARGET_KINDS.APPLET_SHARED]: "applet-shared",
+    [STORAGE_TARGET_KINDS.APPLET_GLOBAL]: "applets",
+    [STORAGE_TARGET_KINDS.APPLET_PUBLISHED]: "applets",
+    [STORAGE_TARGET_KINDS.WORKSPACE_PRIVATE]: "workspace-user-legacy",
+    [STORAGE_TARGET_KINDS.WORKSPACE_SHARED]: "workspace-shared-legacy",
+    [STORAGE_TARGET_KINDS.PROFILE]: "profile",
+    [STORAGE_TARGET_KINDS.ARTICLE]: "articles",
+    [STORAGE_TARGET_KINDS.SKILL]: "skills",
+    [STORAGE_TARGET_KINDS.AUTOMATION]: "automations",
+});
+
+function cleanObject(object) {
+    return Object.fromEntries(
+        Object.entries(object).filter(
+            ([, value]) => value != null && value !== "",
+        ),
+    );
+}
+
+function toNullableString(value) {
+    return value == null || value === "" ? null : String(value);
+}
+
+export function buildAppletUserContextId(userContextId, appletId) {
+    const resolvedUserContextId = toNullableString(userContextId);
+    const resolvedAppletId = toNullableString(appletId);
+    if (!resolvedUserContextId || !resolvedAppletId) {
+        return null;
+    }
+    return `applet-user:${resolvedAppletId}:${resolvedUserContextId}`;
+}
+
+export function buildAppletSharedContextId(appletId) {
+    const resolvedAppletId = toNullableString(appletId);
+    if (!resolvedAppletId) {
+        return null;
+    }
+    return `applet-shared:${resolvedAppletId}`;
+}
+
+function inferStorageTargetKind({
+    kind = null,
+    fileScope = null,
+    chatId = null,
+    workspaceId = null,
+    appletId = null,
+    isArtifact = false,
+} = {}) {
+    if (kind) {
+        return kind;
+    }
+
+    if (fileScope === "applet-user") {
+        return STORAGE_TARGET_KINDS.APPLET_USER;
+    }
+    if (fileScope === "applet-shared") {
+        return STORAGE_TARGET_KINDS.APPLET_SHARED;
+    }
+    if (
+        fileScope === "workspace-shared-legacy" ||
+        (isArtifact && workspaceId)
+    ) {
+        return STORAGE_TARGET_KINDS.WORKSPACE_SHARED;
+    }
+    if (fileScope === "workspace-user-legacy") {
+        return STORAGE_TARGET_KINDS.WORKSPACE_PRIVATE;
+    }
+    if (fileScope === "chat" || chatId) {
+        return STORAGE_TARGET_KINDS.CHAT;
+    }
+    if (fileScope === "media") {
+        return STORAGE_TARGET_KINDS.MEDIA;
+    }
+    if (fileScope === "profile") {
+        return STORAGE_TARGET_KINDS.PROFILE;
+    }
+    if (fileScope === "articles") {
+        return STORAGE_TARGET_KINDS.ARTICLE;
+    }
+    if (fileScope === "applets") {
+        return STORAGE_TARGET_KINDS.APPLET_GLOBAL;
+    }
+    if (appletId && isArtifact) {
+        return STORAGE_TARGET_KINDS.APPLET_SHARED;
+    }
+    if (appletId) {
+        return STORAGE_TARGET_KINDS.APPLET_USER;
+    }
+    if (fileScope === "skills") {
+        return STORAGE_TARGET_KINDS.SKILL;
+    }
+    if (fileScope === "automations") {
+        return STORAGE_TARGET_KINDS.AUTOMATION;
+    }
+    if (workspaceId) {
+        return STORAGE_TARGET_KINDS.WORKSPACE_PRIVATE;
+    }
+
+    return STORAGE_TARGET_KINDS.USER_GLOBAL;
+}
+
+export function createStorageTarget(kind, options = {}) {
+    return cleanObject({
+        kind,
+        contextId: options.contextId,
+        userContextId: options.userContextId,
+        workspaceId: options.workspaceId,
+        appletId: options.appletId,
+        chatId: options.chatId,
+    });
+}
+
+export function createUserGlobalStorageTarget(userContextId) {
+    return createStorageTarget(STORAGE_TARGET_KINDS.USER_GLOBAL, {
+        userContextId,
+    });
+}
+
+export function createChatStorageTarget(userContextId, chatId) {
+    return createStorageTarget(STORAGE_TARGET_KINDS.CHAT, {
+        userContextId,
+        chatId,
+    });
+}
+
+export function createAppletUserStorageTarget(userContextId, appletId) {
+    return createStorageTarget(STORAGE_TARGET_KINDS.APPLET_USER, {
+        userContextId,
+        appletId,
+    });
+}
+
+export function createAppletSharedStorageTarget(appletId) {
+    return createStorageTarget(STORAGE_TARGET_KINDS.APPLET_SHARED, {
+        appletId,
+    });
+}
+
+export function createMediaStorageTarget(userContextId) {
+    return createStorageTarget(STORAGE_TARGET_KINDS.MEDIA, {
+        userContextId,
+    });
+}
+
+export function createWorkspacePrivateStorageTarget(
+    userContextId,
+    workspaceId,
+) {
+    return createStorageTarget(STORAGE_TARGET_KINDS.WORKSPACE_PRIVATE, {
+        userContextId,
+        workspaceId,
+    });
+}
+
+export function createWorkspaceSharedStorageTarget(workspaceId) {
+    return createStorageTarget(STORAGE_TARGET_KINDS.WORKSPACE_SHARED, {
+        workspaceId,
+    });
+}
+
+export function createProfileStorageTarget(userContextId) {
+    return createStorageTarget(STORAGE_TARGET_KINDS.PROFILE, {
+        userContextId,
+    });
+}
+
+export function createArticleStorageTarget(userContextId) {
+    return createStorageTarget(STORAGE_TARGET_KINDS.ARTICLE, {
+        userContextId,
+    });
+}
+
+export function createAppletGlobalStorageTarget(userContextId) {
+    return createStorageTarget(STORAGE_TARGET_KINDS.APPLET_GLOBAL, {
+        userContextId,
+    });
+}
+
+export function createAppletPublishedStorageTarget(contextId = null) {
+    return createStorageTarget(STORAGE_TARGET_KINDS.APPLET_PUBLISHED, {
+        contextId,
+    });
+}
+
+export function createSkillStorageTarget(userContextId) {
+    return createStorageTarget(STORAGE_TARGET_KINDS.SKILL, {
+        userContextId,
+    });
+}
+
+export function createAutomationStorageTarget(userContextId) {
+    return createStorageTarget(STORAGE_TARGET_KINDS.AUTOMATION, {
+        userContextId,
+    });
+}
+export function resolveStorageTarget(input = {}) {
+    const target = input.storageTarget || input.target || input;
+    const kind = inferStorageTargetKind({
+        kind: target.kind ?? input.kind,
+        fileScope: target.fileScope ?? input.fileScope,
+        chatId: target.chatId ?? input.chatId,
+        workspaceId: target.workspaceId ?? input.workspaceId,
+        appletId: target.appletId ?? input.appletId,
+        isArtifact: target.isArtifact ?? input.isArtifact,
+    });
+
+    const userContextIdHint =
+        target.userContextId ??
+        target.userId ??
+        input.userContextId ??
+        input.userId;
+    const contextIdHint = target.contextId ?? input.contextId;
+    const workspaceIdHint =
+        target.workspaceId ??
+        input.workspaceId ??
+        (kind === STORAGE_TARGET_KINDS.WORKSPACE_SHARED ? contextIdHint : null);
+    const appletIdHint =
+        target.appletId ??
+        input.appletId ??
+        (APPLET_SCOPED_KINDS.has(kind) ? workspaceIdHint : null);
+    const chatIdHint = target.chatId ?? input.chatId;
+
+    const userContextId = USER_SCOPED_KINDS.has(kind)
+        ? toNullableString(userContextIdHint ?? contextIdHint)
+        : null;
+    const workspaceId = toNullableString(workspaceIdHint);
+    const appletId = APPLET_SCOPED_KINDS.has(kind)
+        ? toNullableString(appletIdHint)
+        : null;
+    const chatId =
+        kind === STORAGE_TARGET_KINDS.CHAT
+            ? toNullableString(chatIdHint)
+            : null;
+    const fileScope = FILE_SCOPE_BY_KIND[kind] || "global";
+    let resolvedContextId = userContextId;
+    if (kind === STORAGE_TARGET_KINDS.WORKSPACE_SHARED) {
+        resolvedContextId = workspaceId;
+    } else if (kind === STORAGE_TARGET_KINDS.APPLET_USER) {
+        resolvedContextId = buildAppletUserContextId(userContextId, appletId);
+    } else if (kind === STORAGE_TARGET_KINDS.APPLET_SHARED) {
+        resolvedContextId = buildAppletSharedContextId(appletId);
+    } else if (kind === STORAGE_TARGET_KINDS.APPLET_PUBLISHED) {
+        resolvedContextId =
+            toNullableString(contextIdHint) ||
+            toNullableString(
+                typeof process !== "undefined"
+                    ? process.env.CONCIERGE_PUBLISHED_APPLETS_CONTEXT_ID
+                    : null,
+            ) ||
+            "concierge-published-applets";
+    }
+
+    return {
+        kind,
+        userContextId,
+        workspaceId,
+        appletId,
+        chatId,
+        fileScope,
+        contextId: resolvedContextId,
+    };
+}
+
+export function getStorageContextId(input = {}) {
+    return resolveStorageTarget(input).contextId;
+}
+
+export function buildMediaHelperFileParams(input = {}) {
+    const resolved = resolveStorageTarget(input);
+    return cleanObject({
+        contextId: resolved.contextId,
+        userId: resolved.userContextId,
+        workspaceId: resolved.workspaceId,
+        appletId: resolved.appletId,
+        chatId: resolved.chatId,
+        fileScope: resolved.fileScope,
+    });
+}
+
+export function buildMediaHelperListParams({
+    storageTarget = null,
+    userContextId = null,
+    contextId = null,
+    fileScope = "all",
+    workspaceId = null,
+    appletId = null,
+    chatId = null,
+} = {}) {
+    if (storageTarget) {
+        const resolved = resolveStorageTarget({ storageTarget });
+        return cleanObject({
+            userId: resolved.userContextId || resolved.contextId,
+            fileScope: resolved.fileScope,
+            workspaceId: resolved.workspaceId,
+            appletId: resolved.appletId,
+            chatId: resolved.chatId,
+        });
+    }
+
+    return cleanObject({
+        userId: toNullableString(userContextId ?? contextId),
+        fileScope,
+        workspaceId: toNullableString(workspaceId),
+        appletId: toNullableString(appletId),
+        chatId: toNullableString(chatId),
+    });
+}


### PR DESCRIPTION
## Summary
- port unified file manager UI, media thumbnails, folder navigation, and file selection tests
- add scoped storage target utilities plus workspace/applet/user file routing helpers
- update upload, delete, rename, URL check, refresh, and LLM file handling paths for scoped file access
- keep legacy Concierge helpers exported where existing routes still depend on them

## Validation
- npm test -- app/api/utils/__tests__/llm-file-utils.test.js app/api/__tests__/streamingUploadIntegration.test.js -- --runInBand --silent --openHandlesTimeout=1000
- npm test -- --runInBand --silent --openHandlesTimeout=1000
- npm run build
- git diff --check concierge-upstream-audit
- changed-file brand/sensitive scan against concierge-upstream-audit

## Stacking
Draft stacked on #13 / concierge-upstream-audit. Rebase this onto main after #13 merges, rerun the full validation, then make it review-ready.