### PR TITLE
Add Concierge applet backend and SDK APIs

### DIFF
--- a/app/api/__tests__/appletFileContent.test.js
+++ b/app/api/__tests__/appletFileContent.test.js
@@ -59,6 +59,25 @@ jest.mock("../utils/auth", () => ({
     getCurrentUser: jest.fn(),
 }));
 
+jest.mock("../utils/file-resolution-utils", () => ({
+    resolveAndHealFile: jest.fn(),
+}));
+
+jest.mock("../../../src/utils/storageTargets", () => ({
+    createAppletUserStorageTarget: jest.fn((userContextId, appletId) => ({
+        kind: "applet-user",
+        userContextId,
+        appletId,
+    })),
+    createWorkspacePrivateStorageTarget: jest.fn(
+        (userContextId, workspaceId) => ({
+            kind: "workspace-private",
+            userContextId,
+            workspaceId,
+        }),
+    ),
+}));
+
 jest.mock("../models/applet-file", () => {
     const mockFindOne = jest.fn().mockReturnValue({
         populate: jest.fn(),
@@ -71,6 +90,13 @@ jest.mock("../models/applet-file", () => {
         findOne: mockFindOne, // Also export directly for require() compatibility
     };
 });
+
+jest.mock("../models/file", () => ({
+    __esModule: true,
+    default: {
+        findByIdAndUpdate: jest.fn(),
+    },
+}));
 
 jest.mock("../workspaces/[id]/db", () => ({
     getWorkspace: jest.fn(),
@@ -102,6 +128,7 @@ describe("Applet File Content Endpoint", () => {
 
         mockUser = {
             _id: "user123",
+            contextId: "ctx123",
             toString: () => "user123",
         };
 
@@ -128,6 +155,15 @@ describe("Applet File Content Endpoint", () => {
         // Setup mocks
         const { getCurrentUser } = require("../utils/auth");
         getCurrentUser.mockResolvedValue(mockUser);
+
+        const {
+            resolveAndHealFile,
+        } = require("../utils/file-resolution-utils");
+        resolveAndHealFile.mockResolvedValue({
+            file: mockFile,
+            accessUrl: mockFile.url,
+            status: "resolved",
+        });
 
         const { getWorkspace } = require("../workspaces/[id]/db");
         getWorkspace.mockResolvedValue(mockWorkspace);
@@ -171,7 +207,7 @@ describe("Applet File Content Endpoint", () => {
                 params,
             });
 
-            // Verify fetch was called with the Azure URL
+            // Verify fetch was called with the resolved storage URL
             expect(global.fetch).toHaveBeenCalledWith(mockFile.url, {
                 redirect: "follow",
             });
@@ -203,6 +239,48 @@ describe("Applet File Content Endpoint", () => {
             expect(headers["Access-Control-Allow-Methods"]).toBe("GET");
             expect(headers["Content-Disposition"]).toContain("test-file.jpg");
             expect(headers["Cache-Control"]).toBe("public, max-age=3600");
+        });
+
+        test("should pass the legacy workspace-private fallback target", async () => {
+            const {
+                createAppletUserStorageTarget,
+                createWorkspacePrivateStorageTarget,
+            } = require("../../../src/utils/storageTargets");
+            const {
+                resolveAndHealFile,
+            } = require("../utils/file-resolution-utils");
+
+            await appletFileContentGet(
+                { url: "https://example.com" },
+                { params: { id: "workspace123", fileId: "file123" } },
+            );
+
+            expect(createAppletUserStorageTarget).toHaveBeenCalledWith(
+                "ctx123",
+                "applet123",
+            );
+            expect(createWorkspacePrivateStorageTarget).toHaveBeenCalledWith(
+                "ctx123",
+                "workspace123",
+            );
+            expect(resolveAndHealFile).toHaveBeenCalledWith(
+                mockFile,
+                expect.objectContaining({
+                    storageTarget: expect.objectContaining({
+                        kind: "applet-user",
+                        userContextId: "ctx123",
+                        appletId: "applet123",
+                    }),
+                    fallbackStorageTargets: [
+                        expect.objectContaining({
+                            kind: "workspace-private",
+                            userContextId: "ctx123",
+                            workspaceId: "workspace123",
+                        }),
+                    ],
+                    allowUrlRefresh: true,
+                }),
+            );
         });
 
         test("should use mimeType from file when Azure doesn't provide content-type", async () => {
@@ -410,6 +488,33 @@ describe("Applet File Content Endpoint", () => {
 
             expect(response.status).toBe(404);
             expect(response.error).toBe("Failed to fetch file from storage");
+        });
+
+        test("should return 404 when resolver cannot recover the file", async () => {
+            const {
+                resolveAndHealFile,
+            } = require("../utils/file-resolution-utils");
+            resolveAndHealFile.mockResolvedValueOnce({
+                file: mockFile,
+                accessUrl: null,
+                status: "unresolved",
+            });
+
+            const mockRequest = {
+                url: "https://example.com",
+            };
+            const params = {
+                id: "workspace123",
+                fileId: "file123",
+            };
+
+            const response = await appletFileContentGet(mockRequest, {
+                params,
+            });
+
+            expect(response.status).toBe(404);
+            expect(response.error).toBe("Failed to resolve file from storage");
+            expect(global.fetch).not.toHaveBeenCalled();
         });
 
         test("should handle Azure fetch server error", async () => {

--- a/app/api/applet/__tests__/service-token.test.js
+++ b/app/api/applet/__tests__/service-token.test.js
@@ -1,0 +1,132 @@
+/**
+ * @jest-environment node
+ */
+
+/* eslint-disable import/first */
+
+jest.mock("../../utils/auth.js", () => ({
+    getCurrentUser: jest.fn(),
+}));
+
+jest.mock("../access.js", () => ({
+    validateAppletAccess: jest.fn(() => null),
+}));
+
+jest.mock("../../models/applet.js", () => ({
+    __esModule: true,
+    default: {
+        findById: jest.fn(() => ({
+            select: jest.fn().mockReturnValue({
+                lean: jest.fn().mockResolvedValue(null),
+            }),
+        })),
+        updateOne: jest.fn(),
+    },
+}));
+
+import { POST } from "../service-token/route.js";
+import { getCurrentUser } from "../../utils/auth.js";
+
+function makeRequest(body) {
+    return {
+        json: jest.fn().mockResolvedValue(body),
+    };
+}
+
+function makeUser(mcpServers) {
+    return {
+        _id: "user-1",
+        mcpServers,
+        markModified: jest.fn(),
+        save: jest.fn().mockResolvedValue(true),
+    };
+}
+
+describe("POST /api/applet/service-token", () => {
+    const originalFetch = global.fetch;
+    const originalEnv = process.env;
+
+    beforeEach(() => {
+        jest.spyOn(console, "log").mockImplementation(() => {});
+        jest.spyOn(console, "warn").mockImplementation(() => {});
+        jest.spyOn(console, "error").mockImplementation(() => {});
+        process.env = {
+            ...originalEnv,
+            NEXT_PUBLIC_ATLASSIAN_CLIENT_ID: "atlassian-client",
+            ATLASSIAN_CLIENT_CREDENTIAL: "atlassian-credential",
+        };
+    });
+
+    afterEach(() => {
+        global.fetch = originalFetch;
+        process.env = originalEnv;
+        jest.restoreAllMocks();
+    });
+
+    it("refreshes the Atlassian service-token alias without overwriting MCP credentials", async () => {
+        const now = Date.now();
+        global.fetch = jest.fn().mockResolvedValue({
+            ok: true,
+            json: jest.fn().mockResolvedValue({
+                access_token: "rest-new-token",
+                refresh_token: "rest-new-refresh",
+                expires_in: 3600,
+            }),
+        });
+        const user = makeUser({
+            atlassian: {
+                type: "streamable-http",
+                url: "https://mcp.atlassian.com/v1/mcp",
+                headers: {
+                    Authorization: "Bearer mcp-token",
+                    "X-Atlassian-Cloud-Id": "cloud-1",
+                },
+                cloudId: "cloud-1",
+                refreshToken: "mcp-refresh",
+                mcpClientId: "mcp-client",
+                expiresAt: now + 3600,
+            },
+            atlassian_api: {
+                type: "streamable-http",
+                url: "https://mcp.atlassian.com/v1/mcp",
+                headers: {
+                    Authorization: "Bearer rest-old-token",
+                },
+                cloudId: "cloud-1",
+                refreshToken: "rest-refresh",
+                expiresAt: now - 1000,
+            },
+        });
+        getCurrentUser.mockResolvedValue(user);
+
+        const response = await POST(
+            makeRequest({
+                service: "atlassian",
+                appletId: "507f191e810c19729de860ea",
+            }),
+        );
+        const body = await response.json();
+
+        expect(response.status).toBe(200);
+        expect(body.token).toBe("Bearer rest-new-token");
+        expect(global.fetch).toHaveBeenCalledWith(
+            "https://auth.atlassian.com/oauth/token",
+            expect.objectContaining({
+                method: "POST",
+                body: expect.stringContaining("rest-refresh"),
+            }),
+        );
+        expect(user.mcpServers.atlassian.headers.Authorization).toBe(
+            "Bearer mcp-token",
+        );
+        expect(user.mcpServers.atlassian.refreshToken).toBe("mcp-refresh");
+        expect(user.mcpServers.atlassian_api.headers.Authorization).toBe(
+            "Bearer rest-new-token",
+        );
+        expect(user.mcpServers.atlassian_api.refreshToken).toBe(
+            "rest-new-refresh",
+        );
+        expect(user.markModified).toHaveBeenCalledWith("mcpServers");
+        expect(user.save).toHaveBeenCalled();
+    });
+});

--- a/app/api/applet/access.js
+++ b/app/api/applet/access.js
@@ -1,0 +1,61 @@
+import { NextResponse } from "next/server";
+import mongoose from "mongoose";
+import Applet from "../models/applet.js";
+import App, { APP_STATUS, APP_TYPES } from "../models/app.js";
+import Workspace from "../models/workspace.js";
+
+export async function validateAppletAccess(appletId, user) {
+    if (!user?._id) {
+        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    if (!mongoose.Types.ObjectId.isValid(appletId)) {
+        return NextResponse.json(
+            { error: "Invalid applet ID" },
+            { status: 400 },
+        );
+    }
+
+    const applet = await Applet.findById(appletId)
+        .select("owner version publishedVersionIndex")
+        .lean();
+
+    if (!applet) {
+        return NextResponse.json(
+            { error: "Applet not found" },
+            { status: 404 },
+        );
+    }
+
+    if (String(applet.owner) === String(user._id)) {
+        return null;
+    }
+
+    if (applet.version === 2) {
+        if (applet.publishedVersionIndex != null) {
+            return null;
+        }
+
+        return NextResponse.json({ error: "Access denied" }, { status: 403 });
+    }
+
+    const workspace = await Workspace.findOne({ applet: applet._id })
+        .select("_id")
+        .lean();
+    const publicApplet = await App.findOne({
+        type: APP_TYPES.APPLET,
+        status: APP_STATUS.ACTIVE,
+        $or: [
+            { appletId: applet._id },
+            ...(workspace?._id ? [{ workspaceId: workspace._id }] : []),
+        ],
+    })
+        .select("_id")
+        .lean();
+
+    if (publicApplet) {
+        return null;
+    }
+
+    return NextResponse.json({ error: "Access denied" }, { status: 403 });
+}

--- a/app/api/applet/agent-chat/route.js
+++ b/app/api/applet/agent-chat/route.js
@@ -1,0 +1,103 @@
+import { NextResponse } from "next/server";
+import { getClient, QUERIES } from "../../../../src/graphql";
+import { getCurrentUser } from "../../utils/auth.js";
+import {
+    buildFileAccessPlan,
+    buildRunContext,
+} from "../../../../src/utils/fileAccessPlanUtils.js";
+import config from "../../../../app.config/config/index.js";
+import { validateAppletAccess } from "../access.js";
+import { APPLET_SDK_LIMITS, withAppletSdkGuard } from "../sdk-guard.js";
+
+export async function POST(request) {
+    try {
+        const { messages, systemPrompt, model, appletId } =
+            await request.json();
+
+        if (!messages || !Array.isArray(messages) || messages.length === 0) {
+            return NextResponse.json(
+                { error: "messages array is required" },
+                { status: 400 },
+            );
+        }
+        if (!appletId || typeof appletId !== "string") {
+            return NextResponse.json(
+                { error: "appletId is required" },
+                { status: 400 },
+            );
+        }
+
+        const user = await getCurrentUser();
+        const accessError = await validateAppletAccess(appletId, user);
+        if (accessError) {
+            return accessError;
+        }
+
+        // Build chatHistory with optional system prompt
+        const chatHistory = [];
+        if (systemPrompt) {
+            chatHistory.push({ role: "system", content: systemPrompt });
+        }
+        for (const m of messages) {
+            chatHistory.push({
+                role: m.role || "user",
+                content: m.content || "",
+            });
+        }
+
+        const fileAccessPlan = buildFileAccessPlan({
+            appletId,
+            userContextId: user.contextId || null,
+            userContextKey: user.contextKey || null,
+            includeUserGlobal: true,
+        });
+        const runContext = buildRunContext({
+            appletId,
+            userContextId: user.contextId || null,
+            userContextKey: user.contextKey || null,
+        });
+
+        const variables = {
+            chatHistory,
+            fileAccessPlan,
+            contextId: runContext.contextId,
+            contextKey: runContext.contextKey,
+            aiMemorySelfModify: false, // Do not write to user's main memory
+            stream: false,
+            entityId: user?.personalEntityId || "",
+            model: model || config.cortex.defaultChatModel,
+        };
+        if (user?.aiName) {
+            variables.aiName = user.aiName;
+        }
+
+        return await withAppletSdkGuard({
+            appletId,
+            userId: user._id,
+            api: "agent.chat",
+            limits: APPLET_SDK_LIMITS.agentChat,
+            run: async () => {
+                const graphqlClient = getClient();
+                const response = await graphqlClient.query({
+                    query: QUERIES.SYS_ENTITY_AGENT,
+                    variables,
+                    fetchPolicy: "network-only",
+                });
+
+                const data = response.data?.sys_entity_agent;
+
+                return NextResponse.json({
+                    result: data?.result || "",
+                    warnings: data?.warnings || [],
+                    errors: data?.errors || [],
+                });
+            },
+        });
+    } catch (error) {
+        console.error("Error in applet agent-chat:", error);
+        return NextResponse.json(
+            { error: "Failed to process agent chat" },
+            { status: 500 },
+        );
+    }
+}

--- a/app/api/applet/model-generate/route.js
+++ b/app/api/applet/model-generate/route.js
@@ -1,0 +1,155 @@
+import { NextResponse } from "next/server";
+import { getClient } from "../../../../src/graphql";
+import { getCurrentUser } from "../../utils/auth.js";
+import { buildWorkspacePromptVariables } from "../../utils/llm-file-utils.js";
+import config from "../../../../app.config/config/index.js";
+import { executeRunWorkspacePrompt } from "../../utils/run-workspace-prompt.js";
+import { validateAppletAccess } from "../access.js";
+import {
+    fetchAppletModelMetadata,
+    findAllowedModel,
+    isValidReasoningEffort,
+} from "../model-utils.js";
+import { APPLET_SDK_LIMITS, withAppletSdkGuard } from "../sdk-guard.js";
+
+function normalizeMessages(messages, systemPrompt) {
+    const normalized = [];
+
+    if (systemPrompt) {
+        normalized.push({ role: "system", content: systemPrompt });
+    }
+
+    for (const message of messages) {
+        normalized.push({
+            role: message.role || "user",
+            content: message.content || "",
+        });
+    }
+
+    return normalized;
+}
+
+export async function POST(request) {
+    try {
+        const {
+            appletId,
+            prompt,
+            messages,
+            systemPrompt,
+            model,
+            reasoningEffort,
+        } = await request.json();
+
+        if (!appletId || typeof appletId !== "string") {
+            return NextResponse.json(
+                { error: "appletId is required" },
+                { status: 400 },
+            );
+        }
+
+        const hasPrompt = typeof prompt === "string" && prompt.trim();
+        const hasMessages = Array.isArray(messages) && messages.length > 0;
+        if (!hasPrompt && !hasMessages) {
+            return NextResponse.json(
+                { error: "Either prompt or messages is required" },
+                { status: 400 },
+            );
+        }
+
+        if (
+            reasoningEffort !== undefined &&
+            reasoningEffort !== null &&
+            !isValidReasoningEffort(reasoningEffort)
+        ) {
+            return NextResponse.json(
+                {
+                    error: "Invalid reasoningEffort. Must be one of: none, low, medium, high",
+                },
+                { status: 400 },
+            );
+        }
+
+        const user = await getCurrentUser();
+        const accessError = await validateAppletAccess(appletId, user);
+        if (accessError) {
+            return accessError;
+        }
+
+        return await withAppletSdkGuard({
+            appletId,
+            userId: user._id,
+            api: "models.generate",
+            limits: APPLET_SDK_LIMITS.modelGenerate,
+            run: async () => {
+                const graphqlClient = getClient();
+                const modelMetadata =
+                    await fetchAppletModelMetadata(graphqlClient);
+                const requestedModel = model || modelMetadata.defaultModel;
+                const allowedModel = findAllowedModel(
+                    modelMetadata,
+                    requestedModel,
+                );
+
+                if (!allowedModel) {
+                    return NextResponse.json(
+                        { error: "Model is not available for applets" },
+                        { status: 400 },
+                    );
+                }
+
+                if (
+                    reasoningEffort &&
+                    !allowedModel.reasoningEfforts.includes(reasoningEffort)
+                ) {
+                    return NextResponse.json(
+                        {
+                            error: `reasoningEffort is not supported by ${requestedModel}`,
+                        },
+                        { status: 400 },
+                    );
+                }
+
+                const variables = await buildWorkspacePromptVariables({
+                    systemPrompt: hasMessages ? null : systemPrompt,
+                    text: hasPrompt ? prompt.trim() : "",
+                    chatHistory: hasMessages
+                        ? normalizeMessages(messages, systemPrompt)
+                        : null,
+                    appletId,
+                    userContextId: user?.contextId || null,
+                    userContextKey: user?.contextKey || null,
+                    includeUserGlobal: true,
+                });
+
+                variables.model =
+                    requestedModel || config.cortex.defaultChatModel;
+                if (reasoningEffort) {
+                    variables.reasoningEffort = reasoningEffort;
+                }
+
+                const { response } = await executeRunWorkspacePrompt({
+                    graphqlClient,
+                    variables,
+                    onUnsupportedReasoningEffort: (error) => {
+                        console.warn(
+                            "[applet model-generate] Cortex rejected reasoningEffort; retried without it.",
+                            error?.message || error,
+                        );
+                    },
+                });
+
+                const data = response.data?.run_workspace_prompt;
+
+                return NextResponse.json({
+                    result: data?.result || "",
+                });
+            },
+        });
+    } catch (error) {
+        console.error("Error in applet model-generate:", error);
+        return NextResponse.json(
+            { error: "Failed to generate model response" },
+            { status: 500 },
+        );
+    }
+}

--- a/app/api/applet/model-utils.js
+++ b/app/api/applet/model-utils.js
@@ -1,0 +1,97 @@
+import { SYS_MODEL_METADATA } from "../../../src/graphql";
+import {
+    getReasoningEffortLevelsForModel,
+    REASONING_EFFORT_LEVELS,
+} from "../../../src/utils/reasoningEffortI18n.js";
+import config from "../../../app.config/config/index.js";
+
+function parseMetadataResult(result) {
+    if (!result) return {};
+    if (typeof result === "string") return JSON.parse(result);
+    return result;
+}
+
+function toSdkModel(model, defaultModelId) {
+    const id = model.modelId || model.id;
+    const reasoningEfforts = getReasoningEffortLevelsForModel(model);
+
+    return {
+        id,
+        modelId: id,
+        name: model.displayName || model.name || id,
+        provider: model.provider || null,
+        category: model.category || "chat",
+        isDefault: id === defaultModelId,
+        isModelGroup: Boolean(model.isModelGroup),
+        supportsReasoningEffort: reasoningEfforts.length > 0,
+        reasoningEfforts,
+    };
+}
+
+export function normalizeAppletModelMetadata(
+    metadata,
+    defaultModelId = config.cortex.defaultChatModel,
+) {
+    const rawModels = Array.isArray(metadata?.models) ? metadata.models : [];
+    const allowedModels = rawModels.filter(
+        (model) =>
+            (model.modelId || model.id) &&
+            model.category === "chat" &&
+            model.isAvailable !== false,
+    );
+    const resolvedDefaultModelId =
+        allowedModels.find((model) => model.modelId === defaultModelId)
+            ?.modelId ||
+        allowedModels.find((model) => model.isDefault)?.modelId ||
+        allowedModels[0]?.modelId ||
+        defaultModelId;
+
+    const models = allowedModels.map((model) =>
+        toSdkModel(model, resolvedDefaultModelId),
+    );
+
+    if (
+        resolvedDefaultModelId &&
+        !models.some((model) => model.id === resolvedDefaultModelId)
+    ) {
+        models.unshift({
+            id: resolvedDefaultModelId,
+            modelId: resolvedDefaultModelId,
+            name: resolvedDefaultModelId,
+            provider: null,
+            category: "chat",
+            isDefault: true,
+            isModelGroup: false,
+            supportsReasoningEffort: true,
+            reasoningEfforts: REASONING_EFFORT_LEVELS,
+        });
+    }
+
+    return {
+        models,
+        defaultModel: resolvedDefaultModelId,
+        reasoningEfforts: REASONING_EFFORT_LEVELS,
+    };
+}
+
+export async function fetchAppletModelMetadata(graphqlClient) {
+    const response = await graphqlClient.query({
+        query: SYS_MODEL_METADATA,
+        variables: { category: "chat" },
+        fetchPolicy: "network-only",
+    });
+    const metadata = parseMetadataResult(
+        response.data?.sys_model_metadata?.result,
+    );
+
+    return normalizeAppletModelMetadata(metadata);
+}
+
+export function findAllowedModel(metadata, modelId) {
+    if (!modelId) return null;
+    return metadata.models.find((model) => model.id === modelId) || null;
+}
+
+export function isValidReasoningEffort(reasoningEffort) {
+    return REASONING_EFFORT_LEVELS.includes(reasoningEffort);
+}

--- a/app/api/applet/models/route.js
+++ b/app/api/applet/models/route.js
@@ -1,0 +1,43 @@
+import { NextResponse } from "next/server";
+import { getClient } from "../../../../src/graphql";
+import { getCurrentUser } from "../../utils/auth.js";
+import { validateAppletAccess } from "../access.js";
+import { fetchAppletModelMetadata } from "../model-utils.js";
+import { APPLET_SDK_LIMITS, withAppletSdkGuard } from "../sdk-guard.js";
+
+export async function GET(request) {
+    try {
+        const { searchParams } = new URL(request.url);
+        const appletId = searchParams.get("appletId");
+
+        if (!appletId) {
+            return NextResponse.json(
+                { error: "appletId is required" },
+                { status: 400 },
+            );
+        }
+
+        const user = await getCurrentUser();
+        const accessError = await validateAppletAccess(appletId, user);
+        if (accessError) {
+            return accessError;
+        }
+
+        return await withAppletSdkGuard({
+            appletId,
+            userId: user._id,
+            api: "models.list",
+            limits: APPLET_SDK_LIMITS.read,
+            run: async () => {
+                const metadata = await fetchAppletModelMetadata(getClient());
+                return NextResponse.json(metadata);
+            },
+        });
+    } catch (error) {
+        console.error("Error in applet models:", error);
+        return NextResponse.json(
+            { error: "Failed to load models" },
+            { status: 500 },
+        );
+    }
+}

--- a/app/api/applet/sdk-guard.js
+++ b/app/api/applet/sdk-guard.js
@@ -1,0 +1,231 @@
+import { NextResponse } from "next/server";
+import Applet from "../models/applet.js";
+
+const FIFTEEN_MINUTES_MS = 15 * 60 * 1000;
+const ONE_MINUTE_MS = 60 * 1000;
+const TEN_SECONDS_MS = 10 * 1000;
+
+const activeRequests = new Map();
+const rateWindows = new Map();
+const limitStrikes = new Map();
+
+export const APPLET_SDK_LIMITS = {
+    agentChat: {
+        concurrent: 3,
+        maxPerWindow: 12,
+        windowMs: ONE_MINUTE_MS,
+    },
+    modelGenerate: {
+        concurrent: 3,
+        maxPerWindow: 30,
+        windowMs: ONE_MINUTE_MS,
+    },
+    serviceToken: {
+        concurrent: 3,
+        maxPerWindow: 10,
+        windowMs: ONE_MINUTE_MS,
+    },
+    read: {
+        concurrent: 6,
+        maxPerWindow: 300,
+        windowMs: ONE_MINUTE_MS,
+    },
+    dataWrite: {
+        concurrent: 3,
+        maxPerWindow: 120,
+        windowMs: ONE_MINUTE_MS,
+    },
+    fileWrite: {
+        concurrent: 3,
+        maxPerWindow: 30,
+        windowMs: ONE_MINUTE_MS,
+    },
+};
+
+export const APPLET_SDK_SUSPENSION_MS = FIFTEEN_MINUTES_MS;
+export const APPLET_SDK_STRIKE_LIMIT = 100;
+export const APPLET_SDK_STRIKE_WINDOW_MS = TEN_SECONDS_MS;
+
+function nowMs() {
+    return Date.now();
+}
+
+function suspensionPayload(applet, now = nowMs()) {
+    const suspendedUntil = applet?.sdkSuspendedUntil
+        ? new Date(applet.sdkSuspendedUntil)
+        : null;
+    if (!suspendedUntil || suspendedUntil.getTime() <= now) {
+        return null;
+    }
+
+    const reason =
+        applet.sdkSuspendedReason ||
+        "This applet exceeded Concierge SDK safety limits.";
+    return {
+        error: `Applet SDK access is temporarily suspended until ${suspendedUntil.toISOString()}. ${reason} Fix the applet code, then clear the SDK suspension with UpdateAppletMetadata or wait for it to expire.`,
+        code: "APPLET_SDK_SUSPENDED",
+        suspendedUntil: suspendedUntil.toISOString(),
+        reason,
+    };
+}
+
+function jsonGuardError(payload, status, retryAfterSeconds = null) {
+    const response = NextResponse.json(payload, { status });
+    if (retryAfterSeconds) {
+        response.headers.set("Retry-After", String(retryAfterSeconds));
+    }
+    return response;
+}
+
+async function getActiveSuspension(appletId, now = nowMs()) {
+    const applet = await Applet.findById(appletId)
+        .select("sdkSuspendedUntil sdkSuspendedReason")
+        .lean();
+    const payload = suspensionPayload(applet, now);
+    if (payload) return payload;
+
+    if (applet?.sdkSuspendedUntil) {
+        await Applet.updateOne(
+            { _id: appletId },
+            {
+                $unset: {
+                    sdkSuspendedAt: "",
+                    sdkSuspendedUntil: "",
+                    sdkSuspendedReason: "",
+                },
+            },
+        );
+    }
+
+    return null;
+}
+
+function evictExpiredRateWindows(now) {
+    for (const [key, window] of rateWindows) {
+        if (window.resetAt <= now) {
+            rateWindows.delete(key);
+        }
+    }
+}
+
+function takeWindowSlot(key, limits, now = nowMs()) {
+    evictExpiredRateWindows(now);
+
+    const current = rateWindows.get(key);
+    if (!current || current.resetAt <= now) {
+        rateWindows.set(key, {
+            resetAt: now + limits.windowMs,
+            count: 1,
+        });
+        return true;
+    }
+
+    if (current.count >= limits.maxPerWindow) {
+        return false;
+    }
+
+    current.count += 1;
+    return true;
+}
+
+async function recordLimitStrike(appletId, api, reason, now = nowMs()) {
+    const key = String(appletId);
+    const current = limitStrikes.get(key);
+    const strike =
+        !current || current.resetAt <= now
+            ? { resetAt: now + APPLET_SDK_STRIKE_WINDOW_MS, count: 1 }
+            : { ...current, count: current.count + 1 };
+
+    limitStrikes.set(key, strike);
+    if (strike.count < APPLET_SDK_STRIKE_LIMIT) {
+        return null;
+    }
+
+    const suspendedUntil = new Date(now + APPLET_SDK_SUSPENSION_MS);
+    const suspensionReason = `Auto-suspended after repeated ${api} SDK ${reason} limit violations.`;
+    await Applet.updateOne(
+        { _id: appletId },
+        {
+            $set: {
+                sdkSuspendedAt: new Date(now),
+                sdkSuspendedUntil: suspendedUntil,
+                sdkSuspendedReason: suspensionReason,
+            },
+        },
+    );
+    limitStrikes.delete(key);
+
+    return {
+        error: `Applet SDK access is temporarily suspended until ${suspendedUntil.toISOString()}. ${suspensionReason} Fix the applet code, then clear the SDK suspension with UpdateAppletMetadata or wait for it to expire.`,
+        code: "APPLET_SDK_SUSPENDED",
+        suspendedUntil: suspendedUntil.toISOString(),
+        reason: suspensionReason,
+    };
+}
+
+export async function withAppletSdkGuard({
+    appletId,
+    userId,
+    api,
+    limits,
+    run,
+}) {
+    const activeSuspension = await getActiveSuspension(appletId);
+    if (activeSuspension) {
+        return jsonGuardError(activeSuspension, 403);
+    }
+
+    const key = `${userId || "anonymous"}:${appletId}:${api}`;
+    const activeCount = activeRequests.get(key) || 0;
+    if (activeCount >= limits.concurrent) {
+        const suspension = await recordLimitStrike(
+            appletId,
+            api,
+            "concurrency",
+        );
+        if (suspension) {
+            return jsonGuardError(suspension, 403);
+        }
+        return jsonGuardError(
+            {
+                error: "Too many applet SDK requests are already running. Slow the applet down or wait for in-flight requests to finish.",
+                code: "APPLET_SDK_CONCURRENCY_LIMITED",
+            },
+            429,
+            5,
+        );
+    }
+
+    if (!takeWindowSlot(key, limits)) {
+        const suspension = await recordLimitStrike(appletId, api, "rate");
+        if (suspension) {
+            return jsonGuardError(suspension, 403);
+        }
+        return jsonGuardError(
+            {
+                error: "Too many applet SDK requests. Slow the applet down before trying again.",
+                code: "APPLET_SDK_RATE_LIMITED",
+            },
+            429,
+            Math.ceil(limits.windowMs / 1000),
+        );
+    }
+
+    activeRequests.set(key, activeCount + 1);
+    try {
+        return await run();
+    } finally {
+        const nextCount = (activeRequests.get(key) || 1) - 1;
+        if (nextCount <= 0) {
+            activeRequests.delete(key);
+        } else {
+            activeRequests.set(key, nextCount);
+        }
+    }
+}
+
+export function clearAppletSdkGuardStateForTests() {
+    activeRequests.clear();
+    rateWindows.clear();
+    limitStrikes.clear();
+}

--- a/app/api/applet/service-token/route.js
+++ b/app/api/applet/service-token/route.js
@@ -1,0 +1,238 @@
+import { NextResponse } from "next/server";
+import { getCurrentUser } from "../../utils/auth.js";
+import { MCP_PRESETS } from "../../../../src/utils/mcpPresets.js";
+import { fetchAtlassianCloudIdFromAuthorization } from "../../utils/atlassianCloudId.js";
+import { refreshMcpServerConfig } from "../../utils/mcp-token-refresh.js";
+import { validateAppletAccess } from "../access.js";
+import { APPLET_SDK_LIMITS, withAppletSdkGuard } from "../sdk-guard.js";
+
+export const dynamic = "force-dynamic";
+
+const ALLOWED_SERVICES = ["atlassian", "github", "slack"];
+
+// Map public service names to their mcpServers storage key.
+// Atlassian uses "atlassian_api" (Jira page 3LO tokens with API access)
+// rather than "atlassian" (MCP tokens without direct API access).
+const SERVICE_STORAGE_KEY = {
+    atlassian: "atlassian_api",
+};
+
+/**
+ * Build OAuth connect info from the MCP preset for a service.
+ * Returned to the client so the SDK can auto-initiate the OAuth flow.
+ *
+ * Atlassian uses the 3LO (three-legged OAuth) flow here instead of
+ * MCP OAuth 2.1 because applets need direct Jira REST API access
+ * (cloudId lookup, issue queries, etc.) which requires scopes like
+ * read:jira-work that MCP tokens don't carry.
+ */
+function getConnectInfo(service) {
+    if (service === "atlassian") {
+        return {
+            service: "atlassian",
+            mcpOAuthInit: "/api/auth/atlassian/applet-init",
+            mcpOAuthRedirect: "/code/jira",
+        };
+    }
+    const preset = MCP_PRESETS[service];
+    if (!preset) return undefined;
+    const info = { service: preset.id };
+    if (preset.mcpOAuthInit) {
+        info.mcpOAuthInit = preset.mcpOAuthInit;
+        info.mcpOAuthRedirect = preset.mcpOAuthRedirect;
+    } else if (preset.oauthUrl) {
+        info.oauthUrl = preset.oauthUrl;
+    }
+    return info;
+}
+
+/**
+ * POST /api/applet/service-token
+ * Returns an access token for a connected service.
+ * Used by applets (via ConciergeSDK.services.getAccessToken) to call
+ * external APIs directly.
+ *
+ * Body: { service: "atlassian" | "github" | "slack", appletId: string }
+ * Returns: { token, service, expiresAt?, metadata? }
+ */
+export async function POST(request) {
+    try {
+        const user = await getCurrentUser(false);
+        if (!user?._id) {
+            return NextResponse.json(
+                { error: "Unauthorized" },
+                { status: 401 },
+            );
+        }
+
+        const { service, appletId } = await request.json();
+
+        if (!service || typeof service !== "string") {
+            return NextResponse.json(
+                { error: "service is required" },
+                { status: 400 },
+            );
+        }
+        if (!appletId || typeof appletId !== "string") {
+            return NextResponse.json(
+                { error: "appletId is required" },
+                { status: 400 },
+            );
+        }
+
+        if (!ALLOWED_SERVICES.includes(service)) {
+            return NextResponse.json(
+                {
+                    error: `Unknown service: ${service}. Allowed: ${ALLOWED_SERVICES.join(", ")}`,
+                },
+                { status: 400 },
+            );
+        }
+
+        const accessError = await validateAppletAccess(appletId, user);
+        if (accessError) {
+            return accessError;
+        }
+
+        return await withAppletSdkGuard({
+            appletId,
+            userId: user._id,
+            api: "services.getAccessToken",
+            limits: APPLET_SDK_LIMITS.serviceToken,
+            run: async () => getServiceTokenResponse({ user, service }),
+        });
+    } catch (error) {
+        console.error("Error in applet service-token:", error);
+        return NextResponse.json(
+            { error: "Failed to get service token" },
+            { status: 500 },
+        );
+    }
+}
+
+async function getServiceTokenResponse({ user, service }) {
+    const mcpServers = user.mcpServers || {};
+    const storageKey = SERVICE_STORAGE_KEY[service] || service;
+    const serverConfig = mcpServers[storageKey];
+
+    if (!serverConfig) {
+        return NextResponse.json(
+            {
+                error: `${service} is not connected.`,
+                code: "SERVICE_NOT_CONNECTED",
+                connectInfo: getConnectInfo(service),
+            },
+            { status: 404 },
+        );
+    }
+
+    let serviceConfig = serverConfig;
+    let authorization =
+        serviceConfig.headers?.Authorization ||
+        serviceConfig.headers?.authorization;
+
+    if (!authorization) {
+        return NextResponse.json(
+            {
+                error: `${service} has no access token. The user may need to reconnect.`,
+                code: "NO_TOKEN",
+                connectInfo: getConnectInfo(service),
+            },
+            { status: 404 },
+        );
+    }
+
+    // Auto-refresh expired Atlassian tokens
+    if (
+        serviceConfig.expiresAt &&
+        typeof serviceConfig.expiresAt === "number" &&
+        serviceConfig.expiresAt <= Date.now()
+    ) {
+        if (service === "atlassian" && serviceConfig.refreshToken) {
+            const refreshed = await refreshMcpServerConfig(
+                storageKey,
+                serviceConfig,
+                { logPrefix: "[MCP:service-token]" },
+            );
+            if (refreshed.refreshed) {
+                const newConfig = refreshed.config;
+                // Persist refreshed tokens
+                const updatedServers = { ...mcpServers };
+                updatedServers[storageKey] = newConfig;
+                user.mcpServers = updatedServers;
+                user.markModified("mcpServers");
+                await user.save();
+
+                serviceConfig = newConfig;
+                authorization = serviceConfig.headers.Authorization;
+            } else {
+                return NextResponse.json(
+                    {
+                        error: `${service} token has expired and could not be refreshed.`,
+                        code: "TOKEN_EXPIRED",
+                        connectInfo: getConnectInfo(service),
+                    },
+                    { status: 401 },
+                );
+            }
+        } else {
+            return NextResponse.json(
+                {
+                    error: `${service} token has expired.`,
+                    code: "TOKEN_EXPIRED",
+                    connectInfo: getConnectInfo(service),
+                },
+                { status: 401 },
+            );
+        }
+    }
+
+    if (service === "atlassian" && authorization && !serviceConfig.cloudId) {
+        const cloudId =
+            await fetchAtlassianCloudIdFromAuthorization(authorization);
+        if (cloudId) {
+            const newConfig = { ...serviceConfig, cloudId };
+            const updatedServers = { ...mcpServers };
+            updatedServers[storageKey] = newConfig;
+            user.mcpServers = updatedServers;
+            user.markModified("mcpServers");
+            await user.save();
+            serviceConfig = newConfig;
+        }
+    }
+
+    if (!authorization || typeof authorization !== "string") {
+        return NextResponse.json(
+            {
+                error: `${service} has no access token. The user may need to reconnect.`,
+                code: "NO_TOKEN",
+                connectInfo: getConnectInfo(service),
+            },
+            { status: 404 },
+        );
+    }
+
+    // Build metadata with service-specific fields the applet needs
+    const metadata = {};
+    if (service === "atlassian") {
+        if (!serviceConfig.cloudId) {
+            return NextResponse.json(
+                {
+                    error: `Could not determine your Jira site. Please reconnect your Atlassian account.`,
+                    code: "TOKEN_EXPIRED",
+                    connectInfo: getConnectInfo(service),
+                },
+                { status: 401 },
+            );
+        }
+        metadata.cloudId = serviceConfig.cloudId;
+        metadata.baseUrl = `https://api.atlassian.com/ex/jira/${serviceConfig.cloudId}`;
+    }
+
+    return NextResponse.json({
+        service,
+        token: authorization,
+        expiresAt: serviceConfig.expiresAt || null,
+        metadata,
+    });
+}

--- a/app/api/canvas-applets/[id]/data/route.js
+++ b/app/api/canvas-applets/[id]/data/route.js
@@ -1,0 +1,122 @@
+import { NextResponse } from "next/server";
+import AppletData from "../../../models/applet-data";
+import { validateMongoDBKey } from "../../../utils/fileValidation";
+import { parseJsonRequest } from "../../../utils/parseJsonRequest";
+import { getCanvasAppletForDataAccess } from "../utils";
+import {
+    APPLET_SDK_LIMITS,
+    withAppletSdkGuard,
+} from "../../../applet/sdk-guard";
+
+// GET: retrieve data for a canvas applet
+export async function GET(request, { params }) {
+    const { id } = params;
+
+    try {
+        const access = await getCanvasAppletForDataAccess(id);
+        if (access.error) return access.error;
+
+        const { user } = access;
+
+        return await withAppletSdkGuard({
+            appletId: id,
+            userId: user._id,
+            api: "data.get",
+            limits: APPLET_SDK_LIMITS.read,
+            run: async () => {
+                const appletData = await AppletData.findOne({
+                    appletId: id,
+                    userId: user._id,
+                });
+
+                return NextResponse.json({
+                    data: appletData ? appletData.data : {},
+                });
+            },
+        });
+    } catch (error) {
+        console.error("Error retrieving canvas applet data:", error);
+        return NextResponse.json(
+            { error: "Internal server error" },
+            { status: 500 },
+        );
+    }
+}
+
+// PUT: store data for a canvas applet
+export async function PUT(request, { params }) {
+    const { id } = params;
+
+    try {
+        const parsedBody = await parseJsonRequest(request);
+        if (!parsedBody.ok) {
+            return parsedBody.errorResponse;
+        }
+        const body = parsedBody.body;
+
+        if (!body.key || body.value === undefined) {
+            return NextResponse.json(
+                { error: "Key and value are required" },
+                { status: 400 },
+            );
+        }
+
+        const keyValidation = validateMongoDBKey(body.key);
+        if (!keyValidation.isValid) {
+            return NextResponse.json(
+                {
+                    error: "Invalid key format",
+                    details: keyValidation.errors,
+                },
+                { status: 400 },
+            );
+        }
+
+        const access = await getCanvasAppletForDataAccess(id);
+        if (access.error) return access.error;
+
+        const { user } = access;
+
+        return await withAppletSdkGuard({
+            appletId: id,
+            userId: user._id,
+            api: "data.set",
+            limits: APPLET_SDK_LIMITS.dataWrite,
+            run: async () => {
+                const query = {
+                    appletId: id,
+                    userId: user._id,
+                };
+                const existing = await AppletData.findOne(query);
+                const nextData = {
+                    ...(existing?.data || {}),
+                    [keyValidation.sanitizedKey]: body.value,
+                };
+                const appletData = await AppletData.findOneAndUpdate(
+                    query,
+                    {
+                        $set: {
+                            data: nextData,
+                        },
+                    },
+                    {
+                        new: true,
+                        upsert: true,
+                        runValidators: true,
+                    },
+                );
+
+                return NextResponse.json({
+                    success: true,
+                    data: appletData.data,
+                });
+            },
+        });
+    } catch (error) {
+        console.error("Error storing canvas applet data:", error);
+        return NextResponse.json(
+            { error: "Internal server error" },
+            { status: 500 },
+        );
+    }
+}

--- a/app/api/canvas-applets/[id]/files/[fileId]/content/route.js
+++ b/app/api/canvas-applets/[id]/files/[fileId]/content/route.js
@@ -1,0 +1,152 @@
+import { NextResponse } from "next/server";
+import AppletFile from "../../../../../models/applet-file";
+import AppletSharedFile from "../../../../../models/applet-shared-file";
+import File from "../../../../../models/file";
+import {
+    createAppletSharedStorageTarget,
+    createAppletUserStorageTarget,
+} from "../../../../../../../src/utils/storageTargets";
+import { resolveAndHealFile } from "../../../../../utils/file-resolution-utils";
+import { getCanvasAppletForDataAccess } from "../../../utils";
+import {
+    APPLET_SDK_LIMITS,
+    withAppletSdkGuard,
+} from "../../../../../applet/sdk-guard";
+
+function getRequestedScope(request) {
+    const scope = new URL(request.url).searchParams.get("scope");
+    return scope === "shared" ? "shared" : "user";
+}
+
+function isAppletOwner(applet, user) {
+    return String(applet?.owner) === String(user?._id);
+}
+
+function getStorageTarget({ scope, appletId, userContextId }) {
+    if (scope === "shared") {
+        return createAppletSharedStorageTarget(appletId);
+    }
+    return createAppletUserStorageTarget(userContextId, appletId);
+}
+
+async function getStoreDocument({ scope, appletId, userId }) {
+    const query =
+        scope === "shared"
+            ? AppletSharedFile.findOne({ appletId })
+            : AppletFile.findOne({ appletId, userId });
+    return query.populate("files");
+}
+
+// GET: stream file content for a canvas applet (proxies storage to avoid CORS)
+export async function GET(request, { params }) {
+    const { id: appletId, fileId } = params;
+    const scope = getRequestedScope(request);
+
+    try {
+        const access = await getCanvasAppletForDataAccess(appletId);
+        if (access.error) return access.error;
+
+        const { applet, user } = access;
+        if (scope === "shared" && !isAppletOwner(applet, user)) {
+            return NextResponse.json(
+                { error: "Only the applet owner can view shared files here" },
+                { status: 403 },
+            );
+        }
+
+        return await withAppletSdkGuard({
+            appletId,
+            userId: user._id,
+            api: "files.content",
+            limits: APPLET_SDK_LIMITS.read,
+            run: async () => {
+                const fileStore = await getStoreDocument({
+                    scope,
+                    appletId,
+                    userId: user._id,
+                });
+
+                if (!fileStore) {
+                    return NextResponse.json(
+                        { error: "File not found" },
+                        { status: 404 },
+                    );
+                }
+
+                const file = fileStore.files.find(
+                    (f) => f._id.toString() === fileId,
+                );
+                if (!file) {
+                    return NextResponse.json(
+                        { error: "File not found" },
+                        { status: 404 },
+                    );
+                }
+
+                const storageTarget = getStorageTarget({
+                    scope,
+                    appletId,
+                    userContextId: user.contextId,
+                });
+                const resolved = await resolveAndHealFile(file, {
+                    storageTarget,
+                    allowUrlRefresh: true,
+                    persistResolvedFile: async (updateFields) => {
+                        await File.findByIdAndUpdate(file._id, updateFields);
+                    },
+                });
+
+                if (!resolved.accessUrl) {
+                    return NextResponse.json(
+                        { error: "Failed to resolve file from storage" },
+                        { status: 404 },
+                    );
+                }
+
+                const azureResponse = await fetch(resolved.accessUrl, {
+                    redirect: "follow",
+                });
+
+                if (!azureResponse.ok) {
+                    console.error(
+                        `Failed to fetch file from storage: ${azureResponse.status} ${azureResponse.statusText}`,
+                    );
+                    return NextResponse.json(
+                        { error: "Failed to fetch file from storage" },
+                        { status: azureResponse.status },
+                    );
+                }
+
+                const contentType =
+                    azureResponse.headers.get("content-type") ||
+                    file.mimeType ||
+                    "application/octet-stream";
+
+                const contentLength =
+                    azureResponse.headers.get("content-length");
+
+                return new NextResponse(azureResponse.body, {
+                    status: 200,
+                    headers: {
+                        "Content-Type": contentType,
+                        ...(contentLength && {
+                            "Content-Length": contentLength,
+                        }),
+                        "Access-Control-Allow-Origin": "*",
+                        "Access-Control-Allow-Methods": "GET",
+                        "Access-Control-Expose-Headers":
+                            "Content-Type, Content-Length, Content-Disposition",
+                        "Cache-Control": "public, max-age=3600",
+                        "Content-Disposition": `inline; filename="${file.originalName || file.filename}"`,
+                    },
+                });
+            },
+        });
+    } catch (error) {
+        console.error("Error streaming canvas applet file content:", error);
+        return NextResponse.json(
+            { error: "Failed to stream file" },
+            { status: 500 },
+        );
+    }
+}

--- a/app/api/canvas-applets/[id]/files/route.js
+++ b/app/api/canvas-applets/[id]/files/route.js
@@ -1,0 +1,352 @@
+import { NextResponse } from "next/server";
+import AppletFile from "../../../models/applet-file";
+import AppletSharedFile from "../../../models/applet-shared-file";
+import File from "../../../models/file";
+import { handleStreamingFileUpload } from "../../../utils/upload-utils";
+import { deleteMediaFile } from "../../../utils/media-service-utils";
+import {
+    createAppletSharedStorageTarget,
+    createAppletUserStorageTarget,
+} from "../../../../../src/utils/storageTargets";
+import { getCanvasAppletForDataAccess } from "../utils";
+import {
+    APPLET_SDK_LIMITS,
+    withAppletSdkGuard,
+} from "../../../applet/sdk-guard";
+
+function getRequestedScope(request) {
+    const scope = new URL(request.url).searchParams.get("scope");
+    return scope === "shared" ? "shared" : "user";
+}
+
+function isAppletOwner(applet, user) {
+    return String(applet?.owner) === String(user?._id);
+}
+
+function getStorageTarget({ scope, appletId, userContextId }) {
+    if (scope === "shared") {
+        return createAppletSharedStorageTarget(appletId);
+    }
+    return createAppletUserStorageTarget(userContextId, appletId);
+}
+
+async function getStoreDocument({ scope, appletId, userId, match = null }) {
+    const query =
+        scope === "shared"
+            ? AppletSharedFile.findOne({ appletId })
+            : AppletFile.findOne({ appletId, userId });
+
+    if (match) {
+        return query.populate({ path: "files", match });
+    }
+
+    return query.populate("files");
+}
+
+async function appendFileToStore({ scope, appletId, userId, fileId }) {
+    if (scope === "shared") {
+        return AppletSharedFile.findOneAndUpdate(
+            { appletId },
+            {
+                $push: {
+                    files: fileId,
+                },
+            },
+            {
+                new: true,
+                upsert: true,
+                runValidators: true,
+            },
+        ).populate("files");
+    }
+
+    return AppletFile.findOneAndUpdate(
+        { appletId, userId },
+        {
+            $push: {
+                files: fileId,
+            },
+        },
+        {
+            new: true,
+            upsert: true,
+            runValidators: true,
+        },
+    ).populate("files");
+}
+
+async function removeFileFromStore({ scope, appletId, userId, fileId }) {
+    if (scope === "shared") {
+        return AppletSharedFile.findOneAndUpdate(
+            { appletId },
+            {
+                $pull: {
+                    files: fileId,
+                },
+            },
+            {
+                new: true,
+                runValidators: true,
+            },
+        ).populate("files");
+    }
+
+    return AppletFile.findOneAndUpdate(
+        { appletId, userId },
+        {
+            $pull: {
+                files: fileId,
+            },
+        },
+        {
+            new: true,
+            runValidators: true,
+        },
+    ).populate("files");
+}
+
+async function deleteCloudFile(file, { scope, appletId, userContextId }) {
+    if ((!file?.blobPath && !file?.hash) || !appletId) {
+        return;
+    }
+    await deleteMediaFile({
+        blobPath: file.blobPath,
+        hash: file.hash,
+        storageTarget: getStorageTarget({
+            scope,
+            appletId,
+            userContextId,
+        }),
+    });
+}
+
+// POST: upload a file for a canvas applet
+export async function POST(request, { params }) {
+    const { id } = params;
+    const scope = getRequestedScope(request);
+
+    const access = await getCanvasAppletForDataAccess(id);
+    if (access.error) return access.error;
+
+    const { applet, user } = access;
+    if (scope === "shared" && !isAppletOwner(applet, user)) {
+        return NextResponse.json(
+            { error: "Only the applet owner can manage shared files" },
+            { status: 403 },
+        );
+    }
+
+    return await withAppletSdkGuard({
+        appletId: id,
+        userId: user._id,
+        api: "files.upload",
+        limits: APPLET_SDK_LIMITS.fileWrite,
+        run: async () => {
+            const result = await handleStreamingFileUpload(request, {
+                getWorkspace: async () => applet,
+                checkAuthorization: null,
+                storageTarget: getStorageTarget({
+                    scope,
+                    appletId: id,
+                    userContextId: user.contextId,
+                }),
+                associateFile: async (newFile, appletObj, uploadUser) => {
+                    const matchQuery = [];
+                    if (newFile.blobPath) {
+                        matchQuery.push({ blobPath: newFile.blobPath });
+                    }
+                    if (newFile.hash) {
+                        matchQuery.push({ hash: newFile.hash });
+                    }
+
+                    if (matchQuery.length > 0) {
+                        const existingStore = await getStoreDocument({
+                            scope,
+                            appletId: appletObj._id,
+                            userId: uploadUser._id,
+                            match:
+                                matchQuery.length === 1
+                                    ? matchQuery[0]
+                                    : { $or: matchQuery },
+                        });
+
+                        if (existingStore?.files?.length > 0) {
+                            const existingFile = existingStore.files[0];
+                            const allFiles = await getStoreDocument({
+                                scope,
+                                appletId: appletObj._id,
+                                userId: uploadUser._id,
+                            });
+
+                            await deleteCloudFile(newFile, {
+                                scope,
+                                appletId: String(appletObj._id),
+                                userContextId: uploadUser.contextId,
+                            });
+                            await File.findByIdAndDelete(newFile._id);
+
+                            return {
+                                success: true,
+                                file: existingFile,
+                                files: allFiles?.files || [],
+                            };
+                        }
+                    }
+
+                    const fileStore = await appendFileToStore({
+                        scope,
+                        appletId: appletObj._id,
+                        userId: uploadUser._id,
+                        fileId: newFile._id,
+                    });
+
+                    return {
+                        success: true,
+                        file: newFile,
+                        files: fileStore.files,
+                    };
+                },
+                errorPrefix: "canvas applet file upload",
+            });
+
+            if (result.error) {
+                return result.error;
+            }
+
+            return NextResponse.json({
+                success: true,
+                ...result.data,
+            });
+        },
+    });
+}
+
+// GET: retrieve files for a canvas applet
+export async function GET(request, { params }) {
+    const { id } = params;
+    const scope = getRequestedScope(request);
+
+    try {
+        const access = await getCanvasAppletForDataAccess(id);
+        if (access.error) return access.error;
+
+        const { applet, user } = access;
+        if (scope === "shared" && !isAppletOwner(applet, user)) {
+            return NextResponse.json(
+                { error: "Only the applet owner can view shared files here" },
+                { status: 403 },
+            );
+        }
+
+        return await withAppletSdkGuard({
+            appletId: id,
+            userId: user._id,
+            api: "files.list",
+            limits: APPLET_SDK_LIMITS.read,
+            run: async () => {
+                const fileStore = await getStoreDocument({
+                    scope,
+                    appletId: id,
+                    userId: user._id,
+                });
+                const files = Array.isArray(fileStore?.files)
+                    ? fileStore.files
+                    : [];
+
+                return NextResponse.json({
+                    files,
+                });
+            },
+        });
+    } catch (error) {
+        console.error("Error retrieving canvas applet files:", error);
+        return NextResponse.json(
+            { error: "Internal server error" },
+            { status: 500 },
+        );
+    }
+}
+
+// DELETE: delete a specific file from a canvas applet
+export async function DELETE(request, { params }) {
+    const { id } = params;
+    const scope = getRequestedScope(request);
+    const { searchParams } = new URL(request.url);
+    const filename = searchParams.get("filename");
+
+    try {
+        const access = await getCanvasAppletForDataAccess(id);
+        if (access.error) return access.error;
+
+        const { applet, user } = access;
+        if (scope === "shared" && !isAppletOwner(applet, user)) {
+            return NextResponse.json(
+                { error: "Only the applet owner can manage shared files" },
+                { status: 403 },
+            );
+        }
+
+        if (!filename) {
+            return NextResponse.json(
+                { error: "Filename is required" },
+                { status: 400 },
+            );
+        }
+
+        const fileStore = await getStoreDocument({
+            scope,
+            appletId: id,
+            userId: user._id,
+        });
+
+        if (!fileStore) {
+            return NextResponse.json({
+                success: true,
+                files: [],
+            });
+        }
+
+        const files = Array.isArray(fileStore?.files) ? fileStore.files : [];
+        const fileToDelete = files.find((file) => file.filename === filename);
+
+        if (!fileToDelete) {
+            return NextResponse.json(
+                { error: "File not found" },
+                { status: 404 },
+            );
+        }
+
+        return await withAppletSdkGuard({
+            appletId: id,
+            userId: user._id,
+            api: "files.delete",
+            limits: APPLET_SDK_LIMITS.fileWrite,
+            run: async () => {
+                await deleteCloudFile(fileToDelete, {
+                    scope,
+                    appletId: id,
+                    userContextId: user.contextId,
+                });
+                await File.findByIdAndDelete(fileToDelete._id);
+
+                const updatedStore = await removeFileFromStore({
+                    scope,
+                    appletId: id,
+                    userId: user._id,
+                    fileId: fileToDelete._id,
+                });
+
+                return NextResponse.json({
+                    success: true,
+                    files: updatedStore?.files || [],
+                });
+            },
+        });
+    } catch (error) {
+        console.error("Error deleting canvas applet file:", error);
+        return NextResponse.json(
+            { error: "Internal server error" },
+            { status: 500 },
+        );
+    }
+}

--- a/app/api/canvas-applets/[id]/route.js
+++ b/app/api/canvas-applets/[id]/route.js
@@ -1,0 +1,78 @@
+import { NextResponse } from "next/server";
+import mongoose from "mongoose";
+import { getCurrentUser } from "../../utils/auth";
+import {
+    deleteAppletRegistry,
+    getAppletRegistry,
+    updateAppletRegistry,
+} from "../registry";
+
+function jsonError(error, fallback = "Internal server error") {
+    return NextResponse.json(
+        { error: error?.message || fallback },
+        { status: error?.status || 500 },
+    );
+}
+
+function validateAppletId(id) {
+    if (!mongoose.Types.ObjectId.isValid(id)) {
+        const error = new Error("Invalid applet ID");
+        error.status = 400;
+        throw error;
+    }
+}
+
+async function requireUser() {
+    const user = await getCurrentUser();
+    if (!user?._id) {
+        const error = new Error("Unauthorized");
+        error.status = 401;
+        throw error;
+    }
+    return user;
+}
+
+export async function GET(request, { params }) {
+    const { id } = params;
+
+    try {
+        validateAppletId(id);
+        return NextResponse.json(
+            await getAppletRegistry(await requireUser(), id),
+        );
+    } catch (error) {
+        console.error("Error fetching canvas applet:", error);
+        return jsonError(error);
+    }
+}
+
+export async function PUT(request, { params }) {
+    const { id } = params;
+
+    try {
+        validateAppletId(id);
+        const updated = await updateAppletRegistry(
+            await requireUser(),
+            id,
+            await request.json(),
+        );
+        return NextResponse.json(updated);
+    } catch (error) {
+        console.error("Error updating canvas applet:", error);
+        return jsonError(error);
+    }
+}
+
+export async function DELETE(request, { params }) {
+    const { id } = params;
+
+    try {
+        validateAppletId(id);
+        return NextResponse.json(
+            await deleteAppletRegistry(await requireUser(), id),
+        );
+    } catch (error) {
+        console.error("Error deleting canvas applet:", error);
+        return jsonError(error);
+    }
+}

--- a/app/api/canvas-applets/[id]/shared-data/[key]/backups/route.js
+++ b/app/api/canvas-applets/[id]/shared-data/[key]/backups/route.js
@@ -1,0 +1,66 @@
+import { NextResponse } from "next/server";
+import AppletSharedDataRevision from "../../../../../models/applet-shared-data-revision";
+import { getCanvasAppletForDataAccess } from "../../../utils";
+import {
+    APPLET_SDK_LIMITS,
+    withAppletSdkGuard,
+} from "../../../../../applet/sdk-guard";
+import {
+    revisionToken,
+    validateSharedDataKey,
+} from "../../../../shared-data-utils";
+
+function toBackupSummary(backup) {
+    return {
+        id: backup._id?.toString?.() || backup._id,
+        revision: revisionToken(backup.revision),
+        value: backup.value,
+        reason: backup.reason,
+        createdAt: backup.createdAt,
+        createdBy: backup.createdBy?.toString?.() || backup.createdBy,
+    };
+}
+
+// GET: list shared data recovery snapshots for a workspace key.
+export async function GET(request, { params }) {
+    const { id } = params;
+
+    try {
+        const keyValidation = validateSharedDataKey(params.key);
+        if (keyValidation.error) return keyValidation.error;
+
+        const access = await getCanvasAppletForDataAccess(id);
+        if (access.error) return access.error;
+
+        const { user } = access;
+
+        return await withAppletSdkGuard({
+            appletId: id,
+            userId: user._id,
+            api: "sharedData.backups",
+            limits: APPLET_SDK_LIMITS.read,
+            run: async () => {
+                const backups = await AppletSharedDataRevision.find({
+                    appletId: id,
+                    key: keyValidation.key,
+                })
+                    .sort({ revision: -1, createdAt: -1 })
+                    .limit(50)
+                    .lean();
+
+                return NextResponse.json({
+                    backups: backups.map(toBackupSummary),
+                });
+            },
+        });
+    } catch (error) {
+        console.error(
+            "Error listing canvas applet shared data backups:",
+            error,
+        );
+        return NextResponse.json(
+            { error: error.status ? error.message : "Internal server error" },
+            { status: error.status || 500 },
+        );
+    }
+}

--- a/app/api/canvas-applets/[id]/shared-data/[key]/restore/route.js
+++ b/app/api/canvas-applets/[id]/shared-data/[key]/restore/route.js
@@ -1,0 +1,131 @@
+import { NextResponse } from "next/server";
+import AppletSharedDataRevision from "../../../../../models/applet-shared-data-revision";
+import { parseJsonRequest } from "../../../../../utils/parseJsonRequest";
+import { getCanvasAppletForDataAccess } from "../../../utils";
+import {
+    APPLET_SDK_LIMITS,
+    withAppletSdkGuard,
+} from "../../../../../applet/sdk-guard";
+import {
+    createSharedDataBackup,
+    loadSharedData,
+    replaceSharedData,
+    revisionToken,
+    validateSharedDataKey,
+} from "../../../../shared-data-utils";
+
+function findBackupQuery({ appletId, key, body }) {
+    const query = { appletId, key };
+    if (body.backupId) {
+        query._id = body.backupId;
+    } else if (body.revision != null) {
+        query.revision = Number(body.revision);
+    }
+    return query;
+}
+
+// POST: restore a shared data recovery snapshot.
+export async function POST(request, { params }) {
+    const { id } = params;
+
+    try {
+        const keyValidation = validateSharedDataKey(params.key);
+        if (keyValidation.error) return keyValidation.error;
+
+        const parsedBody = await parseJsonRequest(request);
+        if (!parsedBody.ok) return parsedBody.errorResponse;
+
+        const body = parsedBody.body || {};
+        if (!body.backupId && body.revision == null) {
+            return NextResponse.json(
+                { error: "backupId or revision is required" },
+                { status: 400 },
+            );
+        }
+
+        const access = await getCanvasAppletForDataAccess(id);
+        if (access.error) return access.error;
+
+        const { user } = access;
+
+        return await withAppletSdkGuard({
+            appletId: id,
+            userId: user._id,
+            api: "sharedData.restore",
+            limits: APPLET_SDK_LIMITS.dataWrite,
+            run: async () => {
+                const [existing, backup] = await Promise.all([
+                    loadSharedData({
+                        appletId: id,
+                        key: keyValidation.key,
+                    }),
+                    AppletSharedDataRevision.findOne(
+                        findBackupQuery({
+                            appletId: id,
+                            key: keyValidation.key,
+                            body,
+                        }),
+                    ),
+                ]);
+
+                if (!existing) {
+                    return NextResponse.json(
+                        {
+                            error: "Shared data is missing",
+                            code: "SHARED_DATA_MISSING",
+                        },
+                        { status: 404 },
+                    );
+                }
+
+                if (!backup) {
+                    return NextResponse.json(
+                        {
+                            error: "Shared data backup not found",
+                            code: "SHARED_DATA_BACKUP_NOT_FOUND",
+                        },
+                        { status: 404 },
+                    );
+                }
+
+                await createSharedDataBackup({
+                    existing,
+                    userId: user._id,
+                    reason: "restore",
+                });
+
+                const updated = await replaceSharedData({
+                    existing,
+                    value: backup.value,
+                    userId: user._id,
+                });
+
+                if (!updated) {
+                    return NextResponse.json(
+                        {
+                            error: "Shared data revision conflict",
+                            code: "SHARED_DATA_REVISION_CONFLICT",
+                            revision: revisionToken(existing.revision),
+                        },
+                        { status: 409 },
+                    );
+                }
+
+                return NextResponse.json({
+                    success: true,
+                    found: true,
+                    key: keyValidation.key,
+                    value: updated.value,
+                    revision: revisionToken(updated.revision),
+                    restoredFromRevision: revisionToken(backup.revision),
+                });
+            },
+        });
+    } catch (error) {
+        console.error("Error restoring canvas applet shared data:", error);
+        return NextResponse.json(
+            { error: error.status ? error.message : "Internal server error" },
+            { status: error.status || 500 },
+        );
+    }
+}

--- a/app/api/canvas-applets/[id]/shared-data/[key]/route.js
+++ b/app/api/canvas-applets/[id]/shared-data/[key]/route.js
@@ -1,0 +1,200 @@
+import { NextResponse } from "next/server";
+import { parseJsonRequest } from "../../../../utils/parseJsonRequest";
+import { getCanvasAppletForDataAccess } from "../../utils";
+import {
+    APPLET_SDK_LIMITS,
+    withAppletSdkGuard,
+} from "../../../../applet/sdk-guard";
+import {
+    createSharedData,
+    createSharedDataBackup,
+    hasMeaningfulContent,
+    isPlainSharedDataObject,
+    isRevisionMatch,
+    loadSharedData,
+    replaceSharedData,
+    revisionToken,
+    validateSharedDataKey,
+} from "../../../shared-data-utils";
+
+function sharedDataResponse(doc) {
+    return {
+        found: Boolean(doc),
+        value: doc ? doc.value : null,
+        revision: doc ? revisionToken(doc.revision) : null,
+        key: doc ? doc.key : null,
+    };
+}
+
+// GET: retrieve shared data for a canvas applet workspace.
+export async function GET(request, { params }) {
+    const { id } = params;
+
+    try {
+        const keyValidation = validateSharedDataKey(params.key);
+        if (keyValidation.error) return keyValidation.error;
+
+        const access = await getCanvasAppletForDataAccess(id);
+        if (access.error) return access.error;
+
+        const { user } = access;
+
+        return await withAppletSdkGuard({
+            appletId: id,
+            userId: user._id,
+            api: "sharedData.get",
+            limits: APPLET_SDK_LIMITS.read,
+            run: async () => {
+                const sharedData = await loadSharedData({
+                    appletId: id,
+                    key: keyValidation.key,
+                });
+
+                return NextResponse.json(sharedDataResponse(sharedData));
+            },
+        });
+    } catch (error) {
+        console.error("Error retrieving canvas applet shared data:", error);
+        return NextResponse.json(
+            { error: error.status ? error.message : "Internal server error" },
+            { status: error.status || 500 },
+        );
+    }
+}
+
+// PUT: create or replace shared data with revision protection.
+export async function PUT(request, { params }) {
+    const { id } = params;
+
+    try {
+        const keyValidation = validateSharedDataKey(params.key);
+        if (keyValidation.error) return keyValidation.error;
+
+        const parsedBody = await parseJsonRequest(request);
+        if (!parsedBody.ok) return parsedBody.errorResponse;
+
+        const body = parsedBody.body || {};
+        if (body.value === undefined) {
+            return NextResponse.json(
+                { error: "value is required" },
+                { status: 400 },
+            );
+        }
+        if (!isPlainSharedDataObject(body.value)) {
+            return NextResponse.json(
+                { error: "value must be an object" },
+                { status: 400 },
+            );
+        }
+
+        const access = await getCanvasAppletForDataAccess(id);
+        if (access.error) return access.error;
+
+        const { user } = access;
+
+        return await withAppletSdkGuard({
+            appletId: id,
+            userId: user._id,
+            api: "sharedData.set",
+            limits: APPLET_SDK_LIMITS.dataWrite,
+            run: async () => {
+                const existing = await loadSharedData({
+                    appletId: id,
+                    key: keyValidation.key,
+                });
+
+                if (!existing) {
+                    if (
+                        body.expectedRevision !== undefined &&
+                        body.expectedRevision !== null
+                    ) {
+                        return NextResponse.json(
+                            {
+                                error: "expectedRevision must be null when creating shared data",
+                                code: "SHARED_DATA_REVISION_CONFLICT",
+                            },
+                            { status: 409 },
+                        );
+                    }
+
+                    const created = await createSharedData({
+                        appletId: id,
+                        key: keyValidation.key,
+                        value: body.value,
+                        userId: user._id,
+                    });
+
+                    return NextResponse.json({
+                        success: true,
+                        ...sharedDataResponse(created),
+                    });
+                }
+
+                if (
+                    body.expectedRevision != null &&
+                    !isRevisionMatch(body.expectedRevision, existing.revision)
+                ) {
+                    return NextResponse.json(
+                        {
+                            error: "Shared data revision conflict",
+                            code: "SHARED_DATA_REVISION_CONFLICT",
+                            revision: revisionToken(existing.revision),
+                        },
+                        { status: 409 },
+                    );
+                }
+
+                const incomingHasContent = hasMeaningfulContent(body.value);
+                const existingHasContent = hasMeaningfulContent(existing.value);
+                if (
+                    existingHasContent &&
+                    !incomingHasContent &&
+                    body.reset !== true
+                ) {
+                    return NextResponse.json(
+                        {
+                            error: "sharedData.set() cannot clear non-empty shared data. Use sharedData.reset() for a user-confirmed clear or reset.",
+                            code: "SHARED_DATA_EMPTY_OVERWRITE_BLOCKED",
+                            revision: revisionToken(existing.revision),
+                        },
+                        { status: 409 },
+                    );
+                }
+
+                await createSharedDataBackup({
+                    existing,
+                    userId: user._id,
+                    reason: body.reset === true ? "reset" : "replace",
+                });
+
+                const updated = await replaceSharedData({
+                    existing,
+                    value: body.value,
+                    userId: user._id,
+                });
+
+                if (!updated) {
+                    return NextResponse.json(
+                        {
+                            error: "Shared data revision conflict",
+                            code: "SHARED_DATA_REVISION_CONFLICT",
+                            revision: revisionToken(existing.revision),
+                        },
+                        { status: 409 },
+                    );
+                }
+
+                return NextResponse.json({
+                    success: true,
+                    ...sharedDataResponse(updated),
+                });
+            },
+        });
+    } catch (error) {
+        console.error("Error storing canvas applet shared data:", error);
+        return NextResponse.json(
+            { error: error.status ? error.message : "Internal server error" },
+            { status: error.status || 500 },
+        );
+    }
+}

--- a/app/api/canvas-applets/[id]/utils.js
+++ b/app/api/canvas-applets/[id]/utils.js
@@ -1,0 +1,61 @@
+import { NextResponse } from "next/server";
+import mongoose from "mongoose";
+import Applet from "../../models/applet";
+import { getCurrentUser } from "../../utils/auth";
+
+/**
+ * Verify that the current user can access a v2 canvas applet's data/files.
+ * Access is granted if the user is the owner OR the applet is published.
+ *
+ * @param {string} appletId - The applet ID from the URL params
+ * @returns {{ applet: Object, user: Object } | { error: NextResponse }}
+ */
+export async function getCanvasAppletForDataAccess(appletId) {
+    const user = await getCurrentUser();
+    if (!user?._id) {
+        return {
+            error: NextResponse.json(
+                { error: "Unauthorized" },
+                { status: 401 },
+            ),
+        };
+    }
+
+    if (!mongoose.Types.ObjectId.isValid(appletId)) {
+        return {
+            error: NextResponse.json(
+                { error: "Invalid applet ID" },
+                { status: 400 },
+            ),
+        };
+    }
+
+    const applet = await Applet.findOne({
+        _id: appletId,
+        version: 2,
+    });
+
+    if (!applet) {
+        return {
+            error: NextResponse.json(
+                { error: "Applet not found" },
+                { status: 404 },
+            ),
+        };
+    }
+
+    // Allow access if user is owner or applet is published
+    const isOwner = applet.owner.toString() === user._id.toString();
+    const isPublished = applet.publishedVersionIndex != null;
+
+    if (!isOwner && !isPublished) {
+        return {
+            error: NextResponse.json(
+                { error: "Access denied" },
+                { status: 403 },
+            ),
+        };
+    }
+
+    return { applet, user };
+}

--- a/app/api/canvas-applets/delete.js
+++ b/app/api/canvas-applets/delete.js
@@ -1,0 +1,141 @@
+import AppletData from "../models/applet-data";
+import AppletFile from "../models/applet-file";
+import AppletSharedData from "../models/applet-shared-data";
+import AppletSharedDataRevision from "../models/applet-shared-data-revision";
+import AppletSharedFile from "../models/applet-shared-file";
+import File from "../models/file";
+import { deleteMediaFile } from "../utils/media-service-utils";
+import {
+    createAppletGlobalStorageTarget,
+    createAppletSharedStorageTarget,
+    createAppletUserStorageTarget,
+    createUserGlobalStorageTarget,
+} from "../../../src/utils/storageTargets";
+import { resolveCanvasAppletPrimaryFile } from "./files";
+import {
+    deleteAppletVersionSnapshots,
+    deletePublishedAppletSnapshot,
+} from "./versioning";
+
+function dedupeFiles(files = []) {
+    const seen = new Set();
+    return files.filter((file) => {
+        if (!file?._id) {
+            return false;
+        }
+        const key = String(file._id);
+        if (seen.has(key)) {
+            return false;
+        }
+        seen.add(key);
+        return true;
+    });
+}
+
+function isV2Applet(applet) {
+    return Number(applet?.version || 1) === 2;
+}
+
+async function deleteAppletCloudFiles(files, storageTarget) {
+    if (!storageTarget) {
+        return;
+    }
+
+    await Promise.allSettled(
+        files.map((file) =>
+            deleteMediaFile({
+                blobPath: file?.blobPath || null,
+                hash: file?.hash || null,
+                fallbackToHash: false,
+                storageTarget,
+            }),
+        ),
+    );
+}
+
+export async function deleteCanvasAppletArtifacts(applet, user) {
+    const [appletFiles, sharedFiles] = await Promise.all([
+        AppletFile.findOne({
+            appletId: applet._id,
+            userId: user._id,
+        }).populate("files"),
+        AppletSharedFile.findOne({
+            appletId: applet._id,
+        }).populate("files"),
+    ]);
+    const primaryFile = await resolveCanvasAppletPrimaryFile(applet, user);
+    const userFilesToDelete = dedupeFiles(appletFiles?.files || []);
+    const sharedFilesToDelete = dedupeFiles(sharedFiles?.files || []);
+    const primaryFilesToDelete = dedupeFiles(primaryFile ? [primaryFile] : []);
+    const shouldDeleteLegacyPrimaryFiles = !isV2Applet(applet);
+    const userFileIds = new Set(
+        userFilesToDelete.map((file) => String(file?._id)).filter(Boolean),
+    );
+    const primaryFilesNeedingLegacyDelete = shouldDeleteLegacyPrimaryFiles
+        ? primaryFilesToDelete.filter(
+              (file) => !userFileIds.has(String(file?._id)),
+          )
+        : [];
+    const filesToDelete = dedupeFiles([
+        ...userFilesToDelete,
+        ...sharedFilesToDelete,
+        ...primaryFilesToDelete,
+    ]);
+
+    await Promise.allSettled([
+        deleteAppletCloudFiles(
+            userFilesToDelete,
+            createAppletUserStorageTarget(
+                user?.contextId || null,
+                applet?._id?.toString() || null,
+            ),
+        ),
+        deleteAppletCloudFiles(
+            sharedFilesToDelete,
+            createAppletSharedStorageTarget(applet?._id?.toString() || null),
+        ),
+        deleteAppletCloudFiles(
+            primaryFilesToDelete,
+            createAppletGlobalStorageTarget(user?.contextId || null),
+        ),
+        // Legacy: applets used to live under the user's global folder before
+        // the dedicated applets/ scope existed. Try that path too so we don't
+        // leave orphaned files for older applets.
+        shouldDeleteLegacyPrimaryFiles
+            ? deleteAppletCloudFiles(
+                  primaryFilesToDelete,
+                  createUserGlobalStorageTarget(user?.contextId || null),
+              )
+            : Promise.resolve(),
+        shouldDeleteLegacyPrimaryFiles
+            ? deleteAppletCloudFiles(
+                  primaryFilesNeedingLegacyDelete,
+                  createAppletUserStorageTarget(
+                      user?.contextId || null,
+                      applet?._id?.toString() || null,
+                  ),
+              )
+            : Promise.resolve(),
+        deleteAppletVersionSnapshots(applet?.htmlVersions || [], user),
+        deletePublishedAppletSnapshot(applet),
+    ]);
+
+    await Promise.all([
+        AppletData.deleteMany({ appletId: applet._id, userId: user._id }),
+        AppletFile.deleteMany({ appletId: applet._id, userId: user._id }),
+        AppletSharedData.deleteMany({ appletId: applet._id }),
+        AppletSharedDataRevision.deleteMany({ appletId: applet._id }),
+        AppletSharedFile.deleteMany({ appletId: applet._id }),
+        filesToDelete.length > 0
+            ? File.deleteMany({
+                  _id: {
+                      $in: filesToDelete.map((file) => file._id),
+                  },
+              })
+            : Promise.resolve(),
+    ]);
+
+    return {
+        deletedFileCount: filesToDelete.length,
+    };
+}

--- a/app/api/canvas-applets/files.js
+++ b/app/api/canvas-applets/files.js
@@ -1,0 +1,255 @@
+import Applet from "../models/applet";
+import File from "../models/file";
+import {
+    checkMediaFile,
+    hashBuffer,
+    uploadBufferToMediaService,
+} from "../utils/media-service-utils";
+import { createAppletGlobalStorageTarget } from "../../../src/utils/storageTargets";
+import {
+    injectAppletIdMeta,
+    injectAppletMetaTags,
+} from "../../../src/utils/appletHtmlUtils";
+import { resolveAppletVersionContent } from "./versioning";
+
+const WORKSPACE_FILES_PREFIX = "/workspace/files/";
+
+export function extractBlobPathFromUrl(blobUrl) {
+    try {
+        const urlObj = new URL(blobUrl);
+        const segments = urlObj.pathname.split("/").filter(Boolean);
+        const isAzurite =
+            urlObj.hostname === "127.0.0.1" || urlObj.hostname === "localhost";
+        const skip = isAzurite ? 2 : 1;
+        if (segments.length <= skip) return null;
+        return segments.slice(skip).map(decodeURIComponent).join("/");
+    } catch {
+        return null;
+    }
+}
+
+export function buildWorkspacePathFromBlobPath(blobPath) {
+    return blobPath ? `/workspace/files/${blobPath}` : null;
+}
+
+export function extractBlobPathFromWorkspacePath(workspacePath) {
+    if (
+        !workspacePath ||
+        typeof workspacePath !== "string" ||
+        !workspacePath.startsWith(WORKSPACE_FILES_PREFIX)
+    ) {
+        return null;
+    }
+
+    return workspacePath.slice(WORKSPACE_FILES_PREFIX.length) || null;
+}
+
+function endsWithHtml(value) {
+    return (
+        typeof value === "string" &&
+        value.trim().toLowerCase().endsWith(".html")
+    );
+}
+
+export function isCanvasAppletHtmlFile(file) {
+    if (!file) {
+        return false;
+    }
+
+    if (file.mimeType === "text/html") {
+        return true;
+    }
+
+    return [
+        file.displayFilename,
+        file.filename,
+        file.originalName,
+        file.blobPath,
+        file.url,
+        file.gcsUrl,
+    ].some(endsWithHtml);
+}
+
+export async function resolveCanvasAppletFileByWorkspacePath(
+    workspacePath,
+    user,
+) {
+    const blobPath = extractBlobPathFromWorkspacePath(workspacePath);
+    if (!blobPath || !user?.contextId) {
+        return null;
+    }
+
+    const resolvedFile = await checkMediaFile({
+        blobPath,
+        userId: user.contextId,
+    });
+
+    if (!resolvedFile?.url) {
+        return null;
+    }
+
+    return {
+        ...resolvedFile,
+        blobPath: resolvedFile.blobPath || blobPath,
+    };
+}
+
+export async function resolveCanvasAppletPrimaryFile(applet, user) {
+    if (!applet?.filePath || !user?._id) {
+        return null;
+    }
+
+    const matchQuery = [{ url: applet.filePath }, { gcsUrl: applet.filePath }];
+    const blobPath = extractBlobPathFromUrl(applet.filePath);
+    if (blobPath) {
+        matchQuery.push({ blobPath });
+    }
+
+    return File.findOne({
+        owner: user._id,
+        $or: matchQuery,
+    }).lean();
+}
+
+export async function getCanvasAppletEditableFileInfo(applet, user) {
+    const primaryFile = await resolveCanvasAppletPrimaryFile(applet, user);
+    const blobPath =
+        primaryFile?.blobPath || extractBlobPathFromUrl(applet?.filePath);
+
+    return {
+        fileHash: primaryFile?.hash || null,
+        fileBlobPath: blobPath || null,
+        workspacePath: buildWorkspacePathFromBlobPath(blobPath),
+    };
+}
+
+function slugifyAppletName(name) {
+    const cleaned = (name || "")
+        .toString()
+        .trim()
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, "-")
+        .replace(/^-+|-+$/g, "")
+        .slice(0, 60);
+    return cleaned || "applet";
+}
+
+export function buildAppletFilenameFromWorkspacePath(
+    workspacePath,
+    appletName = "Applet",
+) {
+    const fileNameFromPath = (workspacePath || "").split("/").pop() || "";
+    if (fileNameFromPath) {
+        return fileNameFromPath;
+    }
+
+    return `${slugifyAppletName(appletName)}.html`;
+}
+
+export function getAppletWorkspaceUploadSubPath(workspacePath) {
+    if (!workspacePath) return null;
+
+    const normalized = workspacePath.replace(/^\/workspace\/files\/?/, "");
+    const prefix = "applets/";
+    if (!normalized.startsWith(prefix)) return null;
+
+    const relative = normalized.slice(prefix.length);
+    const segments = relative.split("/").filter(Boolean);
+    if (segments.length <= 1) return null;
+
+    return segments.slice(0, -1).join("/");
+}
+
+async function pickAppletSourceHtml(applet) {
+    if (typeof applet?.html === "string" && applet.html.length > 0) {
+        return applet.html;
+    }
+    const versions = Array.isArray(applet?.htmlVersions)
+        ? applet.htmlVersions
+        : [];
+    const publishedIndex =
+        typeof applet?.publishedVersionIndex === "number"
+            ? applet.publishedVersionIndex
+            : null;
+    if (publishedIndex != null && versions[publishedIndex]) {
+        return await resolveAppletVersionContent(versions[publishedIndex]);
+    }
+    const last = versions[versions.length - 1];
+    return await resolveAppletVersionContent(last);
+}
+
+/**
+ * For legacy (v1) applets that have no editable workspace file backing, write
+ * the applet's current HTML to the user's applets/ folder via media-helper,
+ * persist a File record so getCanvasAppletEditableFileInfo can resolve it,
+ * and store filePath on the applet. No-op if filePath is already set.
+ *
+ * Returns a possibly-updated applet (plain object) on success; on failure
+ * returns the original applet unchanged so callers can degrade gracefully.
+ */
+export async function ensureAppletWorkspaceFile(applet, user) {
+    if (!applet || !user?._id) return applet;
+    if (applet.filePath) return applet;
+    if (!user.contextId) return applet;
+
+    const sourceHtml = await pickAppletSourceHtml(applet);
+    if (!sourceHtml) return applet;
+
+    const appletId = applet._id?.toString?.() || String(applet._id);
+    const appletName = applet.name || "Applet";
+    const taggedHtml = injectAppletIdMeta(
+        injectAppletMetaTags(sourceHtml, appletName),
+        appletId,
+    );
+
+    const filename = `${slugifyAppletName(appletName)}-${appletId}.html`;
+    const buffer = Buffer.from(taggedHtml, "utf8");
+    const hash = await hashBuffer(buffer);
+    const metadata = {
+        filename,
+        mimeType: "text/html",
+        size: buffer.length,
+        hash,
+    };
+
+    const uploadResult = await uploadBufferToMediaService(buffer, metadata, {
+        storageTarget: createAppletGlobalStorageTarget(user.contextId),
+    });
+    if (uploadResult?.error || !uploadResult?.data?.url) {
+        return applet;
+    }
+
+    const data = uploadResult.data;
+    const fileUrl = data.converted?.url || data.url;
+    const gcsUrl = data.converted?.gcs || data.gcs || null;
+    const blobPath = data.blobPath || extractBlobPathFromUrl(fileUrl);
+
+    try {
+        const fileDoc = new File({
+            filename: data.filename || filename,
+            originalName: filename,
+            mimeType: "text/html",
+            size: buffer.length,
+            url: fileUrl,
+            gcsUrl,
+            hash: data.hash || hash,
+            blobPath,
+            owner: user._id,
+        });
+        await fileDoc.save();
+    } catch (err) {
+        // File doc may already exist for the same blob — that's fine.
+        console.warn(
+            "ensureAppletWorkspaceFile: File document insert skipped:",
+            err?.message,
+        );
+    }
+
+    const updated = await Applet.findByIdAndUpdate(
+        applet._id,
+        { filePath: fileUrl },
+        { new: true },
+    ).lean();
+
+    return updated || { ...applet, filePath: fileUrl };
+}

--- a/app/api/canvas-applets/registry.js
+++ b/app/api/canvas-applets/registry.js
@@ -1,0 +1,686 @@
+import Applet from "../models/applet";
+import App, { APP_TYPES, APP_STATUS } from "../models/app";
+import { uploadBufferToMediaService } from "../utils/media-service-utils";
+import { createAppletGlobalStorageTarget } from "../../../src/utils/storageTargets";
+import {
+    applyPublishedAppletSnapshot,
+    clearPublishedContentFields,
+    createAppletVersionEntry,
+    deleteAppletVersionSnapshots,
+    deletePublishedAppletSnapshot,
+    deleteReplacedPublishedAppletSnapshot,
+    getPublishedAppletSnapshot,
+    hydrateAppletVersionContents,
+    resolveAppletVersionContent,
+} from "./versioning";
+import {
+    buildAppletFilenameFromWorkspacePath,
+    ensureAppletWorkspaceFile,
+    getAppletWorkspaceUploadSubPath,
+    getCanvasAppletEditableFileInfo,
+    isCanvasAppletHtmlFile,
+    resolveCanvasAppletFileByWorkspacePath,
+} from "./files";
+import { deleteCanvasAppletArtifacts } from "./delete";
+
+const RESERVED_APP_NAMES = new Set([
+    "Translate",
+    "Transcribe",
+    "Write",
+    "Workspaces",
+    "Images",
+    "Jira",
+]);
+
+function toPlainApplet(applet) {
+    return typeof applet?.toObject === "function" ? applet.toObject() : applet;
+}
+
+async function maybeLean(queryOrValue) {
+    if (!queryOrValue) return null;
+    if (typeof queryOrValue.lean === "function") {
+        return queryOrValue.lean();
+    }
+    return queryOrValue;
+}
+
+function isV2(applet) {
+    return Number(applet?.version || 1) === 2;
+}
+
+function versionsOf(applet) {
+    return Array.isArray(applet?.htmlVersions) ? applet.htmlVersions : [];
+}
+
+function publishedIndexOf(applet) {
+    return typeof applet?.publishedVersionIndex === "number"
+        ? applet.publishedVersionIndex
+        : null;
+}
+
+function parseVersionNumber(value, field) {
+    if (value == null || value === "") return null;
+    const version = Number(value);
+    if (!Number.isInteger(version) || version <= 0) {
+        const error = new Error(`${field} must be a positive whole number`);
+        error.status = 400;
+        throw error;
+    }
+    return version;
+}
+
+function getVersionByNumber(applet, versionNumber) {
+    const versions = versionsOf(applet);
+    const index = versionNumber - 1;
+    const version = versions[index] || null;
+    if (!version) {
+        const error = new Error(
+            `Version ${versionNumber} not found. Applet has ${versions.length} saved version(s).`,
+        );
+        error.status = 404;
+        throw error;
+    }
+    return { version, index };
+}
+
+function ensureHtmlContent(html, message) {
+    if (typeof html === "string" && html.length > 0) return html;
+    const error = new Error(message);
+    error.status = 404;
+    throw error;
+}
+
+const EMPTY_APPLET_DRAFT_HTML =
+    "<!doctype html><html><head></head><body></body></html>";
+
+function slugify(value) {
+    return (value || "")
+        .toString()
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, "-")
+        .replace(/^-|-$/g, "");
+}
+
+async function resolveExistingAppSlug(applet, appName, requestedSlug) {
+    if (requestedSlug) return requestedSlug;
+    const existing = await maybeLean(App.findOne({ appletId: applet._id }));
+    return existing?.slug || slugify(appName);
+}
+
+async function validateAppStorePublish(applet, body) {
+    if (body.publishToAppStore !== true) return null;
+
+    const appName =
+        body.appName || body.name || applet.name || "Untitled Applet";
+    if (RESERVED_APP_NAMES.has(appName)) {
+        const error = new Error(
+            `App name "${appName}" is reserved. Please use another name.`,
+        );
+        error.status = 400;
+        throw error;
+    }
+
+    const appSlug = await resolveExistingAppSlug(applet, appName, body.appSlug);
+    const collision = await maybeLean(
+        App.findOne({
+            slug: appSlug,
+            appletId: { $ne: applet._id },
+            status: APP_STATUS.ACTIVE,
+        }),
+    );
+    if (collision) {
+        const error = new Error(
+            `The slug "${appSlug}" is already in use. Please choose a different slug.`,
+        );
+        error.status = 400;
+        throw error;
+    }
+
+    return { appName, appSlug };
+}
+
+async function saveApplet(applet) {
+    if (typeof applet.save === "function") {
+        return applet.save();
+    }
+    return Applet.findByIdAndUpdate(applet._id, applet, {
+        new: true,
+        runValidators: true,
+    });
+}
+
+async function loadOwnedApplet(user, id, { materializeLegacy = false } = {}) {
+    const applet = await Applet.findOne({ _id: id, owner: user._id });
+    if (!applet) {
+        const error = new Error("Applet not found");
+        error.status = 404;
+        throw error;
+    }
+
+    if (materializeLegacy && !applet.filePath) {
+        const materialized = await ensureAppletWorkspaceFile(
+            toPlainApplet(applet),
+            user,
+        );
+        if (
+            materialized?.filePath &&
+            materialized.filePath !== applet.filePath
+        ) {
+            const refreshed = await Applet.findById(applet._id);
+            return refreshed || applet;
+        }
+    }
+
+    return applet;
+}
+
+async function toRegistryPayload(applet, user, { includeApp = true } = {}) {
+    const plain = await hydrateAppletVersionContents(
+        toPlainApplet(applet),
+        user,
+    );
+    const [fileInfo, app] = await Promise.all([
+        getCanvasAppletEditableFileInfo(plain, user),
+        includeApp
+            ? maybeLean(
+                  App.findOne({
+                      appletId: plain._id,
+                      status: APP_STATUS.ACTIVE,
+                  }),
+              )
+            : null,
+    ]);
+
+    return {
+        ...plain,
+        ...fileInfo,
+        app: app || null,
+    };
+}
+
+async function resolveLinkedWorkspaceFile(workspacePath, user) {
+    const linkedFile = await resolveCanvasAppletFileByWorkspacePath(
+        workspacePath,
+        user,
+    );
+    if (!linkedFile) {
+        const error = new Error(
+            "Workspace file not found for this applet link",
+        );
+        error.status = 404;
+        throw error;
+    }
+    if (!isCanvasAppletHtmlFile(linkedFile)) {
+        const error = new Error(
+            "Applet workspace link must point to an HTML file",
+        );
+        error.status = 400;
+        throw error;
+    }
+    return linkedFile;
+}
+
+async function writeDraftToWorkspace(applet, user, html, workspacePath) {
+    const filename = buildAppletFilenameFromWorkspacePath(
+        workspacePath,
+        applet.name || "Applet",
+    );
+    const buffer = Buffer.from(typeof html === "string" ? html : "", "utf8");
+    const uploadResult = await uploadBufferToMediaService(
+        buffer,
+        {
+            filename,
+            mimeType: "text/html",
+            size: buffer.length,
+        },
+        {
+            storageTarget: createAppletGlobalStorageTarget(user.contextId),
+            subPath: getAppletWorkspaceUploadSubPath(workspacePath),
+        },
+    );
+
+    if (uploadResult?.error || !uploadResult?.data?.url) {
+        const error = new Error("Failed to write applet HTML to workspace");
+        error.status = 502;
+        throw error;
+    }
+
+    return uploadResult.data.converted?.url || uploadResult.data.url;
+}
+
+async function latestVersionHtml(applet) {
+    const versions = versionsOf(applet);
+    return resolveAppletVersionContent(versions[versions.length - 1]);
+}
+
+async function appendVersionIfChanged(applet, user, html) {
+    const versions = versionsOf(applet);
+    const currentLatestHtml = await latestVersionHtml(applet);
+    if (versions.length > 0 && currentLatestHtml === html) {
+        return {
+            versionSaved: false,
+            latestVersionIndex: versions.length - 1,
+        };
+    }
+
+    const entry = await createAppletVersionEntry(applet, user, html, {
+        versionIndex: versions.length,
+        external: isV2(applet),
+    });
+    applet.htmlVersions = [...versions, entry];
+    return {
+        versionSaved: true,
+        latestVersionIndex: versions.length,
+    };
+}
+
+async function publishVersionIndex(applet, index) {
+    const version = versionsOf(applet)[index];
+    const html = ensureHtmlContent(
+        await resolveAppletVersionContent(version),
+        `Version ${index + 1} has no HTML content`,
+    );
+
+    applet.publishedVersionIndex = index;
+    if (isV2(applet)) {
+        return applyPublishedAppletSnapshot(applet, html, {
+            versionIndex: index,
+        });
+    }
+    return null;
+}
+
+async function unpublish(applet) {
+    const previousPublishedSnapshot = isV2(applet)
+        ? getPublishedAppletSnapshot(applet)
+        : null;
+    if (isV2(applet)) {
+        clearPublishedContentFields(applet);
+    }
+    applet.publishedVersionIndex = null;
+    return previousPublishedSnapshot;
+}
+
+async function applyAppStoreState(applet, user, body, appStorePublish) {
+    if (body.publishToAppStore === undefined) return;
+
+    if (body.publishToAppStore) {
+        await App.findOneAndUpdate(
+            { appletId: applet._id },
+            {
+                name: appStorePublish.appName,
+                slug: appStorePublish.appSlug,
+                author: user._id,
+                type: APP_TYPES.APPLET,
+                status: APP_STATUS.ACTIVE,
+                appletId: applet._id,
+                icon: body.appIcon || null,
+                description: body.appDescription || null,
+            },
+            { new: true, upsert: true, runValidators: true },
+        );
+    } else {
+        await App.findOneAndUpdate(
+            { appletId: applet._id },
+            { status: APP_STATUS.INACTIVE },
+            { new: true },
+        );
+    }
+}
+
+export async function listAppletRegistry(user) {
+    const applets = await Applet.find({ owner: user._id })
+        .select(
+            "name filePath publishedVersionIndex version createdAt updatedAt sdkSuspendedAt sdkSuspendedUntil sdkSuspendedReason",
+        )
+        .sort({ updatedAt: -1 })
+        .lean();
+
+    const hydrated = await Promise.all(
+        applets.map(async (applet) => ({
+            ...applet,
+            ...(await getCanvasAppletEditableFileInfo(applet, user)),
+        })),
+    );
+
+    return { applets: hydrated };
+}
+
+export async function createAppletRegistry(user, body = {}) {
+    const { name, filePath, html, workspacePath } = body;
+    let resolvedFilePath = filePath || null;
+
+    if (workspacePath) {
+        const linkedFile = await resolveLinkedWorkspaceFile(
+            workspacePath,
+            user,
+        );
+        const possiblePaths = [linkedFile.url, linkedFile.gcsUrl].filter(
+            Boolean,
+        );
+        const duplicate = await maybeLean(
+            Applet.findOne({
+                owner: user._id,
+                filePath: { $in: possiblePaths },
+            }),
+        );
+        if (duplicate) {
+            const error = new Error(
+                "An applet already references this workspace file",
+            );
+            error.status = 409;
+            error.details = { appletId: duplicate._id };
+            throw error;
+        }
+        resolvedFilePath =
+            linkedFile.url || linkedFile.gcsUrl || resolvedFilePath;
+    } else if (filePath) {
+        const duplicate = await maybeLean(
+            Applet.findOne({
+                owner: user._id,
+                filePath,
+            }),
+        );
+        if (duplicate) {
+            const error = new Error("An applet already references this file");
+            error.status = 409;
+            error.details = { appletId: duplicate._id };
+            throw error;
+        }
+    }
+
+    const applet = await Applet.create({
+        owner: user._id,
+        name: name || "Untitled Applet",
+        filePath: resolvedFilePath,
+        html: "",
+        version: 2,
+        htmlVersions: [],
+    });
+
+    if (html) {
+        const { latestVersionIndex } = await appendVersionIfChanged(
+            applet,
+            user,
+            html,
+        );
+        applet.html = "";
+        await saveApplet(applet);
+        return {
+            ...(await toRegistryPayload(applet, user, { includeApp: false })),
+            versionSaved: true,
+            latestVersionIndex,
+        };
+    }
+
+    return toRegistryPayload(applet, user, { includeApp: false });
+}
+
+export async function getAppletRegistry(user, id) {
+    const applet = await loadOwnedApplet(user, id, { materializeLegacy: true });
+    return toRegistryPayload(applet, user);
+}
+
+export async function updateAppletRegistry(user, id, body = {}) {
+    const restoreVersion = parseVersionNumber(
+        body.restoreVersion,
+        "restoreVersion",
+    );
+    const publishVersion = parseVersionNumber(
+        body.publishVersion,
+        "publishVersion",
+    );
+    const deleteVersion = parseVersionNumber(
+        body.deleteVersion,
+        "deleteVersion",
+    );
+    const clearDraft = body.clearDraft === true;
+    const applet = await loadOwnedApplet(user, id, { materializeLegacy: true });
+    const appStorePublish = await validateAppStorePublish(applet, body);
+    let versionSaved = false;
+    let versionDeleted = false;
+    let deletedVersion = null;
+    let latestVersionIndex =
+        versionsOf(applet).length > 0 ? versionsOf(applet).length - 1 : null;
+    const postSaveCleanups = [];
+
+    function queuePublishedReplacementCleanup(replacement) {
+        if (!replacement) return;
+        postSaveCleanups.push(() =>
+            deleteReplacedPublishedAppletSnapshot(
+                replacement.previousPublishedSnapshot,
+                replacement.nextPublishedSnapshot,
+            ),
+        );
+    }
+
+    function queuePublishedDeleteCleanup(snapshot) {
+        if (!snapshot) return;
+        postSaveCleanups.push(() => deletePublishedAppletSnapshot(snapshot));
+    }
+
+    function queueVersionDeleteCleanup(versions) {
+        if (!versions?.length) return;
+        postSaveCleanups.push(() =>
+            deleteAppletVersionSnapshots(versions, user),
+        );
+    }
+
+    if (body.name !== undefined) {
+        applet.name = body.name;
+    }
+
+    if (body.filePath !== undefined) {
+        applet.filePath = body.filePath || null;
+    }
+
+    if (body.workspacePath !== undefined) {
+        const linkedFile = await resolveLinkedWorkspaceFile(
+            body.workspacePath,
+            user,
+        );
+        applet.filePath =
+            linkedFile.url || linkedFile.gcsUrl || applet.filePath;
+    }
+
+    if (body.clearSdkSuspension === true) {
+        applet.sdkSuspendedAt = undefined;
+        applet.sdkSuspendedUntil = undefined;
+        applet.sdkSuspendedReason = undefined;
+    }
+
+    let htmlForDraft = body.html;
+    if (restoreVersion != null) {
+        const { version, index } = getVersionByNumber(applet, restoreVersion);
+        htmlForDraft = ensureHtmlContent(
+            await resolveAppletVersionContent(version),
+            `Version ${restoreVersion} has no HTML content`,
+        );
+        const { workspacePath } = await getCanvasAppletEditableFileInfo(
+            toPlainApplet(applet),
+            user,
+        );
+        const targetWorkspacePath = body.workspacePath || workspacePath || null;
+        if (!targetWorkspacePath) {
+            const error = new Error(
+                "No editable workspace file is linked to this applet",
+            );
+            error.status = 400;
+            throw error;
+        }
+        applet.filePath = await writeDraftToWorkspace(
+            applet,
+            user,
+            htmlForDraft,
+            targetWorkspacePath,
+        );
+        latestVersionIndex = index;
+    }
+
+    if (clearDraft) {
+        const versions = versionsOf(applet);
+        const latestVersion = versions[versions.length - 1] || null;
+        const draftHtml = latestVersion
+            ? ensureHtmlContent(
+                  await resolveAppletVersionContent(latestVersion),
+                  "Latest version has no HTML content",
+              )
+            : EMPTY_APPLET_DRAFT_HTML;
+        const { workspacePath } = await getCanvasAppletEditableFileInfo(
+            toPlainApplet(applet),
+            user,
+        );
+        const targetWorkspacePath = body.workspacePath || workspacePath || null;
+        if (!targetWorkspacePath) {
+            const error = new Error(
+                "No editable workspace file is linked to this applet",
+            );
+            error.status = 400;
+            throw error;
+        }
+        applet.filePath = await writeDraftToWorkspace(
+            applet,
+            user,
+            draftHtml,
+            targetWorkspacePath,
+        );
+        if (!isV2(applet)) {
+            applet.html = draftHtml;
+        }
+        latestVersionIndex = latestVersion ? versions.length - 1 : null;
+    }
+
+    if (publishVersion != null) {
+        const { index } = getVersionByNumber(applet, publishVersion);
+        queuePublishedReplacementCleanup(
+            await publishVersionIndex(applet, index),
+        );
+    }
+
+    if (deleteVersion != null) {
+        const versions = versionsOf(applet);
+        const { version, index } = getVersionByNumber(applet, deleteVersion);
+        const publishedIndex = publishedIndexOf(applet);
+
+        applet.htmlVersions = versions.filter((_, i) => i !== index);
+        if (publishedIndex === index) {
+            queuePublishedDeleteCleanup(await unpublish(applet));
+        } else if (publishedIndex != null && publishedIndex > index) {
+            applet.publishedVersionIndex = publishedIndex - 1;
+            if (isV2(applet) && applet.publishedContentVersionIndex != null) {
+                applet.publishedContentVersionIndex = publishedIndex - 1;
+            }
+        }
+
+        queueVersionDeleteCleanup([version]);
+        versionDeleted = true;
+        deletedVersion = deleteVersion;
+        latestVersionIndex =
+            applet.htmlVersions.length > 0
+                ? applet.htmlVersions.length - 1
+                : null;
+    }
+
+    if (htmlForDraft !== undefined) {
+        if (body.saveVersion === true || body.publish === true) {
+            const versionResult = await appendVersionIfChanged(
+                applet,
+                user,
+                htmlForDraft,
+            );
+            versionSaved = versionResult.versionSaved;
+            latestVersionIndex = versionResult.latestVersionIndex;
+            if (body.publish === true) {
+                queuePublishedReplacementCleanup(
+                    await publishVersionIndex(applet, latestVersionIndex),
+                );
+            }
+        }
+
+        applet.html = isV2(applet) ? "" : htmlForDraft;
+    } else if (
+        (body.saveVersion === true || body.publish === true) &&
+        restoreVersion == null &&
+        publishVersion == null &&
+        deleteVersion == null &&
+        !clearDraft
+    ) {
+        const error = new Error("html is required when saving or publishing");
+        error.status = 400;
+        throw error;
+    }
+
+    if (body.unpublish) {
+        queuePublishedDeleteCleanup(await unpublish(applet));
+    }
+
+    if (
+        body.publishToAppStore === true &&
+        isV2(applet) &&
+        publishedIndexOf(applet) != null &&
+        (!applet.publishedContentBlobPath ||
+            applet.publishedContentVersionIndex !== publishedIndexOf(applet))
+    ) {
+        queuePublishedReplacementCleanup(
+            await publishVersionIndex(applet, publishedIndexOf(applet)),
+        );
+    }
+
+    const savedApplet = await saveApplet(applet);
+    if (body.clearSdkSuspension === true) {
+        await Applet.updateOne(
+            { _id: applet._id },
+            {
+                $unset: {
+                    sdkSuspendedAt: "",
+                    sdkSuspendedUntil: "",
+                    sdkSuspendedReason: "",
+                },
+            },
+        );
+        for (const target of [applet, savedApplet]) {
+            if (!target) continue;
+            delete target.sdkSuspendedAt;
+            delete target.sdkSuspendedUntil;
+            delete target.sdkSuspendedReason;
+        }
+    }
+    await Promise.allSettled(
+        postSaveCleanups.map(async (cleanup) => {
+            try {
+                return await cleanup();
+            } catch (error) {
+                console.warn(
+                    "updateAppletRegistry: failed to clean applet storage artifact:",
+                    error?.message,
+                );
+                return null;
+            }
+        }),
+    );
+    await applyAppStoreState(
+        savedApplet || applet,
+        user,
+        body,
+        appStorePublish,
+    );
+
+    return {
+        ...(await toRegistryPayload(savedApplet || applet, user)),
+        versionSaved,
+        versionDeleted,
+        deletedVersion,
+        latestVersionIndex,
+    };
+}
+
+export async function deleteAppletRegistry(user, id) {
+    const applet = await loadOwnedApplet(user, id);
+    await deleteCanvasAppletArtifacts(applet, user);
+    await Applet.deleteOne({ _id: id, owner: user._id });
+    await App.findOneAndUpdate(
+        { appletId: id },
+        { status: APP_STATUS.INACTIVE },
+    );
+    return { success: true };
+}

--- a/app/api/canvas-applets/route.js
+++ b/app/api/canvas-applets/route.js
@@ -1,0 +1,48 @@
+import { NextResponse } from "next/server";
+import { getCurrentUser } from "../utils/auth";
+import { createAppletRegistry, listAppletRegistry } from "./registry";
+
+function jsonError(error, fallback = "Internal server error") {
+    return NextResponse.json(
+        {
+            error: error?.message || fallback,
+            ...(error?.details || {}),
+        },
+        { status: error?.status || 500 },
+    );
+}
+
+export async function GET() {
+    try {
+        const user = await getCurrentUser();
+        if (!user?._id) {
+            return NextResponse.json(
+                { error: "Unauthorized" },
+                { status: 401 },
+            );
+        }
+
+        return NextResponse.json(await listAppletRegistry(user));
+    } catch (error) {
+        console.error("Error fetching canvas applets:", error);
+        return jsonError(error);
+    }
+}
+
+export async function POST(request) {
+    try {
+        const user = await getCurrentUser();
+        if (!user?._id) {
+            return NextResponse.json(
+                { error: "Unauthorized" },
+                { status: 401 },
+            );
+        }
+
+        const applet = await createAppletRegistry(user, await request.json());
+        return NextResponse.json(applet, { status: 201 });
+    } catch (error) {
+        console.error("Error creating canvas applet:", error);
+        return jsonError(error);
+    }
+}

--- a/app/api/canvas-applets/shared-data-utils.js
+++ b/app/api/canvas-applets/shared-data-utils.js
@@ -1,0 +1,106 @@
+import { NextResponse } from "next/server";
+import AppletSharedData from "../models/applet-shared-data";
+import AppletSharedDataRevision from "../models/applet-shared-data-revision";
+import { validateMongoDBKey } from "../utils/fileValidation";
+
+export function validateSharedDataKey(key) {
+    const keyValidation = validateMongoDBKey(key);
+    if (!keyValidation.isValid) {
+        return {
+            error: NextResponse.json(
+                {
+                    error: "Invalid key format",
+                    details: keyValidation.errors,
+                },
+                { status: 400 },
+            ),
+        };
+    }
+
+    return { key: keyValidation.sanitizedKey };
+}
+
+export function hasMeaningfulContent(value) {
+    if (value == null) return false;
+    if (typeof value === "string") return value.trim().length > 0;
+    if (typeof value === "number") return Number.isFinite(value);
+    if (typeof value === "boolean") return true;
+    if (Array.isArray(value)) {
+        return value.some((item) => hasMeaningfulContent(item));
+    }
+    if (typeof value === "object") {
+        return Object.values(value).some((item) => hasMeaningfulContent(item));
+    }
+    return false;
+}
+
+export function isPlainSharedDataObject(value) {
+    return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+export function revisionToken(revision) {
+    return revision == null ? null : String(revision);
+}
+
+export function isRevisionMatch(expectedRevision, currentRevision) {
+    return revisionToken(expectedRevision) === revisionToken(currentRevision);
+}
+
+export async function createSharedDataBackup({
+    existing,
+    userId,
+    reason = "replace",
+}) {
+    if (!existing) return null;
+
+    return AppletSharedDataRevision.create({
+        appletId: existing.appletId,
+        key: existing.key,
+        revision: existing.revision,
+        value: existing.value,
+        reason,
+        createdBy: userId,
+    });
+}
+
+export function sharedDataQuery({ appletId, key }) {
+    return { appletId, key };
+}
+
+export async function loadSharedData({ appletId, key }) {
+    return AppletSharedData.findOne(sharedDataQuery({ appletId, key }));
+}
+
+export async function createSharedData({ appletId, key, value, userId }) {
+    return AppletSharedData.create({
+        appletId,
+        key,
+        value,
+        revision: 1,
+        createdBy: userId,
+        updatedBy: userId,
+    });
+}
+
+export async function replaceSharedData({ existing, value, userId }) {
+    const nextRevision = Number(existing.revision || 0) + 1;
+
+    return AppletSharedData.findOneAndUpdate(
+        {
+            appletId: existing.appletId,
+            key: existing.key,
+            revision: existing.revision,
+        },
+        {
+            $set: {
+                value,
+                revision: nextRevision,
+                updatedBy: userId,
+            },
+        },
+        {
+            new: true,
+            runValidators: true,
+        },
+    );
+}

--- a/app/api/canvas-applets/versioning.js
+++ b/app/api/canvas-applets/versioning.js
@@ -1,0 +1,499 @@
+import {
+    deleteMediaFile,
+    hashBuffer,
+    readBlobContent,
+    uploadBufferToMediaService,
+} from "../utils/media-service-utils";
+import Applet from "../models/applet";
+import {
+    createAppletGlobalStorageTarget,
+    createAppletPublishedStorageTarget,
+    getStorageContextId,
+} from "../../../src/utils/storageTargets";
+
+export function extractAppletVersionBlobPathFromUrl(blobUrl) {
+    try {
+        const urlObj = new URL(blobUrl);
+        const segments = urlObj.pathname.split("/").filter(Boolean);
+        const isAzurite =
+            urlObj.hostname === "127.0.0.1" || urlObj.hostname === "localhost";
+        const skip = isAzurite ? 2 : 1;
+        if (segments.length <= skip) return null;
+        return segments.slice(skip).map(decodeURIComponent).join("/");
+    } catch {
+        return null;
+    }
+}
+
+export function getAppletVersionBlobPath(version) {
+    return (
+        version?.contentBlobPath ||
+        extractAppletVersionBlobPathFromUrl(version?.contentUrl) ||
+        null
+    );
+}
+
+function appletIdOf(applet) {
+    return applet?._id?.toString?.() || String(applet?._id || "");
+}
+
+function formatVersionNumber(versionIndex = 0) {
+    return String(Math.max(0, versionIndex) + 1).padStart(6, "0");
+}
+
+function formatTimestampForFilename(date = new Date()) {
+    return date
+        .toISOString()
+        .replace(/[-:]/g, "")
+        .replace(/\.\d{3}Z$/, "Z");
+}
+
+function snapshotBlobPath(data) {
+    return (
+        (data.converted?.url
+            ? data.converted?.blobPath ||
+              extractAppletVersionBlobPathFromUrl(data.converted.url)
+            : null) ||
+        data.blobPath ||
+        data.blobName ||
+        extractAppletVersionBlobPathFromUrl(data.url)
+    );
+}
+
+async function writeHtmlSnapshot({
+    applet,
+    html,
+    storageTarget,
+    subPath,
+    versionIndex = 0,
+    errorLabel,
+}) {
+    const normalizedHtml = typeof html === "string" ? html : "";
+    const buffer = Buffer.from(normalizedHtml, "utf8");
+    const hash = await hashBuffer(buffer);
+    const appletId = appletIdOf(applet);
+    if (!appletId) {
+        throw new Error(`Cannot store ${errorLabel} without applet ID`);
+    }
+
+    const filename = `v${formatVersionNumber(versionIndex)}-${formatTimestampForFilename()}.html`;
+    const uploadResult = await uploadBufferToMediaService(
+        buffer,
+        {
+            filename,
+            mimeType: "text/html",
+            size: buffer.length,
+            hash,
+        },
+        {
+            storageTarget,
+            subPath,
+        },
+    );
+
+    if (uploadResult?.error || !uploadResult?.data?.url) {
+        throw new Error(`Failed to store ${errorLabel}`);
+    }
+
+    const data = uploadResult.data;
+    const blobPath = snapshotBlobPath(data);
+    if (!blobPath) {
+        throw new Error(`Failed to store ${errorLabel} blob path`);
+    }
+
+    return {
+        url: data.converted?.url || data.url,
+        blobPath,
+        hash: data.hash || hash,
+        size: buffer.length,
+        contextId: getStorageContextId({ storageTarget }),
+    };
+}
+
+export async function createAppletHtmlSnapshot(
+    applet,
+    user,
+    html,
+    { versionIndex = 0 } = {},
+) {
+    if (!user?.contextId) {
+        throw new Error(
+            "Cannot store applet version HTML without user context",
+        );
+    }
+
+    const appletId = appletIdOf(applet);
+    return writeHtmlSnapshot({
+        applet,
+        html,
+        storageTarget: createAppletGlobalStorageTarget(user.contextId),
+        subPath: `versions/${appletId}`,
+        versionIndex,
+        errorLabel: "applet version HTML",
+    });
+}
+
+export async function createPublishedAppletHtmlSnapshot(
+    applet,
+    html,
+    { versionIndex = 0 } = {},
+) {
+    const appletId = appletIdOf(applet);
+    const storageTarget = createAppletPublishedStorageTarget();
+    return writeHtmlSnapshot({
+        applet,
+        html,
+        storageTarget,
+        subPath: `published/${appletId}`,
+        versionIndex,
+        errorLabel: "published applet HTML",
+    });
+}
+
+function buildExternalVersionEntry(snapshot) {
+    return {
+        content: "",
+        contentUrl: snapshot.url,
+        contentBlobPath: snapshot.blobPath,
+        contentHash: snapshot.hash,
+        contentSize: snapshot.size,
+        contentContextId: snapshot.contextId,
+        timestamp: new Date(),
+    };
+}
+
+function buildInlineVersionEntry(html) {
+    return {
+        content: typeof html === "string" ? html : "",
+        timestamp: new Date(),
+    };
+}
+
+export async function createAppletVersionEntry(
+    applet,
+    user,
+    html,
+    { versionIndex = 0, external = true } = {},
+) {
+    if (!external) {
+        return buildInlineVersionEntry(html);
+    }
+    const snapshot = await createAppletHtmlSnapshot(applet, user, html, {
+        versionIndex,
+    });
+    return buildExternalVersionEntry(snapshot);
+}
+
+function buildPublishedContentUpdate(snapshot, versionIndex) {
+    return {
+        publishedContentUrl: snapshot.url,
+        publishedContentBlobPath: snapshot.blobPath,
+        publishedContentHash: snapshot.hash,
+        publishedContentSize: snapshot.size,
+        publishedContentContextId: snapshot.contextId,
+        publishedContentVersionIndex:
+            typeof versionIndex === "number" ? versionIndex : null,
+        publishedContentTimestamp: new Date(),
+    };
+}
+
+export function getPublishedAppletSnapshot(applet) {
+    return {
+        publishedContentBlobPath: applet?.publishedContentBlobPath,
+        publishedContentHash: applet?.publishedContentHash,
+        publishedContentContextId: applet?.publishedContentContextId,
+    };
+}
+
+export function clearPublishedContentFields(applet) {
+    applet.publishedContentUrl = undefined;
+    applet.publishedContentBlobPath = undefined;
+    applet.publishedContentHash = undefined;
+    applet.publishedContentSize = undefined;
+    applet.publishedContentContextId = undefined;
+    applet.publishedContentVersionIndex = undefined;
+    applet.publishedContentTimestamp = undefined;
+}
+
+async function resolveAppletVersionSnapshot(version) {
+    if (typeof version?.content === "string" && version.content.length > 0) {
+        return { content: version.content, missing: false };
+    }
+
+    const blobPath = getAppletVersionBlobPath(version);
+    if (!blobPath || !version?.contentContextId) {
+        return { content: version?.content || "", missing: false };
+    }
+
+    const content = await readBlobContent(
+        blobPath,
+        createAppletGlobalStorageTarget(version.contentContextId),
+    );
+
+    return {
+        content: content || "",
+        contentBlobPath: blobPath,
+        missing: content == null,
+    };
+}
+
+export async function resolveAppletVersionContent(version) {
+    const snapshot = await resolveAppletVersionSnapshot(version);
+    return snapshot.content;
+}
+
+async function resolveCanonicalPublishedAppletContent(applet) {
+    const publishedBlobPath =
+        applet?.publishedContentBlobPath ||
+        extractAppletVersionBlobPathFromUrl(applet?.publishedContentUrl) ||
+        null;
+
+    if (!publishedBlobPath) {
+        return null;
+    }
+
+    return readBlobContent(
+        publishedBlobPath,
+        createAppletPublishedStorageTarget(applet?.publishedContentContextId),
+    );
+}
+
+export async function resolvePublishedAppletContent(applet) {
+    const canonicalContent =
+        await resolveCanonicalPublishedAppletContent(applet);
+    if (canonicalContent != null) {
+        return canonicalContent;
+    }
+
+    const publishedVersion =
+        applet?.publishedVersionIndex != null
+            ? applet.htmlVersions?.[applet.publishedVersionIndex]
+            : null;
+    return publishedVersion
+        ? ((await resolveAppletVersionContent(publishedVersion)) ?? null)
+        : null;
+}
+
+export async function createPublishedAppletUpdate(
+    applet,
+    html,
+    { versionIndex = 0 } = {},
+) {
+    const snapshot = await createPublishedAppletHtmlSnapshot(applet, html, {
+        versionIndex,
+    });
+    return buildPublishedContentUpdate(snapshot, versionIndex);
+}
+
+export async function applyPublishedAppletSnapshot(
+    applet,
+    html,
+    { versionIndex = 0 } = {},
+) {
+    const previousPublishedSnapshot = getPublishedAppletSnapshot(applet);
+    const update = await createPublishedAppletUpdate(applet, html, {
+        versionIndex,
+    });
+    Object.assign(applet, update);
+    return {
+        previousPublishedSnapshot,
+        nextPublishedSnapshot: getPublishedAppletSnapshot(applet),
+    };
+}
+
+export async function deletePublishedAppletSnapshot(
+    applet,
+    { allowHashFallback = true } = {},
+) {
+    if (!applet?.publishedContentBlobPath && !applet?.publishedContentHash) {
+        return null;
+    }
+
+    return deleteMediaFile({
+        blobPath: applet.publishedContentBlobPath || null,
+        hash:
+            allowHashFallback || !applet.publishedContentBlobPath
+                ? applet.publishedContentHash || null
+                : null,
+        storageTarget: createAppletPublishedStorageTarget(
+            applet.publishedContentContextId,
+        ),
+    });
+}
+
+export async function deleteReplacedPublishedAppletSnapshot(previous, next) {
+    const previousBlobPath = previous?.publishedContentBlobPath || null;
+    const previousHash = previous?.publishedContentHash || null;
+    if (!previousBlobPath && !previousHash) {
+        return null;
+    }
+
+    const nextBlobPath = next?.publishedContentBlobPath || null;
+    const nextHash = next?.publishedContentHash || null;
+    const sameBlobPath = previousBlobPath && previousBlobPath === nextBlobPath;
+    const sameHashOnly =
+        !previousBlobPath &&
+        !nextBlobPath &&
+        previousHash &&
+        previousHash === nextHash;
+    if (sameBlobPath || sameHashOnly) {
+        return null;
+    }
+
+    return deletePublishedAppletSnapshot(previous, {
+        allowHashFallback: !previousBlobPath,
+    });
+}
+
+function canRepairPublishedVersionSnapshot(applet, user, resolvedVersions) {
+    if (Number(applet?.version || 1) !== 2 || !user?.contextId) {
+        return false;
+    }
+    const publishedIndex =
+        typeof applet?.publishedVersionIndex === "number"
+            ? applet.publishedVersionIndex
+            : null;
+    if (publishedIndex == null || !resolvedVersions[publishedIndex]?.missing) {
+        return false;
+    }
+    if (
+        typeof applet?.publishedContentVersionIndex === "number" &&
+        applet.publishedContentVersionIndex !== publishedIndex
+    ) {
+        return false;
+    }
+    return !!(applet?.publishedContentBlobPath || applet?.publishedContentUrl);
+}
+
+async function repairPublishedVersionSnapshot(applet, user, resolvedVersions) {
+    if (!canRepairPublishedVersionSnapshot(applet, user, resolvedVersions)) {
+        return false;
+    }
+
+    const publishedIndex = applet.publishedVersionIndex;
+    const canonicalHtml = await resolveCanonicalPublishedAppletContent(applet);
+    if (canonicalHtml == null) {
+        return false;
+    }
+
+    const snapshot = await createAppletHtmlSnapshot(
+        applet,
+        user,
+        canonicalHtml,
+        {
+            versionIndex: publishedIndex,
+        },
+    );
+    const entry = resolvedVersions[publishedIndex];
+    entry.version = {
+        ...entry.version,
+        content: "",
+        contentUrl: snapshot.url,
+        contentBlobPath: snapshot.blobPath,
+        contentHash: snapshot.hash,
+        contentSize: snapshot.size,
+        contentContextId: snapshot.contextId,
+        timestamp: entry.version?.timestamp || new Date(),
+    };
+    entry.content = canonicalHtml;
+    entry.contentBlobPath = snapshot.blobPath;
+    entry.missing = false;
+    entry.repaired = true;
+    return true;
+}
+
+export async function hydrateAppletVersionContents(applet, user = null) {
+    const versions = Array.isArray(applet?.htmlVersions)
+        ? applet.htmlVersions
+        : [];
+    if (
+        !versions.some(
+            (version) => version?.contentBlobPath || version?.contentUrl,
+        )
+    ) {
+        return applet;
+    }
+
+    const resolvedVersions = await Promise.all(
+        versions.map(async (version) => ({
+            version,
+            ...(await resolveAppletVersionSnapshot(version)),
+        })),
+    );
+    let healedPublishedVersion = false;
+    try {
+        healedPublishedVersion = await repairPublishedVersionSnapshot(
+            applet,
+            user,
+            resolvedVersions,
+        );
+    } catch (error) {
+        console.warn(
+            "hydrateAppletVersionContents: failed to repair published version snapshot:",
+            error?.message,
+        );
+    }
+
+    const hydratedVersions = resolvedVersions.map((entry) => ({
+        ...entry.version,
+        ...(entry.contentBlobPath
+            ? { contentBlobPath: entry.contentBlobPath }
+            : {}),
+        content: entry.missing ? entry.version?.content || "" : entry.content,
+    }));
+    const persistedVersions = resolvedVersions.map((entry) => ({
+        ...entry.version,
+        ...(!entry.missing && entry.contentBlobPath
+            ? { contentBlobPath: entry.contentBlobPath }
+            : {}),
+    }));
+    const repaired = resolvedVersions.some(
+        (entry) =>
+            entry.repaired ||
+            (!entry.missing &&
+                entry.contentBlobPath &&
+                entry.contentBlobPath !== entry.version?.contentBlobPath),
+    );
+
+    if ((repaired || healedPublishedVersion) && applet?._id) {
+        try {
+            await Applet.findByIdAndUpdate(applet._id, {
+                htmlVersions: persistedVersions,
+                publishedVersionIndex: applet?.publishedVersionIndex,
+            });
+        } catch (error) {
+            console.warn(
+                "hydrateAppletVersionContents: failed to persist repaired version metadata:",
+                error?.message,
+            );
+        }
+    }
+
+    return {
+        ...applet,
+        htmlVersions: hydratedVersions,
+        publishedVersionIndex: applet?.publishedVersionIndex,
+    };
+}
+
+export async function deleteAppletVersionSnapshots(versions = [], user = null) {
+    const snapshotVersions = (Array.isArray(versions) ? versions : []).filter(
+        (version) => version?.contentBlobPath || version?.contentHash,
+    );
+    if (snapshotVersions.length === 0) {
+        return [];
+    }
+
+    return Promise.allSettled(
+        snapshotVersions.map((version) =>
+            deleteMediaFile({
+                blobPath: version.contentBlobPath || null,
+                hash: version.contentHash || null,
+                fallbackToHash: !version.contentBlobPath,
+                storageTarget: createAppletGlobalStorageTarget(
+                    version.contentContextId || user?.contextId || null,
+                ),
+            }),
+        ),
+    );
+}

--- a/app/api/generate-applet/route.js
+++ b/app/api/generate-applet/route.js
@@ -1,0 +1,329 @@
+import { NextResponse } from "next/server";
+import { getClient, SUBSCRIPTIONS } from "../../../src/graphql";
+import { getCurrentUser } from "../utils/auth";
+import config from "../../../config";
+import { ensureAppletSdkScript } from "../../../src/utils/appletSdkUtils.js";
+import { BUILT_IN_SKILLS } from "../../../src/utils/skills.js";
+import {
+    DEFAULT_APPLET_REASONING_EFFORT,
+    resolvePreferredAppletModel,
+} from "../utils/applet-model";
+import {
+    executeRunWorkspacePrompt,
+    RUN_WORKSPACE_PROMPT_PATHWAY,
+} from "../utils/run-workspace-prompt.js";
+
+export const dynamic = "force-dynamic";
+
+function postProcessHtml(html) {
+    if (!html) return html;
+
+    let result = html
+        .replace(/^```html?\s*\n?/i, "")
+        .replace(/\n?```\s*$/i, "")
+        .trim();
+
+    const tailwindScript =
+        '<script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>';
+    if (!result.includes("@tailwindcss/browser")) {
+        result = result.replace(/(<head[^>]*>)/i, `$1\n    ${tailwindScript}`);
+    }
+
+    return ensureAppletSdkScript(result);
+}
+
+function extractTextFromProgressData(resultData) {
+    if (!resultData) return "";
+
+    try {
+        const parsed = JSON.parse(resultData);
+        if (typeof parsed === "string") {
+            return parsed;
+        }
+
+        return parsed?.choices?.[0]?.delta?.content ?? "";
+    } catch {
+        return resultData;
+    }
+}
+
+function getAppletGenerationAttempts(models) {
+    if (models.length > 1) {
+        return models;
+    }
+
+    return models[0] ? [models[0], models[0]] : [];
+}
+
+function buildChatHistory(prompt) {
+    const systemPrompt = `You generate polished, production-ready HTML applets for Concierge users.
+
+Return only a single complete HTML document with inline CSS/JS as needed.
+
+OUTPUT RULES:
+- Return ONLY the HTML code. No markdown fences or explanations.
+- Prefer semantic HTML, accessible controls, and clear visual hierarchy.
+- Keep the code readable and maintainable.
+
+${BUILT_IN_SKILLS.find((skill) => skill.name === "applets")?.content || ""}`;
+
+    return [
+        {
+            role: "system",
+            content: [
+                JSON.stringify({
+                    type: "text",
+                    text: systemPrompt,
+                }),
+            ],
+        },
+        {
+            role: "user",
+            content: [
+                JSON.stringify({
+                    type: "text",
+                    text: prompt.trim(),
+                }),
+            ],
+        },
+    ];
+}
+
+export async function POST(req) {
+    try {
+        const { prompt } = await req.json();
+
+        if (!prompt || !prompt.trim()) {
+            return NextResponse.json(
+                { error: "Prompt is required" },
+                { status: 400 },
+            );
+        }
+
+        await getCurrentUser();
+
+        const preferredModel = resolvePreferredAppletModel(
+            config.cortex.defaultChatModel,
+        );
+        const modelFallbacks = [
+            preferredModel,
+            config.cortex.defaultChatModel,
+        ].filter(
+            (model, index, array) => model && array.indexOf(model) === index,
+        );
+
+        const variables = {
+            chatHistory: buildChatHistory(prompt),
+            reasoningEffort: DEFAULT_APPLET_REASONING_EFFORT,
+            stream: true,
+        };
+
+        const graphqlClient = getClient();
+        const modelAttempts = getAppletGenerationAttempts(modelFallbacks);
+        const encoder = new TextEncoder();
+        let clientConnected = true;
+        let graphqlSubscription = null;
+
+        const unsubscribe = () => {
+            if (!graphqlSubscription) return;
+
+            try {
+                if (typeof graphqlSubscription.unsubscribe === "function") {
+                    graphqlSubscription.unsubscribe();
+                }
+            } catch (error) {
+                console.error("[generate-applet] Error unsubscribing:", error);
+            }
+
+            graphqlSubscription = null;
+        };
+
+        const stream = new ReadableStream({
+            async start(controller) {
+                const sendEvent = (event, data) => {
+                    if (!clientConnected) return;
+
+                    try {
+                        controller.enqueue(
+                            encoder.encode(
+                                `data: ${JSON.stringify({ event, data })}\n\n`,
+                            ),
+                        );
+                    } catch (error) {
+                        if (error.code === "ERR_INVALID_STATE") {
+                            clientConnected = false;
+                        }
+                    }
+                };
+
+                const closeStream = () => {
+                    if (!clientConnected) return;
+
+                    try {
+                        controller.close();
+                        clientConnected = false;
+                    } catch (error) {
+                        if (error.code !== "ERR_INVALID_STATE") {
+                            console.error(
+                                "[generate-applet] Error closing stream:",
+                                error,
+                            );
+                        }
+                    }
+                };
+
+                const runAttempt = async (model) => {
+                    const { response } = await executeRunWorkspacePrompt({
+                        graphqlClient,
+                        variables,
+                        models: [model],
+                        includeStream: true,
+                        onUnsupportedReasoningEffort: (error) => {
+                            console.warn(
+                                "[generate-applet] Cortex rejected reasoningEffort; retried without it.",
+                                error?.message || error,
+                            );
+                        },
+                    });
+
+                    const subscriptionId =
+                        response.data?.[RUN_WORKSPACE_PROMPT_PATHWAY]?.result;
+                    if (!subscriptionId) {
+                        throw new Error(
+                            "Cortex did not start applet generation",
+                        );
+                    }
+
+                    return new Promise((resolve) => {
+                        let accumulated = "";
+
+                        const finishFailure = (message) => {
+                            unsubscribe();
+                            resolve({ ok: false, error: message });
+                        };
+
+                        graphqlSubscription = graphqlClient
+                            .subscribe({
+                                query: SUBSCRIPTIONS.REQUEST_PROGRESS,
+                                variables: { requestIds: [subscriptionId] },
+                            })
+                            .subscribe({
+                                next: (result) => {
+                                    if (!result?.data?.requestProgress) return;
+
+                                    const {
+                                        progress,
+                                        data: resultData,
+                                        error,
+                                    } = result.data.requestProgress;
+
+                                    if (error) {
+                                        finishFailure(error);
+                                        return;
+                                    }
+
+                                    const textContent =
+                                        extractTextFromProgressData(resultData);
+
+                                    if (textContent) {
+                                        accumulated += textContent;
+                                        sendEvent("data", {
+                                            chunk: textContent,
+                                        });
+                                    }
+
+                                    if (progress === 1) {
+                                        const html =
+                                            postProcessHtml(accumulated);
+                                        if (html) {
+                                            unsubscribe();
+                                            resolve({ ok: true, html });
+                                            return;
+                                        }
+
+                                        finishFailure(
+                                            "Applet generation completed without HTML",
+                                        );
+                                    }
+                                },
+                                error: (subscriptionError) => {
+                                    console.error(
+                                        "[generate-applet] Subscription error:",
+                                        subscriptionError,
+                                    );
+                                    finishFailure(
+                                        subscriptionError?.message ||
+                                            "Subscription failed",
+                                    );
+                                },
+                                complete: () => {
+                                    finishFailure(
+                                        "Applet generation stream ended before HTML was produced",
+                                    );
+                                },
+                            });
+                    });
+                };
+
+                try {
+                    let lastError = "Applet generation failed";
+
+                    for (const model of modelAttempts) {
+                        let result;
+                        try {
+                            result = await runAttempt(model);
+                        } catch (error) {
+                            result = {
+                                ok: false,
+                                error:
+                                    error?.message ||
+                                    "Failed to start applet generation",
+                            };
+                        }
+
+                        if (result.ok) {
+                            sendEvent("complete", { html: result.html });
+                            closeStream();
+                            return;
+                        }
+
+                        lastError = result.error || lastError;
+                    }
+
+                    sendEvent("error", {
+                        error: `${lastError}. Retried once.`,
+                    });
+                    closeStream();
+                } catch (error) {
+                    console.error(
+                        "[generate-applet] Error setting up subscription:",
+                        error,
+                    );
+                    sendEvent("error", {
+                        error: error?.message || "Failed to stream applet",
+                    });
+                    unsubscribe();
+                    closeStream();
+                }
+            },
+            cancel() {
+                clientConnected = false;
+                unsubscribe();
+            },
+        });
+
+        return new Response(stream, {
+            headers: {
+                "Content-Type": "text/event-stream",
+                "Cache-Control": "no-cache, no-transform",
+                Connection: "keep-alive",
+            },
+        });
+    } catch (error) {
+        console.error("Error generating applet:", error);
+        return NextResponse.json(
+            { error: "Failed to generate applet" },
+            { status: 500 },
+        );
+    }
+}

--- a/app/api/models/applet-shared-data-revision.js
+++ b/app/api/models/applet-shared-data-revision.js
@@ -1,0 +1,50 @@
+import mongoose from "mongoose";
+
+export const appletSharedDataRevisionSchema = new mongoose.Schema(
+    {
+        appletId: {
+            type: mongoose.Schema.Types.ObjectId,
+            ref: "Applet",
+            required: true,
+        },
+        key: {
+            type: String,
+            required: true,
+            trim: true,
+        },
+        revision: {
+            type: Number,
+            required: true,
+        },
+        value: {
+            type: mongoose.Schema.Types.Mixed,
+            required: true,
+        },
+        reason: {
+            type: String,
+            required: true,
+            enum: ["replace", "reset", "restore"],
+            default: "replace",
+        },
+        createdBy: {
+            type: mongoose.Schema.Types.ObjectId,
+            ref: "User",
+            required: true,
+        },
+    },
+    {
+        timestamps: true,
+    },
+);
+
+appletSharedDataRevisionSchema.index({
+    appletId: 1,
+    key: 1,
+    revision: -1,
+});
+
+const AppletSharedDataRevision =
+    mongoose.models.AppletSharedDataRevision ||
+    mongoose.model("AppletSharedDataRevision", appletSharedDataRevisionSchema);
+
+export default AppletSharedDataRevision;

--- a/app/api/models/applet-shared-data.js
+++ b/app/api/models/applet-shared-data.js
@@ -1,0 +1,47 @@
+import mongoose from "mongoose";
+
+export const appletSharedDataSchema = new mongoose.Schema(
+    {
+        appletId: {
+            type: mongoose.Schema.Types.ObjectId,
+            ref: "Applet",
+            required: true,
+        },
+        key: {
+            type: String,
+            required: true,
+            trim: true,
+        },
+        value: {
+            type: mongoose.Schema.Types.Mixed,
+            required: true,
+            default: {},
+        },
+        revision: {
+            type: Number,
+            required: true,
+            default: 1,
+        },
+        createdBy: {
+            type: mongoose.Schema.Types.ObjectId,
+            ref: "User",
+            required: true,
+        },
+        updatedBy: {
+            type: mongoose.Schema.Types.ObjectId,
+            ref: "User",
+            required: true,
+        },
+    },
+    {
+        timestamps: true,
+    },
+);
+
+appletSharedDataSchema.index({ appletId: 1, key: 1 }, { unique: true });
+
+const AppletSharedData =
+    mongoose.models.AppletSharedData ||
+    mongoose.model("AppletSharedData", appletSharedDataSchema);
+
+export default AppletSharedData;

--- a/app/api/published/applets/[id]/route.js
+++ b/app/api/published/applets/[id]/route.js
@@ -1,0 +1,82 @@
+import { NextResponse } from "next/server";
+import mongoose from "mongoose";
+import Applet from "@/app/api/models/applet";
+import App, { APP_STATUS } from "@/app/api/models/app";
+import {
+    getAppletVersionBlobPath,
+    resolvePublishedAppletContent,
+} from "@/app/api/canvas-applets/versioning";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+function jsonNoStore(body, init = {}) {
+    const response = NextResponse.json(body, init);
+    response.headers.set("Cache-Control", "no-store");
+    return response;
+}
+
+// GET: fetch a published canvas applet (no auth required - public endpoint)
+export async function GET(request, { params }) {
+    const { id } = params;
+
+    try {
+        if (!mongoose.Types.ObjectId.isValid(id)) {
+            return jsonNoStore({ error: "Invalid applet ID" }, { status: 400 });
+        }
+
+        const applet = await Applet.findOne({
+            _id: id,
+            version: 2,
+            publishedVersionIndex: { $exists: true, $ne: null },
+        })
+            .select(
+                "name htmlVersions publishedVersionIndex publishedContentUrl publishedContentBlobPath publishedContentHash publishedContentSize publishedContentContextId publishedContentVersionIndex publishedContentTimestamp",
+            )
+            .lean();
+
+        if (!applet) {
+            return jsonNoStore(
+                { error: "Published applet not found" },
+                { status: 404 },
+            );
+        }
+
+        const publishedVersion =
+            applet.htmlVersions?.[applet.publishedVersionIndex];
+        const publishedHtml =
+            (await resolvePublishedAppletContent(applet)) || null;
+        const repairedBlobPath = getAppletVersionBlobPath(publishedVersion);
+        if (repairedBlobPath && !publishedVersion?.contentBlobPath) {
+            await Applet.updateOne(
+                { _id: applet._id },
+                {
+                    $set: {
+                        [`htmlVersions.${applet.publishedVersionIndex}.contentBlobPath`]:
+                            repairedBlobPath,
+                    },
+                },
+            );
+        }
+
+        const app = await App.findOne({
+            appletId: id,
+            status: APP_STATUS.ACTIVE,
+        })
+            .select("name slug description icon status type")
+            .lean();
+
+        return jsonNoStore({
+            applet: {
+                _id: applet._id,
+                name: applet.name,
+                publishedVersionIndex: applet.publishedVersionIndex,
+                publishedHtml,
+            },
+            app: app || null,
+        });
+    } catch (error) {
+        console.error("Error fetching published applet:", error);
+        return jsonNoStore({ error: "Internal server error" }, { status: 500 });
+    }
+}

--- a/app/api/published/workspaces/[id]/applet/route.js
+++ b/app/api/published/workspaces/[id]/applet/route.js
@@ -1,0 +1,70 @@
+import { NextResponse } from "next/server";
+import mongoose from "mongoose";
+import Workspace from "@/app/api/models/workspace";
+import Applet from "@/app/api/models/applet";
+import App, { APP_STATUS } from "@/app/api/models/app";
+import { resolvePublishedAppletContent } from "@/app/api/canvas-applets/versioning";
+
+// Public endpoint for legacy workspace applet links. This intentionally avoids
+// the authenticated workspace editor route so published links keep working for
+// anonymous users.
+export async function GET(request, { params }) {
+    const { id } = params;
+
+    try {
+        const workspaceQuery = mongoose.isObjectIdOrHexString(id)
+            ? { _id: id }
+            : { slug: id };
+        const workspace = await Workspace.findOne(workspaceQuery)
+            .select("applet")
+            .lean();
+
+        if (!workspace?.applet) {
+            return NextResponse.json(
+                { error: "Published applet not found" },
+                { status: 404 },
+            );
+        }
+
+        const applet = await Applet.findOne({
+            _id: workspace.applet,
+            publishedVersionIndex: { $exists: true, $ne: null },
+        })
+            .select(
+                "name htmlVersions publishedVersionIndex publishedContentUrl publishedContentBlobPath publishedContentHash publishedContentSize publishedContentContextId publishedContentVersionIndex publishedContentTimestamp",
+            )
+            .lean();
+
+        if (!applet) {
+            return NextResponse.json(
+                { error: "Published applet not found" },
+                { status: 404 },
+            );
+        }
+
+        const app = await App.findOne({
+            workspaceId: workspace._id,
+            type: "applet",
+            status: APP_STATUS.ACTIVE,
+        })
+            .select("name slug description icon status type")
+            .lean();
+
+        return NextResponse.json({
+            app: app || null,
+            applet: {
+                _id: applet._id,
+                name: applet.name,
+                publishedVersionIndex: applet.publishedVersionIndex,
+                publishedHtml:
+                    (await resolvePublishedAppletContent(applet)) || null,
+            },
+        });
+    } catch (error) {
+        console.error("Error fetching published workspace applet:", error);
+        return NextResponse.json(
+            { error: "Failed to fetch published applet" },
+            { status: 500 },
+        );
+    }
+}

--- a/app/api/utils/applet-model.js
+++ b/app/api/utils/applet-model.js
@@ -1,0 +1,14 @@
+export const DEFAULT_APPLET_GENERATION_MODEL = "cortex-default-coding";
+export const DEFAULT_APPLET_REASONING_EFFORT = "medium";
+
+export function isPreferredAppletModel(model) {
+    return /(?:gpt[-_]?5\.?5|gpt55|opus)/i.test(model || "");
+}
+
+export function resolvePreferredAppletModel(defaultModel) {
+    if (isPreferredAppletModel(defaultModel)) {
+        return defaultModel;
+    }
+
+    return DEFAULT_APPLET_GENERATION_MODEL;
+}

--- a/app/api/utils/atlassianCloudId.js
+++ b/app/api/utils/atlassianCloudId.js
@@ -1,0 +1,46 @@
+const ACCESSIBLE_RESOURCES_URL =
+    "https://api.atlassian.com/oauth/token/accessible-resources";
+
+/**
+ * @param {string} authorizationValue - Full header e.g. "Bearer eyJ..."
+ * @returns {Promise<string|null>} First accessible Jira cloud id (site id)
+ */
+export async function fetchAtlassianCloudIdFromAuthorization(
+    authorizationValue,
+) {
+    if (!authorizationValue || typeof authorizationValue !== "string") {
+        return null;
+    }
+    try {
+        const res = await fetch(ACCESSIBLE_RESOURCES_URL, {
+            headers: {
+                Authorization: authorizationValue,
+                Accept: "application/json",
+            },
+        });
+        if (!res.ok) {
+            console.warn(
+                `[MCP:cloudId] accessible-resources returned ${res.status}: ${await res.text().catch(() => "no body")}`,
+            );
+            return null;
+        }
+        const data = await res.json();
+        const sites = Array.isArray(data) ? data : [];
+        console.log(
+            `[MCP:cloudId] accessible-resources returned ${sites.length} site(s): ${JSON.stringify(sites.map((r) => ({ id: r.id, name: r.name, url: r.url })))}`,
+        );
+        if (sites.length > 0 && sites[0].id) {
+            return sites[0].id;
+        }
+    } catch (err) {
+        console.warn("[MCP:cloudId] accessible-resources failed:", err.message);
+    }
+    return null;
+}
+
+export async function fetchAtlassianCloudIdFromAccessToken(accessToken) {
+    if (!accessToken) {
+        return null;
+    }
+    return fetchAtlassianCloudIdFromAuthorization(`Bearer ${accessToken}`);
+}

--- a/app/api/utils/mcp-server-config.js
+++ b/app/api/utils/mcp-server-config.js
@@ -1,0 +1,23 @@
+/**
+ * Sanitize mcpServers for the client: strip tokens and refresh material while
+ * preserving connection status and display metadata.
+ */
+export function sanitizeMcpServersForClient(mcpServers) {
+    if (!mcpServers || typeof mcpServers !== "object") return mcpServers;
+
+    const sanitized = {};
+    for (const [key, config] of Object.entries(mcpServers)) {
+        sanitized[key] = {
+            type: config.type,
+            url: config.url,
+            name: config.name,
+            authType: config.authType,
+            hasAuth: !!(
+                config.headers?.Authorization || config.headers?.authorization
+            ),
+            hasBotToken: !!config.botToken,
+            expiresAt: config.expiresAt,
+        };
+    }
+    return sanitized;
+}

--- a/app/api/utils/mcp-token-refresh.js
+++ b/app/api/utils/mcp-token-refresh.js
@@ -1,0 +1,206 @@
+const DEFAULT_REFRESH_WINDOW_MS = 5 * 60 * 1000;
+const ATLASSIAN_3LO_TOKEN_URL = "https://auth.atlassian.com/oauth/token";
+const ATLASSIAN_MCP_TOKEN_URL = "https://cf.mcp.atlassian.com/v1/token";
+
+function serverExpiresWithin(serverConfig, now, refreshWindowMs) {
+    const expiresAt = serverConfig?.expiresAt;
+    return typeof expiresAt === "number" && expiresAt <= now + refreshWindowMs;
+}
+
+function buildRefreshedServerConfig(serverConfig, tokenData, now) {
+    const accessToken = tokenData?.access_token;
+    if (!accessToken) {
+        throw new Error("Token refresh did not return an access token");
+    }
+
+    return {
+        ...serverConfig,
+        headers: {
+            ...(serverConfig.headers || {}),
+            Authorization: `Bearer ${accessToken}`,
+        },
+        refreshToken: tokenData.refresh_token || serverConfig.refreshToken,
+        expiresAt: tokenData.expires_in
+            ? now + tokenData.expires_in * 1000
+            : undefined,
+    };
+}
+
+async function readTokenResponse(response) {
+    const data = await response.json().catch(() => ({}));
+    if (!response.ok || data.error) {
+        throw new Error(
+            data.error_description || data.error || "Token refresh failed",
+        );
+    }
+    return data;
+}
+
+async function refreshAtlassianMcpToken(serverConfig) {
+    const body = {
+        grant_type: "refresh_token",
+        refresh_token: serverConfig.refreshToken,
+        client_id: serverConfig.mcpClientId,
+    };
+
+    if (serverConfig.url) {
+        body.resource = serverConfig.url;
+    }
+
+    const response = await fetch(ATLASSIAN_MCP_TOKEN_URL, {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/x-www-form-urlencoded",
+            Accept: "application/json",
+        },
+        body: new URLSearchParams(body).toString(),
+    });
+
+    return readTokenResponse(response);
+}
+
+async function refreshAtlassian3loToken(serverConfig) {
+    const clientId = process.env.NEXT_PUBLIC_ATLASSIAN_CLIENT_ID;
+    const clientSecret = process.env.ATLASSIAN_CLIENT_CREDENTIAL;
+    if (!clientId || !clientSecret) {
+        throw new Error("Atlassian OAuth is not configured");
+    }
+
+    const response = await fetch(ATLASSIAN_3LO_TOKEN_URL, {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+            Accept: "application/json",
+        },
+        body: JSON.stringify({
+            grant_type: "refresh_token",
+            client_id: clientId,
+            client_secret: clientSecret,
+            refresh_token: serverConfig.refreshToken,
+        }),
+    });
+
+    return readTokenResponse(response);
+}
+
+function isAtlassianUrl(url) {
+    try {
+        const { hostname } = new URL(url);
+        return (
+            hostname === "atlassian.com" || hostname.endsWith(".atlassian.com")
+        );
+    } catch {
+        return false;
+    }
+}
+
+export function isMcpServerExpiring(
+    serverConfig,
+    { now = Date.now(), refreshWindowMs = DEFAULT_REFRESH_WINDOW_MS } = {},
+) {
+    return serverExpiresWithin(serverConfig, now, refreshWindowMs);
+}
+
+export async function refreshMcpServerConfig(
+    serverKey,
+    serverConfig,
+    { now = Date.now(), logPrefix = "[MCP:refresh]" } = {},
+) {
+    if (!serverConfig?.refreshToken) {
+        return {
+            refreshed: false,
+            reason: "missing_refresh_token",
+            config: serverConfig,
+        };
+    }
+
+    const normalizedKey = String(serverKey || "").toLowerCase();
+    const isAtlassian =
+        normalizedKey === "atlassian" ||
+        normalizedKey === "atlassian_api" ||
+        isAtlassianUrl(serverConfig.url);
+
+    if (!isAtlassian) {
+        return {
+            refreshed: false,
+            reason: "unsupported_server",
+            config: serverConfig,
+        };
+    }
+
+    try {
+        const tokenData = serverConfig.mcpClientId
+            ? await refreshAtlassianMcpToken(serverConfig)
+            : await refreshAtlassian3loToken(serverConfig);
+        const config = buildRefreshedServerConfig(serverConfig, tokenData, now);
+        console.log(
+            `${logPrefix} refreshed ${serverKey} token; expiresAt=${config.expiresAt ? new Date(config.expiresAt).toISOString() : "none"}`,
+        );
+        return { refreshed: true, config };
+    } catch (error) {
+        console.warn(
+            `${logPrefix} failed to refresh ${serverKey} token: ${error.message}`,
+        );
+        return {
+            refreshed: false,
+            reason: "refresh_failed",
+            error,
+            config: serverConfig,
+        };
+    }
+}
+
+export async function refreshExpiringMcpServersForUser(
+    user,
+    {
+        logPrefix = "[MCP:refresh]",
+        refreshWindowMs = DEFAULT_REFRESH_WINDOW_MS,
+        now = Date.now(),
+    } = {},
+) {
+    const mcpServers =
+        user?.mcpServers && typeof user.mcpServers === "object"
+            ? { ...user.mcpServers }
+            : {};
+    const refreshedServers = [];
+    const unavailableServers = [];
+    let modified = false;
+
+    for (const [serverKey, serverConfig] of Object.entries(mcpServers)) {
+        if (serverKey === "atlassian_api") {
+            continue;
+        }
+
+        if (!isMcpServerExpiring(serverConfig, { now, refreshWindowMs })) {
+            continue;
+        }
+
+        const result = await refreshMcpServerConfig(serverKey, serverConfig, {
+            now,
+            logPrefix,
+        });
+        if (result.refreshed) {
+            mcpServers[serverKey] = result.config;
+            refreshedServers.push(serverKey);
+            modified = true;
+        } else {
+            unavailableServers.push({
+                serverKey,
+                reason: result.reason,
+                message: result.error?.message,
+            });
+        }
+    }
+
+    if (modified && user) {
+        user.mcpServers = mcpServers;
+        user.markModified?.("mcpServers");
+        await user.save?.();
+    }
+
+    return {
+        mcpServers,
+        refreshedServers,
+        unavailableServers,
+    };
+}

--- a/app/api/utils/mcpOAuth.js
+++ b/app/api/utils/mcpOAuth.js
@@ -1,0 +1,275 @@
+import crypto from "crypto";
+import { validateMcpServerUrl } from "./mcpUrlValidation";
+
+const JSON_HEADERS = { Accept: "application/json" };
+const OAUTH_STATE_PREFIX = "custom_mcp_";
+
+function unique(values) {
+    return [...new Set(values.filter(Boolean))];
+}
+
+function trimTrailingSlash(value) {
+    return value.replace(/\/+$/, "");
+}
+
+function validateFetchUrl(rawUrl, label) {
+    const result = validateMcpServerUrl(rawUrl);
+    if (!result.ok) {
+        throw new Error(`${label} is not allowed: ${result.error}`);
+    }
+    return result.url;
+}
+
+async function readJsonResponse(response) {
+    const text = await response.text();
+    if (!text) return {};
+    try {
+        return JSON.parse(text);
+    } catch {
+        throw new Error("OAuth metadata response was not valid JSON");
+    }
+}
+
+async function fetchJsonIfAvailable(rawUrl, label) {
+    const url = validateFetchUrl(rawUrl, label);
+    const response = await fetch(url, { headers: JSON_HEADERS });
+    if (response.status === 404 || response.status === 405) {
+        return null;
+    }
+    if (!response.ok) {
+        return null;
+    }
+
+    const data = await readJsonResponse(response);
+    return { data, url };
+}
+
+function buildProtectedResourceMetadataUrls(resourceUrl) {
+    const resource = new URL(resourceUrl);
+    const path =
+        resource.pathname && resource.pathname !== "/"
+            ? trimTrailingSlash(resource.pathname)
+            : "";
+
+    return unique([
+        `${resource.origin}/.well-known/oauth-protected-resource${path}`,
+        `${resource.origin}/.well-known/oauth-protected-resource`,
+    ]);
+}
+
+function buildAuthorizationServerMetadataUrls(issuerUrl) {
+    const issuer = new URL(issuerUrl);
+    const issuerNoSlash = trimTrailingSlash(issuer.toString());
+    const path =
+        issuer.pathname && issuer.pathname !== "/"
+            ? trimTrailingSlash(issuer.pathname)
+            : "";
+
+    return unique([
+        `${issuer.origin}/.well-known/oauth-authorization-server${path}`,
+        `${issuer.origin}/.well-known/openid-configuration${path}`,
+        `${issuerNoSlash}/.well-known/oauth-authorization-server`,
+        `${issuerNoSlash}/.well-known/openid-configuration`,
+    ]);
+}
+
+function selectAuthorizationServer(protectedResourceMetadata, resourceUrl) {
+    const authorizationServers =
+        protectedResourceMetadata?.authorization_servers ||
+        protectedResourceMetadata?.authorizationServers;
+
+    if (Array.isArray(authorizationServers) && authorizationServers[0]) {
+        return authorizationServers[0];
+    }
+
+    return new URL(resourceUrl).origin;
+}
+
+function requireEndpoint(metadata, key) {
+    const value = metadata?.[key];
+    if (typeof value !== "string" || !value.trim()) {
+        throw new Error(`OAuth server metadata is missing ${key}`);
+    }
+    return value.trim();
+}
+
+export function createMcpOAuthState() {
+    return `${OAUTH_STATE_PREFIX}${crypto.randomBytes(16).toString("hex")}`;
+}
+
+export function isCustomMcpOAuthState(state) {
+    return typeof state === "string" && state.startsWith(OAUTH_STATE_PREFIX);
+}
+
+export function createPkcePair() {
+    const codeVerifier = crypto.randomBytes(32).toString("base64url");
+    const codeChallenge = crypto
+        .createHash("sha256")
+        .update(codeVerifier)
+        .digest("base64url");
+
+    return { codeVerifier, codeChallenge };
+}
+
+export function isAllowedMcpOAuthRedirectUri(redirectUri) {
+    try {
+        const parsed = new URL(redirectUri);
+        return parsed.pathname.replace(/\/+$/, "").endsWith("/code/mcp");
+    } catch {
+        return false;
+    }
+}
+
+export async function discoverMcpOAuthMetadata(resourceUrl) {
+    const validatedResourceUrl = validateFetchUrl(
+        resourceUrl,
+        "MCP server URL",
+    );
+
+    let protectedResourceMetadata = null;
+    let protectedResourceMetadataUrl = null;
+    for (const candidate of buildProtectedResourceMetadataUrls(
+        validatedResourceUrl,
+    )) {
+        const result = await fetchJsonIfAvailable(
+            candidate,
+            "OAuth protected resource metadata URL",
+        );
+        if (result?.data) {
+            protectedResourceMetadata = result.data;
+            protectedResourceMetadataUrl = result.url;
+            break;
+        }
+    }
+
+    const issuer = selectAuthorizationServer(
+        protectedResourceMetadata,
+        validatedResourceUrl,
+    );
+
+    let authorizationServerMetadata = null;
+    let authorizationServerMetadataUrl = null;
+    for (const candidate of buildAuthorizationServerMetadataUrls(issuer)) {
+        const result = await fetchJsonIfAvailable(
+            candidate,
+            "OAuth authorization server metadata URL",
+        );
+        if (result?.data) {
+            authorizationServerMetadata = result.data;
+            authorizationServerMetadataUrl = result.url;
+            break;
+        }
+    }
+
+    if (!authorizationServerMetadata) {
+        throw new Error(
+            "Could not discover OAuth metadata for this MCP server",
+        );
+    }
+
+    const authorizationEndpoint = validateFetchUrl(
+        requireEndpoint(authorizationServerMetadata, "authorization_endpoint"),
+        "OAuth authorization endpoint",
+    );
+    const tokenEndpoint = validateFetchUrl(
+        requireEndpoint(authorizationServerMetadata, "token_endpoint"),
+        "OAuth token endpoint",
+    );
+    const registrationEndpoint = validateFetchUrl(
+        requireEndpoint(authorizationServerMetadata, "registration_endpoint"),
+        "OAuth dynamic client registration endpoint",
+    );
+
+    return {
+        resourceUrl: validatedResourceUrl,
+        issuer: authorizationServerMetadata.issuer || issuer,
+        protectedResourceMetadataUrl,
+        authorizationServerMetadataUrl,
+        authorizationEndpoint,
+        tokenEndpoint,
+        registrationEndpoint,
+    };
+}
+
+export async function registerMcpOAuthClient(metadata, redirectUri) {
+    const registrationEndpoint = validateFetchUrl(
+        metadata.registrationEndpoint,
+        "OAuth dynamic client registration endpoint",
+    );
+
+    const response = await fetch(registrationEndpoint, {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+            Accept: "application/json",
+        },
+        body: JSON.stringify({
+            client_name: "Concierge MCP Client",
+            redirect_uris: [redirectUri],
+            grant_types: ["authorization_code", "refresh_token"],
+            response_types: ["code"],
+            token_endpoint_auth_method: "none",
+        }),
+    });
+
+    const data = await readJsonResponse(response);
+    if (!response.ok || !data.client_id) {
+        throw new Error(
+            data.error_description ||
+                data.error ||
+                "MCP client registration failed",
+        );
+    }
+
+    return data;
+}
+
+export function buildMcpAuthorizationUrl({
+    metadata,
+    clientId,
+    redirectUri,
+    codeChallenge,
+    state,
+}) {
+    const authUrl = new URL(metadata.authorizationEndpoint);
+    authUrl.searchParams.set("response_type", "code");
+    authUrl.searchParams.set("client_id", clientId);
+    authUrl.searchParams.set("redirect_uri", redirectUri);
+    authUrl.searchParams.set("code_challenge", codeChallenge);
+    authUrl.searchParams.set("code_challenge_method", "S256");
+    authUrl.searchParams.set("state", state);
+    authUrl.searchParams.set("resource", metadata.resourceUrl);
+    return authUrl.toString();
+}
+
+export async function exchangeMcpOAuthCode({ pending, code }) {
+    const tokenEndpoint = validateFetchUrl(
+        pending.tokenEndpoint,
+        "OAuth token endpoint",
+    );
+
+    const response = await fetch(tokenEndpoint, {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/x-www-form-urlencoded",
+            Accept: "application/json",
+        },
+        body: new URLSearchParams({
+            grant_type: "authorization_code",
+            code,
+            redirect_uri: pending.redirectUri,
+            client_id: pending.clientId,
+            code_verifier: pending.codeVerifier,
+            resource: pending.resourceUrl,
+        }).toString(),
+    });
+
+    const data = await readJsonResponse(response);
+    if (!response.ok || data.error) {
+        throw new Error(
+            data.error_description || data.error || "MCP token exchange failed",
+        );
+    }
+
+    return data;
+}

--- a/app/api/utils/mcpRedirectUri.js
+++ b/app/api/utils/mcpRedirectUri.js
@@ -1,0 +1,115 @@
+/**
+ * MCP dynamic registration needs a real HTTPS (or allowed) callback.
+ *
+ * - Rewrites origin using NEXT_PUBLIC_APP_URL when set.
+ * - Sandbox iframes can send "null/code/..." (opaque origin + path); we
+ *   recover the path and attach a real origin from env or the request Host.
+ *
+ * @param {string} clientRedirectUri
+ * @param {Request} [request] - Current request (for Host fallback)
+ * @returns {string}
+ */
+export function normalizeMcpRedirectUri(clientRedirectUri, request) {
+    if (!clientRedirectUri || typeof clientRedirectUri !== "string") {
+        return clientRedirectUri;
+    }
+
+    const basePath = (process.env.NEXT_PUBLIC_BASE_PATH || "").replace(
+        /\/$/,
+        "",
+    );
+    const raw = clientRedirectUri.trim();
+
+    let pathname = "";
+    let search = "";
+    let clientOrigin = null;
+
+    if (raw.indexOf("null/") === 0) {
+        const rest = raw.slice(5);
+        pathname = "/" + rest.replace(/^\/+/, "").split("?")[0];
+        const qi = rest.indexOf("?");
+        search = qi >= 0 ? rest.slice(qi) : "";
+    } else if (/^https?:\/\//i.test(raw)) {
+        try {
+            const u = new URL(raw);
+            clientOrigin = u.origin;
+            pathname = u.pathname;
+            search = u.search;
+        } catch {
+            return clientRedirectUri;
+        }
+    } else {
+        const qGlobal = raw.indexOf("?");
+        const pathPart = qGlobal >= 0 ? raw.slice(0, qGlobal) : raw;
+        pathname = pathPart.startsWith("/")
+            ? pathPart
+            : "/" + pathPart.replace(/^\/+/, "");
+        search = qGlobal >= 0 ? raw.slice(qGlobal) : "";
+    }
+
+    let outOrigin = null;
+    if (process.env.NEXT_PUBLIC_APP_URL) {
+        try {
+            outOrigin = new URL(process.env.NEXT_PUBLIC_APP_URL).origin;
+        } catch {
+            /* ignore */
+        }
+    }
+    if (!outOrigin && clientOrigin) {
+        outOrigin = clientOrigin;
+    }
+    if (!outOrigin && request) {
+        const host =
+            request.headers.get("x-forwarded-host") ||
+            request.headers.get("host");
+        if (host) {
+            const proto = request.headers.get("x-forwarded-proto") || "http";
+            outOrigin = `${proto}://${host}`;
+        }
+    }
+
+    if (!outOrigin) {
+        return clientRedirectUri;
+    }
+
+    let path = pathname + search;
+    if (basePath && path !== basePath && !path.startsWith(basePath + "/")) {
+        path = basePath + (path.startsWith("/") ? path : "/" + path);
+    }
+
+    return `${outOrigin}${path}`;
+}
+
+export function normalizeAtlassianMcpRedirectUri(clientRedirectUri, request) {
+    return normalizeMcpRedirectUri(clientRedirectUri, request);
+}
+
+/**
+ * Returns the origin we trust for OAuth redirect URIs on this request:
+ * NEXT_PUBLIC_APP_URL when set, otherwise the request's own host. Used to
+ * reject client-provided redirectUri values that point at an unrelated
+ * origin — without this check a caller could supply
+ * "https://attacker.com/code/mcp" and exfiltrate the OAuth code.
+ *
+ * @param {Request} [request]
+ * @returns {string|null}
+ */
+export function getTrustedMcpRedirectOrigin(request) {
+    if (process.env.NEXT_PUBLIC_APP_URL) {
+        try {
+            return new URL(process.env.NEXT_PUBLIC_APP_URL).origin;
+        } catch {
+            /* fall through */
+        }
+    }
+    if (request) {
+        const host =
+            request.headers.get("x-forwarded-host") ||
+            request.headers.get("host");
+        if (host) {
+            const proto = request.headers.get("x-forwarded-proto") || "http";
+            return `${proto}://${host}`;
+        }
+    }
+    return null;
+}

--- a/app/api/utils/mcpUrlValidation.js
+++ b/app/api/utils/mcpUrlValidation.js
@@ -1,0 +1,120 @@
+/**
+ * Server-side validation for MCP server URLs.
+ *
+ * Blocks SSRF vectors by rejecting localhost, private IPv4 ranges,
+ * link-local, loopback, and cloud metadata endpoints. The MCP server
+ * URL is fetched server-side during chat streaming, so an unvalidated
+ * URL would let any user reach internal services from the API host.
+ *
+ * In production, also requires HTTPS. Set MCP_ALLOW_PRIVATE_URLS=true
+ * to bypass (e.g. for local dev against a self-hosted MCP server).
+ */
+
+const PRIVATE_IPV4_RANGES = [
+    // 10.0.0.0/8
+    (n) => n[0] === 10,
+    // 172.16.0.0/12
+    (n) => n[0] === 172 && n[1] >= 16 && n[1] <= 31,
+    // 192.168.0.0/16
+    (n) => n[0] === 192 && n[1] === 168,
+    // 127.0.0.0/8 (loopback)
+    (n) => n[0] === 127,
+    // 169.254.0.0/16 (link-local, includes 169.254.169.254 metadata)
+    (n) => n[0] === 169 && n[1] === 254,
+    // 0.0.0.0/8
+    (n) => n[0] === 0,
+    // 100.64.0.0/10 (CGNAT)
+    (n) => n[0] === 100 && n[1] >= 64 && n[1] <= 127,
+];
+
+function parseIpv4(host) {
+    const parts = host.split(".");
+    if (parts.length !== 4) return null;
+    const nums = parts.map((p) => Number(p));
+    if (nums.some((n) => !Number.isInteger(n) || n < 0 || n > 255)) return null;
+    return nums;
+}
+
+function isBlockedHost(hostname) {
+    const host = hostname.toLowerCase();
+
+    // Block obvious localhost aliases
+    if (host === "localhost" || host.endsWith(".localhost")) return true;
+    if (host === "ip6-localhost" || host === "ip6-loopback") return true;
+
+    // Block IPv6 loopback / link-local / unique-local
+    if (host.startsWith("[") && host.endsWith("]")) {
+        const v6 = host.slice(1, -1);
+        if (v6 === "::1" || v6 === "::") return true;
+        if (
+            v6.startsWith("fe80:") ||
+            v6.startsWith("fc") ||
+            v6.startsWith("fd")
+        )
+            return true;
+        // IPv4-mapped IPv6: ::ffff:a.b.c.d (dotted) or ::ffff:HHHH:HHHH (hex,
+        // which is what URL.hostname normalizes to). Extract embedded v4.
+        const dotted = v6.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/i);
+        if (dotted) {
+            const nums = parseIpv4(dotted[1]);
+            if (nums && PRIVATE_IPV4_RANGES.some((fn) => fn(nums))) return true;
+        }
+        const hex = v6.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/i);
+        if (hex) {
+            const hi = parseInt(hex[1], 16);
+            const lo = parseInt(hex[2], 16);
+            const nums = [
+                (hi >> 8) & 0xff,
+                hi & 0xff,
+                (lo >> 8) & 0xff,
+                lo & 0xff,
+            ];
+            if (PRIVATE_IPV4_RANGES.some((fn) => fn(nums))) return true;
+        }
+        return false;
+    }
+
+    const nums = parseIpv4(host);
+    if (nums) {
+        return PRIVATE_IPV4_RANGES.some((fn) => fn(nums));
+    }
+
+    return false;
+}
+
+/**
+ * Validates an MCP server URL. Returns { ok: true, url } on success or
+ * { ok: false, error } on failure.
+ */
+export function validateMcpServerUrl(rawUrl) {
+    if (typeof rawUrl !== "string" || !rawUrl.trim()) {
+        return { ok: false, error: "URL is required" };
+    }
+
+    let parsed;
+    try {
+        parsed = new URL(rawUrl.trim());
+    } catch {
+        return { ok: false, error: "Invalid URL" };
+    }
+
+    if (!/^https?:$/.test(parsed.protocol)) {
+        return { ok: false, error: "URL must use http or https" };
+    }
+
+    const allowPrivate = process.env.MCP_ALLOW_PRIVATE_URLS === "true";
+    const isProd = process.env.NODE_ENV === "production";
+
+    if (isProd && !allowPrivate && parsed.protocol !== "https:") {
+        return { ok: false, error: "URL must use https in production" };
+    }
+
+    if (!allowPrivate && isBlockedHost(parsed.hostname)) {
+        return {
+            ok: false,
+            error: "URL host is not allowed (private or loopback address)",
+        };
+    }
+
+    return { ok: true, url: parsed.toString() };
+}

--- a/app/api/utils/parseJsonRequest.js
+++ b/app/api/utils/parseJsonRequest.js
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server";
+
+function isInvalidJsonError(error) {
+    return (
+        error?.name === "SyntaxError" ||
+        /json|unexpected end of input/i.test(error?.message || "")
+    );
+}
+
+export async function parseJsonRequest(
+    request,
+    { invalidMessage = "Invalid or empty JSON body" } = {},
+) {
+    try {
+        return {
+            ok: true,
+            body: await request.json(),
+        };
+    } catch (error) {
+        if (isInvalidJsonError(error)) {
+            return {
+                ok: false,
+                errorResponse: NextResponse.json(
+                    { error: invalidMessage },
+                    { status: 400 },
+                ),
+            };
+        }
+
+        throw error;
+    }
+}

--- a/app/api/utils/prompt-utils.js
+++ b/app/api/utils/prompt-utils.js
@@ -2,11 +2,11 @@ import LLM from "../models/llm";
 import Prompt from "../models/prompt";
 import { getLLMWithFallback } from "./llm-file-utils";
 
-// LLM identifiers that need migration to agentMode
-const LEGACY_AGENT_IDENTIFIERS = ["labeebagent", "labeebresearchagent"];
+// LLM identifiers that need migration to agentMode.
+const LEGACY_AGENT_IDENTIFIERS = ["conciergeagent", "conciergeresearchagent"];
 
 /**
- * Migrates a prompt if it uses legacy labeeb agent LLMs.
+ * Migrates a prompt if it uses legacy Concierge agent LLMs.
  * Updates the prompt in the database and returns the migrated prompt with its LLM.
  *
  * @param {string} promptId - The prompt ID
@@ -30,7 +30,7 @@ export async function getPromptWithMigration(promptId) {
             const migrationUpdate = {
                 llm: defaultLLM._id,
                 agentMode: true,
-                researchMode: llm.identifier === "labeebresearchagent",
+                researchMode: llm.identifier === "conciergeresearchagent",
             };
 
             await Prompt.findByIdAndUpdate(promptId, migrationUpdate);
@@ -62,4 +62,28 @@ export async function getPromptWithMigration(promptId) {
         pathwayName,
         model,
     };
+}
+
+/**
+ * Get prompt config with model and pathway info.
+ * No LLM collection lookup: prompt.llm is a Cortex model ID string.
+ *
+ * @param {string} promptId
+ * @param {string} defaultModel
+ * @returns {Promise<Object|null>} { prompt, model, agentMode, reasoningEffort, pathwayName }
+ */
+export async function getPromptConfig(promptId, defaultModel) {
+    const prompt = await Prompt.findById(promptId).populate("files");
+    if (!prompt) {
+        return null;
+    }
+
+    const model = prompt.llm || defaultModel;
+    const agentMode = prompt.agentMode || false;
+    const reasoningEffort = prompt.reasoningEffort || null;
+    const pathwayName = agentMode
+        ? "run_workspace_agent"
+        : "run_workspace_prompt";
+
+    return { prompt, model, agentMode, reasoningEffort, pathwayName };
 }

--- a/app/api/utils/run-workspace-prompt.js
+++ b/app/api/utils/run-workspace-prompt.js
@@ -1,0 +1,74 @@
+import {
+    getRunWorkspacePromptQuery,
+    isUnsupportedReasoningEffortError,
+} from "../../../src/utils/runWorkspacePromptQuery.js";
+
+export const RUN_WORKSPACE_PROMPT_PATHWAY = "run_workspace_prompt";
+
+export async function executeRunWorkspacePrompt({
+    graphqlClient,
+    variables,
+    models,
+    pathwayName = RUN_WORKSPACE_PROMPT_PATHWAY,
+    includeStream = false,
+    fetchPolicy = "network-only",
+    onUnsupportedReasoningEffort,
+}) {
+    const modelAttempts =
+        Array.isArray(models) && models.length > 0
+            ? models
+            : [variables?.model].filter(Boolean);
+    const attempts = modelAttempts.length > 0 ? modelAttempts : [undefined];
+    let lastError = null;
+
+    for (const model of attempts) {
+        const requestVariables = {
+            ...variables,
+            ...(model ? { model } : {}),
+        };
+
+        try {
+            const response = await graphqlClient.query({
+                query: getRunWorkspacePromptQuery(pathwayName, {
+                    includeReasoningEffort: Boolean(
+                        requestVariables.reasoningEffort,
+                    ),
+                    includeStream,
+                }),
+                variables: requestVariables,
+                fetchPolicy,
+            });
+
+            return { response, model };
+        } catch (error) {
+            lastError = error;
+
+            if (
+                requestVariables.reasoningEffort &&
+                isUnsupportedReasoningEffortError(error)
+            ) {
+                const { reasoningEffort, ...variablesWithoutReasoning } =
+                    requestVariables;
+
+                try {
+                    const response = await graphqlClient.query({
+                        query: getRunWorkspacePromptQuery(pathwayName, {
+                            includeReasoningEffort: false,
+                            includeStream,
+                        }),
+                        variables: variablesWithoutReasoning,
+                        fetchPolicy,
+                    });
+
+                    onUnsupportedReasoningEffort?.(error);
+
+                    return { response, model };
+                } catch (retryError) {
+                    lastError = retryError;
+                }
+            }
+        }
+    }
+
+    throw lastError || new Error(`Failed to run ${pathwayName}`);
+}

--- a/app/api/workspaces/[id]/applet/chat/route.js
+++ b/app/api/workspaces/[id]/applet/chat/route.js
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { getClient, QUERIES } from "../../../../../../src/graphql";
 import Workspace from "../../../../models/workspace";
 import { getWorkspace } from "../../db.js";
+import { ensureAppletSdkScript } from "../../../../../workspaces/[id]/components/utils.js";
 
 export async function POST(request, { params }) {
     try {
@@ -95,7 +96,7 @@ export async function POST(request, { params }) {
 
             if (htmlContent) {
                 message = {
-                    html: htmlContent,
+                    html: ensureAppletSdkScript(htmlContent),
                     changes: "HTML code generated from APPLET tag",
                 };
             } else {
@@ -118,7 +119,7 @@ export async function POST(request, { params }) {
                 const htmlContent = lastMatch[1].trim();
                 if (htmlContent) {
                     message = {
-                        html: htmlContent,
+                        html: ensureAppletSdkScript(htmlContent),
                         changes: "HTML code generated from code block",
                     };
                 } else {
@@ -136,10 +137,24 @@ export async function POST(request, { params }) {
             message,
         });
     } catch (error) {
-        console.error(
-            "Error in chat endpoint:",
-            error.networkError?.result?.errors || error,
-        );
+        const gqlErrors =
+            error.networkError?.result?.errors || error.graphQLErrors;
+        if (gqlErrors) {
+            console.error("Error in chat endpoint:", gqlErrors);
+            const validationError = gqlErrors.find(
+                (e) => e.extensions?.code === "GRAPHQL_VALIDATION_FAILED",
+            );
+            if (validationError) {
+                return NextResponse.json(
+                    {
+                        error: "Applet editing is not supported by the current backend. Please check your Cortex server configuration.",
+                    },
+                    { status: 501 },
+                );
+            }
+        } else {
+            console.error("Error in chat endpoint:", error);
+        }
         return NextResponse.json(
             { error: "Failed to process chat message" },
             { status: 500 },

--- a/app/api/workspaces/[id]/applet/data/route.js
+++ b/app/api/workspaces/[id]/applet/data/route.js
@@ -3,13 +3,19 @@ import AppletData from "../../../../models/applet-data.js";
 import { getWorkspace } from "../../db.js";
 import { getCurrentUser } from "@/app/api/utils/auth.js";
 import { validateMongoDBKey } from "@/app/api/utils/fileValidation.js";
+import { parseJsonRequest } from "@/app/api/utils/parseJsonRequest.js";
 
 // PUT: store data for an applet
 export async function PUT(request, { params }) {
     const { id } = params;
-    const body = await request.json();
 
     try {
+        const parsedBody = await parseJsonRequest(request);
+        if (!parsedBody.ok) {
+            return parsedBody.errorResponse;
+        }
+        const body = parsedBody.body;
+
         const workspace = await getWorkspace(id);
         if (!workspace) {
             return NextResponse.json(
@@ -43,14 +49,20 @@ export async function PUT(request, { params }) {
 
         // Find or create applet data for this user and applet
         // Use the sanitized key to prevent injection attacks
+        const query = {
+            appletId: workspace.applet,
+            userId: user._id,
+        };
+        const existing = await AppletData.findOne(query);
+        const nextData = {
+            ...(existing?.data || {}),
+            [keyValidation.sanitizedKey]: body.value,
+        };
         const appletData = await AppletData.findOneAndUpdate(
-            {
-                appletId: workspace.applet,
-                userId: user._id,
-            },
+            query,
             {
                 $set: {
-                    [`data.${keyValidation.sanitizedKey}`]: body.value,
+                    data: nextData,
                 },
             },
             {

--- a/app/api/workspaces/[id]/applet/execute_prompt/route.js
+++ b/app/api/workspaces/[id]/applet/execute_prompt/route.js
@@ -1,15 +1,11 @@
 import { NextResponse } from "next/server";
 import { getClient } from "../../../../../../src/graphql";
 import { QUERIES } from "../../../../../../src/graphql";
-import LLM from "../../../../models/llm";
 import Workspace from "../../../../models/workspace";
 import { getCurrentUser } from "../../../../utils/auth";
-import {
-    getAnyAgenticLLM,
-    buildWorkspacePromptVariables,
-} from "../../../../utils/llm-file-utils";
-import { getPromptWithMigration } from "../../../../utils/prompt-utils";
-import { filterValidFiles } from "../../../../utils/file-validation-utils";
+import { buildWorkspacePromptVariables } from "../../../../utils/llm-file-utils";
+import { getPromptConfig } from "../../../../utils/prompt-utils";
+import config from "../../../../../../config";
 
 export async function POST(request, { params }) {
     try {
@@ -32,15 +28,16 @@ export async function POST(request, { params }) {
             );
         }
 
+        const defaultModel = config.cortex.defaultChatModel;
         let promptText = null;
         let pathwayName;
         let model;
         let promptFiles = [];
-        let researchMode = false;
+        let reasoningEffort = null;
         let agentMode = false;
 
         if (promptId) {
-            const promptData = await getPromptWithMigration(promptId);
+            const promptData = await getPromptConfig(promptId, defaultModel);
             if (!promptData) {
                 return NextResponse.json(
                     { error: "Prompt not found" },
@@ -49,18 +46,18 @@ export async function POST(request, { params }) {
             }
 
             promptText = promptData.prompt.text;
-            // Filter out errored files
-            promptFiles = await filterValidFiles(promptData.prompt.files || []);
+            // Keep prompt-attached files even if they have a stale validation error.
+            // buildWorkspacePromptVariables now has self-healing resolution logic.
+            promptFiles = (promptData.prompt.files || []).filter(Boolean);
             pathwayName = promptData.pathwayName;
             model = promptData.model;
-            researchMode = promptData.researchMode || false;
+            reasoningEffort = promptData.reasoningEffort || null;
             agentMode = promptData.agentMode || false;
         } else {
-            // No promptId provided, get default agentic LLM
-            const llm = await getAnyAgenticLLM(LLM);
-            pathwayName = llm.cortexPathwayName;
-            model = llm.cortexModelName;
-            agentMode = true; // Default to agent mode when using agentic LLM
+            // No promptId provided — default to agent mode
+            pathwayName = "run_workspace_agent";
+            model = config.cortex.AGENTIC_MODEL;
+            agentMode = true;
         }
 
         // Fetch workspace to get systemPrompt (workspace context)
@@ -73,27 +70,31 @@ export async function POST(request, { params }) {
             }
         }
 
-        // Collect all files (prompt files + request files)
-        const allFiles = [];
-        if (promptFiles.length > 0) {
-            allFiles.push(...promptFiles);
-        }
-        if (files && Array.isArray(files) && files.length > 0) {
-            allFiles.push(...files);
-        }
+        const requestFiles = Array.isArray(files) ? files : [];
 
-        // Build variables - include agentContext only for agent pathways
+        console.info("[workspace execute_prompt] file counts", {
+            workspaceId: params.id || null,
+            promptId: promptId || null,
+            requestFiles: requestFiles.length,
+            promptFiles: promptFiles.length,
+            totalFiles: promptFiles.length + requestFiles.length,
+            agentMode,
+            pathwayName,
+        });
+
+        // Build variables with explicit prompt-file and request-file routing.
         const variables = await buildWorkspacePromptVariables({
             systemPrompt: workspaceSystemPrompt,
             prompt: promptText,
             text: userInput,
-            files: allFiles,
+            sharedFiles: promptFiles,
+            userFiles: requestFiles,
             chatHistory: chatHistory,
+            appletId: workspace?.applet?.toString() || null,
             workspaceId: workspace?._id?.toString() || null,
             workspaceContextKey: workspace?.contextKey || null,
             userContextId: user?.contextId || null,
             userContextKey: user?.contextKey || null,
-            useCompoundContextId: true, // Use compound contextId for user files
         });
 
         variables.model = model;
@@ -101,14 +102,19 @@ export async function POST(request, { params }) {
         // Use agent query for agent pathways, regular query for non-agent
         let query;
         if (agentMode) {
-            // Pass researchMode for agent pathways
-            if (researchMode) {
-                variables.researchMode = true;
+            variables.entityId = user?.personalEntityId || "";
+            if (user?.aiName) {
+                variables.aiName = user.aiName;
+            }
+            // Pass reasoningEffort for agent pathways
+            if (reasoningEffort) {
+                variables.reasoningEffort = reasoningEffort;
             }
             query = QUERIES.getWorkspaceAgentQuery(pathwayName);
         } else {
-            // Non-agent pathways don't use agentContext or researchMode
-            delete variables.agentContext;
+            // Non-agent pathways still use fileAccessPlan for available file listing.
+            delete variables.contextId;
+            delete variables.contextKey;
             query = QUERIES.getWorkspacePromptQuery(pathwayName);
         }
 

--- a/app/api/workspaces/[id]/applet/files/[fileId]/content/route.js
+++ b/app/api/workspaces/[id]/applet/files/[fileId]/content/route.js
@@ -1,7 +1,13 @@
 import { NextResponse } from "next/server";
 import AppletFile from "../../../../../../models/applet-file.js";
+import File from "../../../../../../models/file.js";
 import { getWorkspace } from "../../../../db.js";
 import { getCurrentUser } from "../../../../../../utils/auth.js";
+import {
+    createAppletUserStorageTarget,
+    createWorkspacePrivateStorageTarget,
+} from "../../../../../../../../src/utils/storageTargets.js";
+import { resolveAndHealFile } from "../../../../../../utils/file-resolution-utils.js";
 
 // GET: stream file content for an applet (proxies Azure storage to avoid CORS)
 export async function GET(request, { params }) {
@@ -49,8 +55,36 @@ export async function GET(request, { params }) {
             );
         }
 
-        // 2. Fetch from Azure storage (server-side, no CORS issues)
-        const azureResponse = await fetch(file.url, {
+        const storageTarget = createAppletUserStorageTarget(
+            user.contextId,
+            workspace?.applet?.toString() || null,
+        );
+        const resolved = await resolveAndHealFile(file, {
+            storageTarget,
+            fallbackStorageTargets:
+                user?.contextId && workspaceId
+                    ? [
+                          createWorkspacePrivateStorageTarget(
+                              user.contextId,
+                              workspaceId,
+                          ),
+                      ]
+                    : [],
+            allowUrlRefresh: true,
+            persistResolvedFile: async (updateFields) => {
+                await File.findByIdAndUpdate(file._id, updateFields);
+            },
+        });
+
+        if (!resolved.accessUrl) {
+            return NextResponse.json(
+                { error: "Failed to resolve file from storage" },
+                { status: 404 },
+            );
+        }
+
+        // 2. Fetch from storage using the current canonical URL
+        const azureResponse = await fetch(resolved.accessUrl, {
             redirect: "follow",
         });
 

--- a/app/api/workspaces/[id]/applet/files/route.js
+++ b/app/api/workspaces/[id]/applet/files/route.js
@@ -4,36 +4,67 @@ import File from "../../../../models/file.js";
 import { getWorkspace } from "../../db.js";
 import { getCurrentUser } from "../../../../utils/auth.js";
 import { handleStreamingFileUpload } from "../../../../utils/upload-utils.js";
+import { deleteMediaFile } from "../../../../utils/media-service-utils.js";
+import { createAppletUserStorageTarget } from "../../../../../../src/utils/storageTargets.js";
+
+async function deleteCloudFile(file, userContextId, appletId) {
+    if ((!file?.blobPath && !file?.hash) || !userContextId || !appletId) {
+        return;
+    }
+    await deleteMediaFile({
+        blobPath: file.blobPath,
+        hash: file.hash,
+        storageTarget: createAppletUserStorageTarget(userContextId, appletId),
+    });
+}
 
 // POST: upload a file for an applet with streaming support
 export async function POST(request, { params }) {
     const { id } = params;
+    const workspace = await getWorkspace(id);
+    const user = await getCurrentUser();
 
     const result = await handleStreamingFileUpload(request, {
-        getWorkspace: async () => await getWorkspace(id),
+        getWorkspace: async () => workspace,
 
         // No authorization check needed for applet files
         checkAuthorization: null,
 
+        storageTarget: workspace?.applet
+            ? createAppletUserStorageTarget(
+                  user?.contextId || null,
+                  workspace.applet?.toString() || null,
+              )
+            : null,
+
         associateFile: async (newFile, workspace, user) => {
-            // Check if a file with the same hash already exists for this user/applet
-            if (newFile.hash) {
+            const appletId = workspace?.applet?.toString() || null;
+            // Check if a file with the same blobPath or hash already exists for this user/applet
+            const matchQuery = [];
+            if (newFile.blobPath)
+                matchQuery.push({ blobPath: newFile.blobPath });
+            if (newFile.hash) matchQuery.push({ hash: newFile.hash });
+            if (matchQuery.length > 0) {
                 const existingAppletFile = await AppletFile.findOne({
-                    appletId: workspace.applet,
+                    appletId,
                     userId: user._id,
                 }).populate({
                     path: "files",
-                    match: { hash: newFile.hash },
+                    match:
+                        matchQuery.length === 1
+                            ? matchQuery[0]
+                            : { $or: matchQuery },
                 });
 
                 if (existingAppletFile && existingAppletFile.files.length > 0) {
                     // File with this hash already exists, return existing file and files without adding
                     const existingFile = existingAppletFile.files[0];
                     const allFiles = await AppletFile.findOne({
-                        appletId: workspace.applet,
+                        appletId,
                         userId: user._id,
                     }).populate("files");
 
+                    await deleteCloudFile(newFile, user.contextId, appletId);
                     // Delete the duplicate File document we just created
                     await File.findByIdAndDelete(newFile._id);
 
@@ -48,7 +79,7 @@ export async function POST(request, { params }) {
             // Find or create applet file record for this user and applet
             const appletFile = await AppletFile.findOneAndUpdate(
                 {
-                    appletId: workspace.applet,
+                    appletId,
                     userId: user._id,
                 },
                 {
@@ -67,8 +98,6 @@ export async function POST(request, { params }) {
         },
 
         errorPrefix: "applet file upload",
-        permanent: false, // User files are temporary (not workspace artifacts)
-        useCompoundContextId: true, // Use compound contextId for user-specific file scoping in applets
     });
 
     if (result.error) {
@@ -165,6 +194,11 @@ export async function DELETE(request, { params }) {
             );
         }
 
+        await deleteCloudFile(
+            fileToDelete,
+            user.contextId,
+            workspace?.applet?.toString() || null,
+        );
         // Remove the file document
         await File.findByIdAndDelete(fileToDelete._id);
 

--- a/app/api/workspaces/[id]/applet/route.js
+++ b/app/api/workspaces/[id]/applet/route.js
@@ -3,7 +3,11 @@ import Workspace from "@/app/api/models/workspace";
 import Applet from "@/app/api/models/applet";
 import { getWorkspace } from "../db.js";
 import App, { APP_TYPES, APP_STATUS } from "@/app/api/models/app";
-// Removed unused import
+import { hydrateAppletVersionContents } from "@/app/api/canvas-applets/versioning";
+
+// Legacy v1 workspace applet endpoint. Keep this route on the original
+// Mongo-inline applet shape; v2 canvas applet versioning/publication belongs in
+// /api/canvas-applets and app/api/canvas-applets/registry.js.
 
 // GET: fetch or create applet (already implemented)
 export async function GET(request, { params }) {
@@ -35,7 +39,11 @@ export async function GET(request, { params }) {
             await workspaceDoc.save();
             await workspaceDoc.populate("applet");
         }
-        return NextResponse.json(workspaceDoc.applet);
+        const applet =
+            typeof workspaceDoc.applet?.toObject === "function"
+                ? workspaceDoc.applet.toObject()
+                : workspaceDoc.applet;
+        return NextResponse.json(await hydrateAppletVersionContents(applet));
     } catch (error) {
         console.error(error);
         return NextResponse.json(

--- a/app/workspaces/[id]/components/utils.js
+++ b/app/workspaces/[id]/components/utils.js
@@ -1,3 +1,7 @@
+import { ensureAppletSdkScript } from "../../../../src/utils/appletSdkUtils.js";
+
+export { ensureAppletSdkScript };
+
 export function getMessagesUpToVersion(messages, versionIndex) {
     if (!messages) return [];
     const idx = messages.findLastIndex(

--- a/public/applet-sdk.js
+++ b/public/applet-sdk.js
@@ -1,0 +1,1557 @@
+/**
+ * =============================================================================
+ * Concierge Applet SDK v1.8.0
+ * =============================================================================
+ *
+ * This SDK provides applets with access to Concierge platform capabilities.
+ * It is automatically injected into every applet at runtime and exposed
+ * as the global `ConciergeSDK` object on `window`.
+ *
+ * Applets can also explicitly include it via:
+ *   <script src="/applet-sdk.js"></script>
+ *
+ * -----------------------------------------------------------------------------
+ * Quick Start
+ * -----------------------------------------------------------------------------
+ *
+ *   // Verify the SDK is loaded
+ *   console.log(ConciergeSDK.version); // "1.8.0"
+ *
+ *   // Call the AI agent
+ *   var response = await ConciergeSDK.agent.chat({
+ *       messages: [{ role: "user", content: "Translate 'hello' to Arabic" }],
+ *       systemPrompt: "You are a translation assistant.",
+ *   });
+ *   console.log(response.result);
+ *
+ *   // Make a direct model call without agent tools/connectors
+ *   var translation = await ConciergeSDK.models.generate({
+ *       prompt: "Translate 'hello' to Arabic. Return only the translation.",
+ *       reasoningEffort: "low",
+ *   });
+ *   console.log(translation.result);
+ *
+ * -----------------------------------------------------------------------------
+ * Available Functions
+ * -----------------------------------------------------------------------------
+ *
+ *   ConciergeSDK.locale.get()
+ *     - Read the current applet UI language and text direction.
+ *     - returns {{ language: string, direction: "ltr"|"rtl" }}
+ *
+ *   ConciergeSDK.locale.getLanguage()
+ *     - returns {string}  "en" or "ar"
+ *
+ *   ConciergeSDK.locale.getDirection()
+ *     - returns {string}  "ltr" or "rtl"
+ *
+ *   ConciergeSDK.locale.isRtl()
+ *     - returns {boolean}
+ *
+ *   ConciergeSDK.agent.chat(options)
+ *     - Send messages to the AI agent and get a response.
+ *     - param  {Object}   options
+ *     - param  {Array}    options.messages       Array of {role, content} objects (required)
+ *     - param  {string}   [options.systemPrompt] Optional system prompt
+ *     - param  {string}   [options.model]        Optional model override
+ *     - returns {Promise<{result: string, warnings: Array, errors: Array}>}
+ *     - NOTE: `result` is Markdown-formatted. Render it with a Markdown
+ *       library (e.g. marked, markdown-it) rather than inserting as plain text.
+ *
+ *   ConciergeSDK.models.list()
+ *     - List applet-available chat models and supported reasoning efforts.
+ *     - returns {Promise<{models: Array, defaultModel: string, reasoningEfforts: Array}>}
+ *
+ *   ConciergeSDK.models.generate(options)
+ *     - Make a stateless direct model call without agent tools/connectors.
+ *     - param  {Object}   options
+ *     - param  {string}   [options.prompt]          Prompt text
+ *     - param  {Array}    [options.messages]        Array of {role, content} objects
+ *     - param  {string}   [options.systemPrompt]    Optional system prompt
+ *     - param  {string}   [options.model]           Optional model ID from models.list()
+ *     - param  {string}   [options.reasoningEffort] Optional: "none", "low", "medium", or "high"
+ *     - returns {Promise<{result: string}>}
+ *
+ *   ConciergeSDK.services.getAccessToken(options)
+ *     - Get an OAuth access token for a connected external service.
+ *     - param  {Object}   options
+ *     - param  {string}   options.service  Service identifier: "atlassian", "github", or "slack"
+ *     - returns {Promise<{token: string, service: string, expiresAt: number|null, metadata: Object}>}
+ *     - if the service is not connected or the token is expired, the SDK
+ *       opens a popup (synchronously on your click), then retries
+ *     - Jira Cloud JQL search: use /rest/api/3/search/jql (not /rest/api/3/search,
+ *       removed — see Atlassian Issue search REST docs & changelog #CHANGE-2046)
+ *
+ *   ConciergeSDK.params.get(name)
+ *     - Read a URL query parameter passed to the applet page.
+ *     - param  {string} name  Parameter name (e.g. "team")
+ *     - returns {string|undefined}
+ *
+ *   ConciergeSDK.params.getAll()
+ *     - Read all URL query parameters as a plain object.
+ *     - returns {Object<string, string>}
+ *
+ *   ConciergeSDK.data.get()
+ *     - Retrieve all stored data for this applet and user.
+ *     - returns {Promise<Object>}  Key-value data object (empty {} if none)
+ *
+ *   ConciergeSDK.data.set(key, value)
+ *     - Store a key-value pair for this applet and user.
+ *     - param  {string} key    The data key (non-empty string)
+ *     - param  {*}      value  The value to store (any JSON-serializable value)
+ *     - returns {Promise<Object>}  The full updated data object
+ *
+ *   ConciergeSDK.sharedData.get(key)
+ *     - Retrieve revision-protected data shared by all users of this applet.
+ *     - returns {Promise<{found: boolean, value: Object, revision: string|null}>}
+ *
+ *   ConciergeSDK.sharedData.set(key, value)
+ *     - Create or replace shared applet data with backups/revision protection.
+ *     - returns {Promise<{success: boolean, value: *, revision: string}>}
+ *
+ *   ConciergeSDK.files.list()
+ *     - List all files stored for this applet and user.
+ *     - returns {Promise<Array>}  Array of file objects
+ *
+ *   ConciergeSDK.files.upload(file)
+ *     - Upload a file for this applet and user.
+ *     - param  {File} file  A File object (from input[type=file] or new File())
+ *     - returns {Promise<{file: Object, files: Array}>}
+ *
+ *   ConciergeSDK.files.getContentUrl(fileId)
+ *     - Get the URL to fetch a file's content.
+ *     - param  {string} fileId  The file's _id
+ *     - returns {string}  URL path (synchronous)
+ *
+ *   ConciergeSDK.files.delete(filename)
+ *     - Delete a file by filename.
+ *     - param  {string} filename  The stored filename
+ *     - returns {Promise<{files: Array}>}  Updated list of remaining files
+ *
+ * =============================================================================
+ */
+(function () {
+    // Guard against double-loading
+    if (window.ConciergeSDK) {
+        return;
+    }
+
+    function _oauthPopupFeatures() {
+        var width = 600;
+        var height = 700;
+        var left = window.screenX + (window.outerWidth - width) / 2;
+        var top = window.screenY + (window.outerHeight - height) / 2;
+        return (
+            "width=" +
+            width +
+            ",height=" +
+            height +
+            ",left=" +
+            left +
+            ",top=" +
+            top
+        );
+    }
+
+    /**
+     * Sandboxed srcDoc iframes may expose location.origin as the string "null".
+     * Prefer top/parent/ancestorOrigins when readable (same-origin).
+     */
+    function _conciergeEffectiveOrigin() {
+        var o = window.location.origin;
+        if (o && o !== "null") {
+            return o;
+        }
+        try {
+            if (
+                window.top &&
+                window.top.location &&
+                window.top.location.origin &&
+                window.top.location.origin !== "null"
+            ) {
+                return window.top.location.origin;
+            }
+        } catch (e1) {}
+        try {
+            if (
+                window.parent &&
+                window.parent !== window &&
+                window.parent.location &&
+                window.parent.location.origin &&
+                window.parent.location.origin !== "null"
+            ) {
+                return window.parent.location.origin;
+            }
+        } catch (e2) {}
+        if (
+            window.location.ancestorOrigins &&
+            window.location.ancestorOrigins.length > 0
+        ) {
+            return window.location.ancestorOrigins[0];
+        }
+        return "";
+    }
+
+    /**
+     * Read the applet ID from the <meta name="applet-id"> tag in the document.
+     * Returns null if the tag is missing or has no content.
+     */
+    function _getAppletId() {
+        var meta = document.querySelector('meta[name="applet-id"]');
+        if (meta && meta.content) {
+            return meta.content;
+        }
+        return null;
+    }
+
+    /**
+     * Get the applet ID or throw a descriptive error.
+     */
+    function _requireAppletId() {
+        var id = _getAppletId();
+        if (!id) {
+            throw new Error(
+                "[ConciergeSDK] No applet-id meta tag found. " +
+                    "Applet-scoped SDK APIs require a registered applet.",
+            );
+        }
+        return id;
+    }
+
+    function _resolveAuthorizeUrl(connectInfo) {
+        var service = connectInfo.service;
+        if (connectInfo.mcpOAuthInit) {
+            var origin = _conciergeEffectiveOrigin();
+            var redirectUri = (origin || "") + connectInfo.mcpOAuthRedirect;
+            return fetch(connectInfo.mcpOAuthInit, {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                credentials: "include",
+                body: JSON.stringify({ redirectUri: redirectUri }),
+            }).then(function (res) {
+                return res.json().then(function (data) {
+                    if (!res.ok || !data.authorizeUrl) {
+                        throw new Error(
+                            data.error || "Failed to initialize OAuth",
+                        );
+                    }
+                    return data.authorizeUrl;
+                });
+            });
+        }
+        if (connectInfo.oauthUrl) {
+            var u = connectInfo.oauthUrl;
+            return Promise.resolve(
+                u.indexOf("http") === 0 ? u : _conciergeEffectiveOrigin() + u,
+            );
+        }
+        return Promise.reject(
+            new Error("No OAuth configuration for " + service),
+        );
+    }
+
+    /**
+     * Popup must be opened in the same synchronous turn as the user gesture.
+     * Pass a window from window.open("about:blank", ...) at the start of
+     * getAccessToken; after async work, navigate it to the authorize URL.
+     */
+    function _initiateOAuth(connectInfo) {
+        var service = connectInfo.service;
+
+        // When running inside a sandboxed iframe, delegate popup to the host
+        // window via postMessage so we don't need allow-popups-to-escape-sandbox.
+        if (window.parent && window.parent !== window) {
+            return new Promise(function (resolve, reject) {
+                var requestId =
+                    "oauth_" +
+                    Date.now() +
+                    "_" +
+                    Math.random().toString(36).substr(2, 9);
+
+                var settled = false;
+                function settle(error) {
+                    if (settled) return;
+                    settled = true;
+                    clearTimeout(timeout);
+                    window.removeEventListener("message", onMessage);
+                    if (error) {
+                        reject(error);
+                    } else {
+                        resolve();
+                    }
+                }
+
+                var timeout = setTimeout(function () {
+                    var err = new Error("OAuth timed out for " + service + ".");
+                    err.code = "OAUTH_TIMEOUT";
+                    settle(err);
+                }, 240000);
+
+                function onMessage(event) {
+                    if (
+                        !event ||
+                        !event.data ||
+                        event.data.type !== "__OAUTH_RESPONSE__"
+                    ) {
+                        return;
+                    }
+                    if (event.data.requestId !== requestId) {
+                        return;
+                    }
+                    if (event.data.success) {
+                        settle(null);
+                    } else {
+                        var err = new Error(
+                            event.data.error || "OAuth failed for " + service,
+                        );
+                        err.code = event.data.code || "OAUTH_FAILED";
+                        settle(err);
+                    }
+                }
+                window.addEventListener("message", onMessage);
+
+                window.parent.postMessage(
+                    {
+                        type: "__OAUTH_REQUEST__",
+                        requestId: requestId,
+                        connectInfo: connectInfo,
+                    },
+                    "*",
+                );
+            });
+        }
+
+        // Fallback: direct popup (non-iframe context)
+        return _resolveAuthorizeUrl(connectInfo).then(function (authorizeUrl) {
+            return new Promise(function (resolve, reject) {
+                var popup = window.open(
+                    authorizeUrl,
+                    "concierge-oauth",
+                    _oauthPopupFeatures(),
+                );
+
+                if (!popup) {
+                    var err = new Error(
+                        "Popup blocked. Please allow popups to connect " +
+                            service +
+                            ".",
+                    );
+                    err.code = "POPUP_BLOCKED";
+                    reject(err);
+                    return;
+                }
+
+                var settled = false;
+                function settle(error) {
+                    if (settled) return;
+                    settled = true;
+                    clearTimeout(timeout);
+                    clearInterval(closedCheck);
+                    window.removeEventListener("message", onMessage);
+                    if (error) {
+                        reject(error);
+                    } else {
+                        resolve();
+                    }
+                }
+
+                var timeout = setTimeout(function () {
+                    var err = new Error("OAuth timed out for " + service + ".");
+                    err.code = "OAUTH_TIMEOUT";
+                    settle(err);
+                }, 240000);
+
+                var expectedType = service + "-oauth-complete";
+                function onMessage(event) {
+                    if (
+                        !event ||
+                        !event.data ||
+                        event.data.type !== expectedType
+                    ) {
+                        return;
+                    }
+                    if (event.source && event.source !== popup) {
+                        return;
+                    }
+                    if (event.data.success) {
+                        settle(null);
+                    } else {
+                        var err = new Error(
+                            event.data.error || "OAuth failed for " + service,
+                        );
+                        err.code = "OAUTH_FAILED";
+                        settle(err);
+                    }
+                }
+                window.addEventListener("message", onMessage);
+
+                var closedCheck = setInterval(function () {
+                    if (popup && popup.closed) {
+                        var err = new Error(
+                            "OAuth window was closed before completing.",
+                        );
+                        err.code = "OAUTH_CANCELLED";
+                        settle(err);
+                    }
+                }, 1000);
+            });
+        });
+    }
+
+    function _sleep(ms) {
+        return new Promise(function (resolve) {
+            window.setTimeout(resolve, ms);
+        });
+    }
+
+    function _retryAfterMs(res) {
+        var value =
+            res.headers && typeof res.headers.get === "function"
+                ? res.headers.get("Retry-After")
+                : null;
+        var seconds = value ? Number(value) : NaN;
+        if (Number.isFinite(seconds) && seconds >= 0) {
+            return seconds * 1000;
+        }
+        var dateMs = value ? Date.parse(value) : NaN;
+        return Number.isFinite(dateMs) && dateMs > Date.now()
+            ? dateMs - Date.now()
+            : null;
+    }
+
+    function _apiError(res, fallback) {
+        return res
+            .json()
+            .catch(function () {
+                return {};
+            })
+            .then(function (err) {
+                var error = new Error(err.error || fallback);
+                error.status = res.status;
+                error.code = err.code || "UNKNOWN";
+                error.retryAfter = _retryAfterMs(res);
+                error.details = err;
+                error.connectInfo = err.connectInfo;
+                throw error;
+            });
+    }
+
+    function _apiFetch(url, options, fallback, retryOptions) {
+        retryOptions = retryOptions || {};
+        var retries = retryOptions.retries || 0;
+        var baseDelayMs = retryOptions.baseDelayMs || 500;
+
+        function shouldRetry(res, attempt) {
+            return (
+                attempt < retries && (res.status === 429 || res.status === 503)
+            );
+        }
+
+        function attemptFetch(attempt) {
+            return fetch(url, options).then(function (res) {
+                if (res.ok) return res.json();
+                if (shouldRetry(res, attempt)) {
+                    var retryAfter = _retryAfterMs(res);
+                    var delay =
+                        retryAfter != null
+                            ? retryAfter
+                            : baseDelayMs * Math.pow(2, attempt);
+                    return _sleep(delay).then(function () {
+                        return attemptFetch(attempt + 1);
+                    });
+                }
+                return _apiError(res, fallback);
+            });
+        }
+
+        return attemptFetch(0);
+    }
+
+    var _sharedDataRevisions = {};
+
+    function _sharedDataArgs(keyOrOptions, value) {
+        if (typeof keyOrOptions === "string") {
+            return { key: keyOrOptions, value: value };
+        }
+        return keyOrOptions || {};
+    }
+
+    function _sharedDataCacheKey(appletId, key) {
+        return appletId + ":" + key;
+    }
+
+    function _rememberSharedDataRevision(appletId, result) {
+        if (result && result.key && result.revision != null) {
+            _sharedDataRevisions[_sharedDataCacheKey(appletId, result.key)] =
+                result.revision;
+        }
+        return result;
+    }
+
+    function _sharedDataRevisionFor(appletId, key) {
+        return _sharedDataRevisions[_sharedDataCacheKey(appletId, key)];
+    }
+
+    function _normalizeSdkLanguage(value) {
+        return value === "ar" ? "ar" : "en";
+    }
+
+    function _normalizeSdkDirection(value) {
+        return value === "rtl" ? "rtl" : "ltr";
+    }
+
+    var ConciergeSDK = {
+        /**
+         * SDK version following semver.
+         * @type {string}
+         */
+        version: "1.8.0",
+
+        /**
+         * Locale namespace — Arabic/English language and text direction.
+         * Mirrors the host Concierge app's language setting.
+         */
+        locale: {
+            /**
+             * @returns {{ language: string, direction: "ltr"|"rtl" }}
+             */
+            get: function () {
+                return {
+                    language: _normalizeSdkLanguage(window.LABEEB_LANGUAGE),
+                    direction: _normalizeSdkDirection(window.LABEEB_DIRECTION),
+                };
+            },
+
+            /** @returns {string} */
+            getLanguage: function () {
+                return _normalizeSdkLanguage(window.LABEEB_LANGUAGE);
+            },
+
+            /** @returns {"ltr"|"rtl"} */
+            getDirection: function () {
+                return _normalizeSdkDirection(window.LABEEB_DIRECTION);
+            },
+
+            /** @returns {boolean} */
+            isRtl: function () {
+                return (
+                    _normalizeSdkDirection(window.LABEEB_DIRECTION) === "rtl"
+                );
+            },
+        },
+
+        /**
+         * URL query parameters passed to the applet page (e.g. iframe src or /apps/{slug}?team=...).
+         * Concierge-internal keys like openChat are excluded.
+         */
+        params: {
+            /**
+             * All query params as a plain object.
+             * @returns {Object<string, string>}
+             */
+            getAll: function () {
+                return Object.assign({}, window.APPLET_PARAMS || {});
+            },
+
+            /**
+             * Read a single query param by name.
+             * @param {string} name
+             * @returns {string|undefined}
+             */
+            get: function (name) {
+                var params = window.APPLET_PARAMS || {};
+                return params[name];
+            },
+        },
+
+        /**
+         * Agent namespace — AI agent capabilities for applets.
+         *
+         * Calls are scoped to the currently logged-in user and run through
+         * that user's personal agent when one is configured. Applet data and
+         * files remain isolated per applet and per user.
+         */
+        agent: {
+            /**
+             * Send messages to the AI agent and get a response.
+             * The request runs as the currently logged-in user's agent, so
+             * user-available tools/connectors may be used normally.
+             *
+             * @param {Object} options
+             * @param {Array<{role: string, content: string}>} options.messages
+             *   Conversation messages. At least one message is required.
+             * @param {string} [options.systemPrompt] - Optional system prompt
+             *   to set the agent's behavior (e.g. "You are a translator").
+             * @param {string} [options.model] - Optional model override.
+             *   Defaults to the platform's default model.
+             * @returns {Promise<{result: string, warnings: Array, errors: Array}>}
+             *   The `result` field contains **Markdown-formatted** text.
+             *   Render it with a Markdown library (e.g. marked, markdown-it)
+             *   rather than inserting it as plain text.
+             *
+             * @example
+             * var response = await ConciergeSDK.agent.chat({
+             *     messages: [{ role: "user", content: "Hello!" }],
+             * });
+             * console.log(response.result);
+             *
+             * @example
+             * var response = await ConciergeSDK.agent.chat({
+             *     messages: [{ role: "user", content: "Translate 'good morning'" }],
+             *     systemPrompt: "Translate all text to Arabic.",
+             * });
+             */
+            chat: function (options) {
+                options = options || {};
+                var messages = options.messages;
+                var appletId;
+
+                if (
+                    !messages ||
+                    !Array.isArray(messages) ||
+                    messages.length === 0
+                ) {
+                    return Promise.reject(
+                        new Error("[ConciergeSDK] messages array is required"),
+                    );
+                }
+
+                try {
+                    appletId = _requireAppletId();
+                } catch (e) {
+                    return Promise.reject(e);
+                }
+
+                var body = { messages: messages, appletId: appletId };
+                if (options.systemPrompt)
+                    body.systemPrompt = options.systemPrompt;
+                if (options.model) body.model = options.model;
+
+                return _apiFetch(
+                    "/api/applet/agent-chat",
+                    {
+                        method: "POST",
+                        headers: { "Content-Type": "application/json" },
+                        credentials: "include",
+                        body: JSON.stringify(body),
+                    },
+                    "Agent chat request failed",
+                    { retries: 2 },
+                );
+            },
+        },
+
+        /**
+         * Models namespace — direct stateless model calls for applets.
+         *
+         * Use these helpers when an applet needs a plain model invocation
+         * without the user's personal agent, tools, connectors, or memory.
+         */
+        models: {
+            /**
+             * List applet-available chat models.
+             *
+             * @returns {Promise<{models: Array, defaultModel: string, reasoningEfforts: Array}>}
+             *
+             * @example
+             * var metadata = await ConciergeSDK.models.list();
+             * console.log(metadata.defaultModel);
+             */
+            list: function () {
+                var appletId;
+
+                try {
+                    appletId = _requireAppletId();
+                } catch (e) {
+                    return Promise.reject(e);
+                }
+
+                return _apiFetch(
+                    "/api/applet/models?appletId=" +
+                        encodeURIComponent(appletId),
+                    {
+                        method: "GET",
+                        credentials: "include",
+                    },
+                    "Model list request failed",
+                    { retries: 1 },
+                );
+            },
+
+            /**
+             * Make a stateless direct model call.
+             *
+             * @param {Object} options
+             * @param {string} [options.prompt] - Prompt text.
+             * @param {Array<{role: string, content: string}>} [options.messages]
+             *   Conversation messages. Use either prompt or messages.
+             * @param {string} [options.systemPrompt] - Optional system prompt.
+             * @param {string} [options.model] - Optional model ID from list().
+             * @param {("none"|"low"|"medium"|"high")} [options.reasoningEffort]
+             *   Optional reasoning effort.
+             * @returns {Promise<{result: string}>}
+             *
+             * @example
+             * var response = await ConciergeSDK.models.generate({
+             *     prompt: "Translate 'good morning' to Arabic. Return only the translation.",
+             *     reasoningEffort: "low",
+             * });
+             */
+            generate: function (options) {
+                options = options || {};
+                var appletId;
+                var body;
+
+                if (
+                    !options.prompt &&
+                    (!Array.isArray(options.messages) ||
+                        options.messages.length === 0)
+                ) {
+                    return Promise.reject(
+                        new Error(
+                            "[ConciergeSDK] prompt or messages array is required",
+                        ),
+                    );
+                }
+
+                try {
+                    appletId = _requireAppletId();
+                } catch (e) {
+                    return Promise.reject(e);
+                }
+
+                body = { appletId: appletId };
+                if (options.prompt) body.prompt = options.prompt;
+                if (options.messages) body.messages = options.messages;
+                if (options.systemPrompt)
+                    body.systemPrompt = options.systemPrompt;
+                if (options.model) body.model = options.model;
+                if (options.reasoningEffort)
+                    body.reasoningEffort = options.reasoningEffort;
+
+                return _apiFetch(
+                    "/api/applet/model-generate",
+                    {
+                        method: "POST",
+                        headers: { "Content-Type": "application/json" },
+                        credentials: "include",
+                        body: JSON.stringify(body),
+                    },
+                    "Model generate request failed",
+                    { retries: 2 },
+                );
+            },
+        },
+
+        /**
+         * Services namespace — access tokens for connected external services.
+         *
+         * Applets can request OAuth access tokens for services the user has
+         * already connected (e.g. Jira, GitHub, Slack) and use them to call
+         * those services' APIs directly.
+         */
+        services: {
+            /**
+             * Get an OAuth access token for a connected external service.
+             *
+             * @param {Object} options
+             * @param {("atlassian"|"github"|"slack")} options.service
+             *   The service to get a token for.
+             * @returns {Promise<{token: string, service: string, expiresAt: number|null, metadata: Object}>}
+             *   - token: The Authorization header value (e.g. "Bearer ...")
+             *   - service: The service identifier
+             *   - expiresAt: Token expiration timestamp (ms) or null
+             *   - metadata: Service-specific fields (e.g. { cloudId, baseUrl } for Atlassian)
+             *
+             * @example
+             * var jira = await ConciergeSDK.services.getAccessToken({ service: "atlassian" });
+             * var response = await fetch(jira.metadata.baseUrl + "/rest/api/3/myself", {
+             *     headers: { Authorization: jira.token },
+             * });
+             * var me = await response.json();
+             *
+             * @example
+             * var gh = await ConciergeSDK.services.getAccessToken({ service: "github" });
+             * var repos = await fetch("https://api.github.com/user/repos", {
+             *     headers: { Authorization: gh.token },
+             * });
+             */
+            getAccessToken: function (options) {
+                options = options || {};
+                var service = options.service;
+
+                if (!service || typeof service !== "string") {
+                    return Promise.reject(
+                        new Error("[ConciergeSDK] service is required"),
+                    );
+                }
+
+                function fetchToken() {
+                    var appletId = _requireAppletId();
+                    return _apiFetch(
+                        "/api/applet/service-token",
+                        {
+                            method: "POST",
+                            headers: { "Content-Type": "application/json" },
+                            credentials: "include",
+                            body: JSON.stringify({
+                                service: service,
+                                appletId: appletId,
+                            }),
+                        },
+                        "Failed to get access token",
+                    );
+                }
+
+                return Promise.resolve()
+                    .then(fetchToken)
+                    .catch(function (err) {
+                        var recoverable =
+                            err.code === "SERVICE_NOT_CONNECTED" ||
+                            err.code === "TOKEN_EXPIRED";
+                        if (recoverable && err.connectInfo) {
+                            console.log(
+                                "[ConciergeSDK] " +
+                                    service +
+                                    " requires OAuth — connecting…",
+                            );
+                            return _initiateOAuth(err.connectInfo)
+                                .then(fetchToken)
+                                .catch(function (oauthErr) {
+                                    throw oauthErr;
+                                });
+                        }
+                        throw err;
+                    });
+            },
+        },
+
+        /**
+         * Data namespace — per-user key-value storage for applets.
+         *
+         * Each user gets their own isolated data store within an applet.
+         * Requires a <meta name="applet-id"> tag in the HTML.
+         */
+        data: {
+            /**
+             * Retrieve all stored data for this applet and user.
+             *
+             * @returns {Promise<Object>} Key-value data object ({} if empty)
+             *
+             * @example
+             * var stored = await ConciergeSDK.data.get();
+             * console.log(stored.counter); // 42
+             */
+            get: function () {
+                try {
+                    var appletId = _requireAppletId();
+                } catch (e) {
+                    return Promise.reject(e);
+                }
+
+                return _apiFetch(
+                    "/api/canvas-applets/" + appletId + "/data",
+                    {
+                        method: "GET",
+                        credentials: "include",
+                    },
+                    "Failed to get applet data",
+                    { retries: 1 },
+                ).then(function (body) {
+                    return body.data;
+                });
+            },
+
+            /**
+             * Store a key-value pair for this applet and user.
+             *
+             * @param {string} key   The data key
+             * @param {*}      value The value to store
+             * @returns {Promise<Object>} The full updated data object
+             *
+             * @example
+             * var updated = await ConciergeSDK.data.set("counter", 42);
+             * console.log(updated.counter); // 42
+             */
+            set: function (key, value) {
+                if (!key || typeof key !== "string") {
+                    return Promise.reject(
+                        new Error(
+                            "[ConciergeSDK] key must be a non-empty string",
+                        ),
+                    );
+                }
+                if (value === undefined) {
+                    return Promise.reject(
+                        new Error("[ConciergeSDK] value is required"),
+                    );
+                }
+
+                try {
+                    var appletId = _requireAppletId();
+                } catch (e) {
+                    return Promise.reject(e);
+                }
+
+                return _apiFetch(
+                    "/api/canvas-applets/" + appletId + "/data",
+                    {
+                        method: "PUT",
+                        headers: { "Content-Type": "application/json" },
+                        credentials: "include",
+                        body: JSON.stringify({ key: key, value: value }),
+                    },
+                    "Failed to set applet data",
+                ).then(function (body) {
+                    return body.data;
+                });
+            },
+        },
+
+        /**
+         * Shared data namespace — revision-protected applet workspace storage.
+         *
+         * Unlike ConciergeSDK.data, values in this namespace are shared across
+         * users of the same applet key.
+         */
+        sharedData: {
+            /**
+             * Retrieve one shared workspace value.
+             *
+             * @param {string|Object} keyOrOptions The key string, or { key }
+             * @returns {Promise<{found: boolean, value: Object, revision: string|null}>}
+             */
+            get: function (keyOrOptions) {
+                var options = _sharedDataArgs(keyOrOptions);
+                if (!options.key || typeof options.key !== "string") {
+                    return Promise.reject(
+                        new Error(
+                            "[ConciergeSDK] key must be a non-empty string",
+                        ),
+                    );
+                }
+
+                try {
+                    var appletId = _requireAppletId();
+                } catch (e) {
+                    return Promise.reject(e);
+                }
+
+                var url =
+                    "/api/canvas-applets/" +
+                    appletId +
+                    "/shared-data/" +
+                    encodeURIComponent(options.key);
+                return _apiFetch(
+                    url,
+                    {
+                        method: "GET",
+                        credentials: "include",
+                    },
+                    "Failed to get shared applet data",
+                    { retries: 1 },
+                ).then(function (body) {
+                    return _rememberSharedDataRevision(appletId, body);
+                });
+            },
+
+            /**
+             * Create or replace one shared workspace value. Existing values
+             * are backed up automatically. If this tab loaded the value first,
+             * the SDK sends the last seen revision to prevent stale overwrites.
+             *
+             * @param {string|Object} keyOrOptions The key string, or { key, value }
+             * @param {Object} [value] Value to store when key is a string
+             */
+            set: function (keyOrOptions, value) {
+                var options = _sharedDataArgs(keyOrOptions, value);
+                var expectedRevision;
+                if (!options.key || typeof options.key !== "string") {
+                    return Promise.reject(
+                        new Error(
+                            "[ConciergeSDK] key must be a non-empty string",
+                        ),
+                    );
+                }
+                if (options.value === undefined) {
+                    return Promise.reject(
+                        new Error("[ConciergeSDK] value is required"),
+                    );
+                }
+                if (
+                    !options.value ||
+                    typeof options.value !== "object" ||
+                    Array.isArray(options.value)
+                ) {
+                    return Promise.reject(
+                        new Error("[ConciergeSDK] value must be an object"),
+                    );
+                }
+
+                try {
+                    var appletId = _requireAppletId();
+                } catch (e) {
+                    return Promise.reject(e);
+                }
+
+                expectedRevision =
+                    options.expectedRevision !== undefined
+                        ? options.expectedRevision
+                        : _sharedDataRevisionFor(appletId, options.key);
+
+                return _apiFetch(
+                    "/api/canvas-applets/" +
+                        appletId +
+                        "/shared-data/" +
+                        encodeURIComponent(options.key),
+                    {
+                        method: "PUT",
+                        headers: { "Content-Type": "application/json" },
+                        credentials: "include",
+                        body: JSON.stringify({
+                            value: options.value,
+                            expectedRevision: expectedRevision,
+                            reset: options.reset === true,
+                        }),
+                    },
+                    "Failed to set shared applet data",
+                ).then(function (body) {
+                    return _rememberSharedDataRevision(appletId, body);
+                });
+            },
+
+            /**
+             * Clear or reset shared data through the explicit reset path.
+             * Use this only for user-confirmed reset actions.
+             */
+            reset: function (keyOrOptions, value) {
+                var options = _sharedDataArgs(keyOrOptions, value);
+                options.reset = true;
+                return this.set(options);
+            },
+
+            /**
+             * List recovery snapshots for one shared workspace value.
+             */
+            backups: function (keyOrOptions) {
+                var options = _sharedDataArgs(keyOrOptions);
+                if (!options.key || typeof options.key !== "string") {
+                    return Promise.reject(
+                        new Error(
+                            "[ConciergeSDK] key must be a non-empty string",
+                        ),
+                    );
+                }
+
+                try {
+                    var appletId = _requireAppletId();
+                } catch (e) {
+                    return Promise.reject(e);
+                }
+
+                var url =
+                    "/api/canvas-applets/" +
+                    appletId +
+                    "/shared-data/" +
+                    encodeURIComponent(options.key) +
+                    "/backups";
+                return _apiFetch(
+                    url,
+                    {
+                        method: "GET",
+                        credentials: "include",
+                    },
+                    "Failed to list shared applet data backups",
+                    { retries: 1 },
+                ).then(function (body) {
+                    return body.backups;
+                });
+            },
+
+            /**
+             * Restore one recovery snapshot.
+             */
+            restore: function (keyOrOptions, backupIdOrRevision) {
+                var options = _sharedDataArgs(keyOrOptions);
+                var appletId;
+                if (!options.key || typeof options.key !== "string") {
+                    return Promise.reject(
+                        new Error(
+                            "[ConciergeSDK] key must be a non-empty string",
+                        ),
+                    );
+                }
+                if (
+                    typeof backupIdOrRevision === "number" &&
+                    options.revision == null
+                ) {
+                    options.revision = backupIdOrRevision;
+                } else if (
+                    backupIdOrRevision != null &&
+                    options.backupId == null
+                ) {
+                    options.backupId = backupIdOrRevision;
+                }
+                if (!options.backupId && options.revision == null) {
+                    return Promise.reject(
+                        new Error(
+                            "[ConciergeSDK] backupId or revision is required",
+                        ),
+                    );
+                }
+
+                try {
+                    appletId = _requireAppletId();
+                } catch (e) {
+                    return Promise.reject(e);
+                }
+
+                return _apiFetch(
+                    "/api/canvas-applets/" +
+                        appletId +
+                        "/shared-data/" +
+                        encodeURIComponent(options.key) +
+                        "/restore",
+                    {
+                        method: "POST",
+                        headers: { "Content-Type": "application/json" },
+                        credentials: "include",
+                        body: JSON.stringify({
+                            backupId: options.backupId,
+                            revision: options.revision,
+                        }),
+                    },
+                    "Failed to restore shared applet data",
+                ).then(function (body) {
+                    return _rememberSharedDataRevision(appletId, body);
+                });
+            },
+        },
+
+        /**
+         * Files namespace — per-user file storage for applets.
+         *
+         * Each user gets their own isolated file store within an applet.
+         * Requires a <meta name="applet-id"> tag in the HTML.
+         */
+        files: {
+            /**
+             * List all files stored for this applet and user.
+             *
+             * @returns {Promise<Array>} Array of file objects
+             *
+             * @example
+             * var files = await ConciergeSDK.files.list();
+             * files.forEach(function(f) { console.log(f.originalName, f.size); });
+             */
+            list: function () {
+                try {
+                    var appletId = _requireAppletId();
+                } catch (e) {
+                    return Promise.reject(e);
+                }
+
+                return _apiFetch(
+                    "/api/canvas-applets/" + appletId + "/files",
+                    {
+                        method: "GET",
+                        credentials: "include",
+                    },
+                    "Failed to list applet files",
+                    { retries: 1 },
+                ).then(function (body) {
+                    return body.files;
+                });
+            },
+
+            /**
+             * Upload a file for this applet and user.
+             *
+             * @param {File} file A File object
+             * @returns {Promise<{file: Object, files: Array}>}
+             *
+             * @example
+             * var input = document.querySelector('input[type="file"]');
+             * var result = await ConciergeSDK.files.upload(input.files[0]);
+             * console.log(result.file.url);
+             */
+            upload: function (file) {
+                if (!file || !(file instanceof File)) {
+                    return Promise.reject(
+                        new Error("[ConciergeSDK] file must be a File object"),
+                    );
+                }
+
+                try {
+                    var appletId = _requireAppletId();
+                } catch (e) {
+                    return Promise.reject(e);
+                }
+
+                var formData = new FormData();
+                formData.append("file", file);
+
+                return _apiFetch(
+                    "/api/canvas-applets/" + appletId + "/files",
+                    {
+                        method: "POST",
+                        credentials: "include",
+                        body: formData,
+                    },
+                    "Failed to upload file",
+                );
+            },
+
+            /**
+             * Get the URL to fetch a file's content.
+             *
+             * @param {string} fileId The file's _id
+             * @returns {string} URL path
+             *
+             * @example
+             * var url = ConciergeSDK.files.getContentUrl(file._id);
+             * var img = document.createElement("img");
+             * img.src = url;
+             */
+            getContentUrl: function (fileId) {
+                if (!fileId || typeof fileId !== "string") {
+                    throw new Error(
+                        "[ConciergeSDK] fileId must be a non-empty string",
+                    );
+                }
+                var appletId = _requireAppletId();
+                return (
+                    "/api/canvas-applets/" +
+                    appletId +
+                    "/files/" +
+                    fileId +
+                    "/content"
+                );
+            },
+
+            /**
+             * Delete a file by filename.
+             *
+             * @param {string} filename The stored filename
+             * @returns {Promise<{files: Array}>} Updated list of remaining files
+             *
+             * @example
+             * var result = await ConciergeSDK.files.delete("photo.png");
+             * console.log(result.files.length);
+             */
+            delete: function (filename) {
+                if (!filename || typeof filename !== "string") {
+                    return Promise.reject(
+                        new Error(
+                            "[ConciergeSDK] filename must be a non-empty string",
+                        ),
+                    );
+                }
+
+                try {
+                    var appletId = _requireAppletId();
+                } catch (e) {
+                    return Promise.reject(e);
+                }
+
+                return _apiFetch(
+                    "/api/canvas-applets/" +
+                        appletId +
+                        "/files?filename=" +
+                        encodeURIComponent(filename),
+                    {
+                        method: "DELETE",
+                        credentials: "include",
+                    },
+                    "Failed to delete file",
+                );
+            },
+        },
+    };
+
+    // ---- Runtime monitor (console + network capture) ----
+
+    var _MON_MAX = 100;
+    var _MON_BODY_MAX = 4096;
+
+    var _monConsole = [];
+    var _monNetwork = [];
+
+    function _monTruncate(val, max) {
+        if (typeof val !== "string") {
+            try {
+                val = JSON.stringify(val);
+            } catch (e) {
+                val = String(val);
+            }
+        }
+        return val.length > max ? val.slice(0, max) + "... [truncated]" : val;
+    }
+
+    function _monPushConsole(entry) {
+        if (_monConsole.length >= _MON_MAX) _monConsole.shift();
+        _monConsole.push(entry);
+    }
+
+    function _monPushNetwork(entry) {
+        if (_monNetwork.length >= _MON_MAX) _monNetwork.shift();
+        _monNetwork.push(entry);
+    }
+
+    function _monArgsToString(args) {
+        var parts = [];
+        for (var i = 0; i < args.length; i++) {
+            var a = args[i];
+            if (a instanceof Error) {
+                parts.push(a.message + (a.stack ? "\n" + a.stack : ""));
+            } else if (typeof a === "object") {
+                try {
+                    parts.push(JSON.stringify(a));
+                } catch (e) {
+                    parts.push(String(a));
+                }
+            } else {
+                parts.push(String(a));
+            }
+        }
+        return parts.join(" ");
+    }
+
+    // Console capture
+    var _origError = console.error;
+    var _origWarn = console.warn;
+    var _origLog = console.log;
+    var _origInfo = console.info;
+
+    console.error = function () {
+        _monPushConsole({
+            level: "error",
+            message: _monTruncate(_monArgsToString(arguments), _MON_BODY_MAX),
+            timestamp: new Date().toISOString(),
+        });
+        return _origError.apply(console, arguments);
+    };
+
+    console.warn = function () {
+        _monPushConsole({
+            level: "warn",
+            message: _monTruncate(_monArgsToString(arguments), _MON_BODY_MAX),
+            timestamp: new Date().toISOString(),
+        });
+        return _origWarn.apply(console, arguments);
+    };
+
+    console.log = function () {
+        _monPushConsole({
+            level: "log",
+            message: _monTruncate(_monArgsToString(arguments), _MON_BODY_MAX),
+            timestamp: new Date().toISOString(),
+        });
+        return _origLog.apply(console, arguments);
+    };
+
+    console.info = function () {
+        _monPushConsole({
+            level: "info",
+            message: _monTruncate(_monArgsToString(arguments), _MON_BODY_MAX),
+            timestamp: new Date().toISOString(),
+        });
+        return _origInfo.apply(console, arguments);
+    };
+
+    window.addEventListener("error", function (event) {
+        _monPushConsole({
+            level: "error",
+            message: event.message || "Unknown error",
+            source: event.filename
+                ? event.filename + ":" + event.lineno + ":" + event.colno
+                : undefined,
+            stack:
+                event.error && event.error.stack
+                    ? _monTruncate(event.error.stack, _MON_BODY_MAX)
+                    : undefined,
+            timestamp: new Date().toISOString(),
+        });
+    });
+
+    window.addEventListener("unhandledrejection", function (event) {
+        var reason = event.reason;
+        var message = "Unhandled promise rejection";
+        var stack;
+        if (reason instanceof Error) {
+            message = reason.message;
+            stack = reason.stack;
+        } else if (typeof reason === "string") {
+            message = reason;
+        } else {
+            try {
+                message = JSON.stringify(reason);
+            } catch (e) {
+                message = String(reason);
+            }
+        }
+        _monPushConsole({
+            level: "error",
+            message: _monTruncate(message, _MON_BODY_MAX),
+            stack: stack ? _monTruncate(stack, _MON_BODY_MAX) : undefined,
+            timestamp: new Date().toISOString(),
+        });
+    });
+
+    // Network capture: fetch
+    var _origFetch = window.fetch;
+    if (_origFetch) {
+        window.fetch = function () {
+            var args = arguments;
+            var url =
+                typeof args[0] === "string"
+                    ? args[0]
+                    : (args[0] && args[0].url) || String(args[0]);
+            var opts = args[1] || {};
+            var method = (
+                (args[0] && typeof args[0] !== "string" && args[0].method) ||
+                opts.method ||
+                "GET"
+            ).toUpperCase();
+
+            var entry = {
+                method: method,
+                url: _monTruncate(url, 500),
+                startTime: new Date().toISOString(),
+                status: null,
+                statusText: null,
+                duration: null,
+                error: null,
+                responseBody: null,
+            };
+            var t0 = Date.now();
+
+            return _origFetch.apply(window, args).then(
+                function (response) {
+                    entry.status = response.status;
+                    entry.statusText = response.statusText;
+                    entry.duration = Date.now() - t0;
+                    if (!response.ok || response.status >= 400) {
+                        var cloned = response.clone();
+                        cloned
+                            .text()
+                            .then(function (body) {
+                                entry.responseBody = _monTruncate(
+                                    body,
+                                    _MON_BODY_MAX,
+                                );
+                            })
+                            .catch(function () {});
+                    }
+                    _monPushNetwork(entry);
+                    return response;
+                },
+                function (err) {
+                    entry.duration = Date.now() - t0;
+                    entry.error = err.message || String(err);
+                    _monPushNetwork(entry);
+                    throw err;
+                },
+            );
+        };
+    }
+
+    // Network capture: XMLHttpRequest
+    var _XHR = window.XMLHttpRequest;
+    if (_XHR) {
+        var _origOpen = _XHR.prototype.open;
+        var _origSend = _XHR.prototype.send;
+
+        _XHR.prototype.open = function (method, url) {
+            this.__lbMon = {
+                method: (method || "GET").toUpperCase(),
+                url: _monTruncate(String(url), 500),
+            };
+            return _origOpen.apply(this, arguments);
+        };
+
+        _XHR.prototype.send = function () {
+            var xhr = this;
+            var mon = xhr.__lbMon;
+            if (!mon) return _origSend.apply(this, arguments);
+
+            var entry = {
+                method: mon.method,
+                url: mon.url,
+                startTime: new Date().toISOString(),
+                status: null,
+                statusText: null,
+                duration: null,
+                error: null,
+                responseBody: null,
+            };
+            var t0 = Date.now();
+
+            xhr.addEventListener("load", function () {
+                entry.status = xhr.status;
+                entry.statusText = xhr.statusText;
+                entry.duration = Date.now() - t0;
+                if (xhr.status >= 400) {
+                    try {
+                        entry.responseBody = _monTruncate(
+                            xhr.responseText,
+                            _MON_BODY_MAX,
+                        );
+                    } catch (e) {}
+                }
+                _monPushNetwork(entry);
+            });
+            xhr.addEventListener("error", function () {
+                entry.duration = Date.now() - t0;
+                entry.error = "Network error";
+                _monPushNetwork(entry);
+            });
+            xhr.addEventListener("timeout", function () {
+                entry.duration = Date.now() - t0;
+                entry.error = "Request timed out";
+                _monPushNetwork(entry);
+            });
+
+            return _origSend.apply(this, arguments);
+        };
+    }
+
+    // postMessage interface for parent window to retrieve captured data
+    window.addEventListener("message", function (event) {
+        if (!event.data || event.data.type !== "__APPLET_INSPECT_REQUEST__")
+            return;
+
+        // Only respond to requests from the parent window
+        if (event.source !== window.parent) return;
+
+        var response = {
+            type: "__APPLET_INSPECT_RESPONSE__",
+            requestId: event.data.requestId,
+            data: {
+                consoleEntries: _monConsole.slice(),
+                networkRequests: _monNetwork.slice(),
+            },
+        };
+
+        if (event.data.clear) {
+            _monConsole = [];
+            _monNetwork = [];
+        }
+
+        var origin;
+        try {
+            origin = event.origin || window.parent.location.origin;
+        } catch (e) {
+            origin = "*";
+        }
+
+        if (event.source) {
+            event.source.postMessage(response, origin);
+        } else if (window.parent && window.parent !== window) {
+            window.parent.postMessage(response, origin);
+        }
+    });
+
+    // Expose on window
+    window.ConciergeSDK = ConciergeSDK;
+})();

--- a/src/content/appletSdkDocumentation.js
+++ b/src/content/appletSdkDocumentation.js
@@ -1,0 +1,435 @@
+/**
+ * Canonical Concierge Applet SDK reference (Markdown).
+ * Consumed by the admin SDK Playground docs tab and the built-in `applets` skill.
+ * Keep in sync with `public/applet-sdk.js` behavior and version.
+ */
+export const APPLET_SDK_DOCUMENTATION = `# Concierge Applet SDK
+
+**Version:** 1.8.0
+
+The Concierge Applet SDK is automatically injected into every applet at runtime and exposed as the global \`ConciergeSDK\` object on \`window\`.
+
+## Getting Started
+
+The SDK is auto-injected — no manual setup required. To explicitly include it:
+
+\`\`\`html
+<script src="/applet-sdk.js"></script>
+\`\`\`
+
+Verify the SDK is loaded:
+
+\`\`\`js
+console.log(ConciergeSDK.version); // "1.8.0"
+\`\`\`
+
+## URL Parameters
+
+Query parameters on the applet page URL are injected at runtime. This supports direct navigation and iframe embeds:
+
+\`\`\`html
+<iframe src="https://your-concierge-host/apps/my-applet?team=team-alpha"></iframe>
+\`\`\`
+
+\`\`\`js
+const team = ConciergeSDK.params.get("team");
+const allParams = ConciergeSDK.params.getAll();
+// window.APPLET_PARAMS is also set with the same values
+\`\`\`
+
+Concierge-internal query keys (such as \`openChat\`) are excluded from applet params.
+
+## API Reference
+
+### Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| \`ConciergeSDK.version\` | \`string\` | SDK version following semver. Currently \`"1.8.0"\`. |
+
+#### \`ConciergeSDK.locale.get()\`
+
+Read the current applet UI language and text direction from the host Concierge app.
+
+**Returns:** \`{ language: "en" | "ar", direction: "ltr" | "rtl" }\`
+
+#### \`ConciergeSDK.locale.getLanguage()\`
+
+**Returns:** \`"en"\` or \`"ar"\`
+
+#### \`ConciergeSDK.locale.getDirection()\`
+
+**Returns:** \`"ltr"\` or \`"rtl"\`
+
+#### \`ConciergeSDK.locale.isRtl()\`
+
+**Returns:** \`boolean\`
+
+**Example:**
+
+\`\`\`js
+const { language, direction } = ConciergeSDK.locale.get();
+document.documentElement.dir = direction;
+
+document.addEventListener("concierge-locale-change", (event) => {
+    const next = event.detail;
+    // Update labels / layout when the user switches Arabic ↔ English
+});
+\`\`\`
+
+#### \`ConciergeSDK.params.get(name)\`
+
+Read a URL query parameter passed to the applet page (direct URL or iframe \`src\`).
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| \`name\` | \`string\` | Yes | Parameter name (e.g. \`"team"\`). |
+
+**Returns:** \`string | undefined\`
+
+#### \`ConciergeSDK.params.getAll()\`
+
+Read all URL query parameters as a plain object. Concierge-internal keys are excluded.
+
+**Returns:** \`Record<string, string>\`
+
+**Example:**
+
+\`\`\`js
+const team = ConciergeSDK.params.get("team"); // e.g. "team-alpha"
+\`\`\`
+
+### Functions
+
+#### \`ConciergeSDK.agent.chat(options)\`
+
+Send messages to the AI agent and get a response. Each call is **scoped to the currently logged-in user** and runs through that user's personal agent when one is configured, so the agent can use tools and connectors available to that user. Applet data and files are still isolated per applet and per user; the applet author's private data is never shared with other users of the same applet.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| \`options.messages\` | \`Array<{role, content}>\` | Yes | Conversation messages. At least one required. |
+| \`options.systemPrompt\` | \`string\` | No | System prompt to set the agent's behavior. |
+| \`options.model\` | \`string\` | No | Model override. Defaults to the platform default. |
+
+**Returns:** \`Promise<{ result: string, warnings: Array, errors: Array }>\`
+
+**Examples:**
+
+\`\`\`js
+// Simple question
+const response = await ConciergeSDK.agent.chat({
+    messages: [{ role: "user", content: "What is the capital of France?" }],
+});
+console.log(response.result); // "The capital of France is Paris."
+\`\`\`
+
+\`\`\`js
+// With system prompt
+const translation = await ConciergeSDK.agent.chat({
+    messages: [{ role: "user", content: "Good morning" }],
+    systemPrompt: "Translate all user messages to Arabic. Return only the translation.",
+});
+console.log(translation.result);
+\`\`\`
+
+\`\`\`js
+// Multi-turn conversation (pass full history)
+const response = await ConciergeSDK.agent.chat({
+    messages: [
+        { role: "user", content: "My name is Sarah" },
+        { role: "assistant", content: "Nice to meet you, Sarah!" },
+        { role: "user", content: "What is my name?" },
+    ],
+});
+\`\`\`
+
+#### \`ConciergeSDK.models.list()\`
+
+List chat models that applets can use for direct model calls. Use this before showing a model picker or before sending a specific \`model\` to \`models.generate()\`.
+
+**Returns:** \`Promise<{ models: Array, defaultModel: string, reasoningEfforts: Array }>\`
+
+Each model has:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| \`id\` / \`modelId\` | \`string\` | Cortex model identifier to pass to \`models.generate()\`. |
+| \`name\` | \`string\` | Display name. |
+| \`provider\` | \`string|null\` | Model provider when known. |
+| \`category\` | \`"chat"\` | Model category. |
+| \`isDefault\` | \`boolean\` | Whether this is the default applet model. |
+| \`isModelGroup\` | \`boolean\` | Whether the ID represents a model group/alias. |
+| \`supportsReasoningEffort\` | \`boolean\` | Whether \`reasoningEffort\` can be set. |
+| \`reasoningEfforts\` | \`Array<string>\` | Supported values such as \`"none"\`, \`"low"\`, \`"medium"\`, and \`"high"\`. |
+
+\`\`\`js
+const { models, defaultModel } = await ConciergeSDK.models.list();
+const defaultInfo = models.find((model) => model.id === defaultModel);
+console.log(defaultInfo.name);
+\`\`\`
+
+#### \`ConciergeSDK.models.generate(options)\`
+
+Make a stateless direct model call without the user's personal agent, tools, connectors, or memory. This is best for translation, classification, extraction, rewriting, scoring, JSON generation, and other app-local tasks where agentic behavior is not needed.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| \`options.prompt\` | \`string\` | Yes* | Prompt text. Required unless \`messages\` is supplied. |
+| \`options.messages\` | \`Array<{role, content}>\` | Yes* | Conversation messages. Required unless \`prompt\` is supplied. |
+| \`options.systemPrompt\` | \`string\` | No | System prompt/instructions. |
+| \`options.model\` | \`string\` | No | Model ID from \`models.list()\`. Defaults to the applet default model. |
+| \`options.reasoningEffort\` | \`"none" \\| "low" \\| "medium" \\| "high"\` | No | Optional reasoning effort. Must be supported by the selected model. |
+
+**Returns:** \`Promise<{ result: string }>\`
+
+\`\`\`js
+const translation = await ConciergeSDK.models.generate({
+    prompt: "Translate to Arabic: Good morning",
+    reasoningEffort: "low",
+});
+console.log(translation.result);
+\`\`\`
+
+\`\`\`js
+const { defaultModel } = await ConciergeSDK.models.list();
+const response = await ConciergeSDK.models.generate({
+    model: defaultModel,
+    systemPrompt: "Return only valid JSON.",
+    messages: [
+        { role: "user", content: "Extract name and company from: Ada at Concierge" },
+    ],
+});
+const data = JSON.parse(response.result);
+\`\`\`
+
+#### \`ConciergeSDK.services.getAccessToken(options)\`
+
+Get an OAuth access token for a connected external service. Use this to call external APIs (Jira, GitHub, Slack) directly from your applet.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| \`options.service\` | \`"atlassian" \\| "github" \\| "slack"\` | Yes | The service to get a token for. |
+
+**Returns:** \`Promise<{ token: string, service: string, expiresAt: number|null, metadata: Object }>\`
+
+- \`token\`: The Authorization header value (e.g. \`"Bearer ..."\`)
+- \`metadata\`: Service-specific fields (e.g. \`{ cloudId, baseUrl }\` for Atlassian)
+
+**Jira Cloud — issue search (do not use removed APIs):** Prefix paths with \`metadata.baseUrl\` (e.g. \`https://api.atlassian.com/ex/jira/{cloudId}\`). To search issues with JQL, use **enhanced JQL search** — \`GET\` or \`POST\` \`/rest/api/3/search/jql\` — not legacy \`/rest/api/3/search\` (that family was **removed** and returns **410**). Prefer \`POST\` with a JSON body when JQL is long. Official reference: [Issue search (Jira Cloud REST API v3)](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-search/). Migration and removal details: [Atlassian developer changelog — CHANGE-2046](https://developer.atlassian.com/changelog/#CHANGE-2046).
+
+**Error codes:** \`SERVICE_NOT_CONNECTED\`, \`TOKEN_EXPIRED\`, \`NO_TOKEN\`, \`POPUP_BLOCKED\`, \`OAUTH_TIMEOUT\`, \`OAUTH_CANCELLED\`, \`OAUTH_FAILED\`
+
+**Examples:**
+
+\`\`\`js
+// Fetch Jira issues (enhanced JQL search — not /rest/api/3/search)
+const jira = await ConciergeSDK.services.getAccessToken({ service: "atlassian" });
+const response = await fetch(jira.metadata.baseUrl + "/rest/api/3/search/jql", {
+    method: "POST",
+    headers: {
+        Authorization: jira.token,
+        Accept: "application/json",
+        "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+        jql: "assignee = currentUser() ORDER BY updated DESC",
+        maxResults: 25,
+        fields: ["summary", "status", "assignee"],
+    }),
+});
+const data = await response.json();
+\`\`\`
+
+\`\`\`js
+// Fetch GitHub repos
+const gh = await ConciergeSDK.services.getAccessToken({ service: "github" });
+const repos = await fetch("https://api.github.com/user/repos", {
+    headers: { Authorization: gh.token },
+});
+\`\`\`
+
+\`\`\`js
+// Handle not-connected gracefully
+try {
+    const slack = await ConciergeSDK.services.getAccessToken({ service: "slack" });
+    // use slack.token ...
+} catch (err) {
+    if (err.code === "SERVICE_NOT_CONNECTED") {
+        alert("Please connect Slack first in your settings.");
+    }
+}
+\`\`\`
+
+#### \`ConciergeSDK.data.get()\`
+
+Load all stored key-value data for **this applet and the current user**. Persists across sessions.
+
+**Returns:** \`Promise<Object>\` — merged key-value store, or \`{}\` if empty.
+
+**Requires:** \`<meta name="applet-id" content="<applet MongoDB id>">\` in the document (see **Applet ID** below).
+
+#### \`ConciergeSDK.data.set(key, value)\`
+
+Store one key. Values must be JSON-serializable.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| \`key\` | \`string\` | Yes | Non-empty string. Avoid \`$\` prefix and dots in keys (MongoDB field rules). |
+| \`value\` | \`any\` | Yes | Any JSON-serializable value. |
+
+**Returns:** \`Promise<Object>\` — the **full** updated data object after this write.
+
+\`\`\`js
+const all = await ConciergeSDK.data.set("settings", { theme: "dark" });
+console.log(all.settings.theme);
+\`\`\`
+
+#### \`ConciergeSDK.sharedData.get(key)\`
+
+Load one revision-protected value shared across users of the same applet. Use this for shared workspace state. Do not use \`ConciergeSDK.data\` for collaborative/shared state; \`data\` is intentionally per-current-user.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| \`key\` | \`string\` | Yes | Non-empty shared data key. |
+
+**Returns:** \`Promise<{ found: boolean, value: object, revision: string | null, key: string | null }>\`
+
+\`\`\`js
+const loaded = await ConciergeSDK.sharedData.get("workspace");
+
+if (loaded.found) {
+    renderWorkspace(loaded.value);
+} else {
+    showCreateWorkspaceButton();
+}
+\`\`\`
+
+#### \`ConciergeSDK.sharedData.set(key, value)\`
+
+Create or replace one shared workspace value. Missing keys are created automatically. Existing values are backed up before replacement. If this browser tab loaded the value first with \`sharedData.get()\`, the SDK sends the last seen revision automatically so stale clients get a conflict instead of silently overwriting newer data. \`set()\` cannot clear a non-empty shared value; use \`reset()\` for a user-confirmed clear or reset.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| \`key\` | \`string\` | Yes | Non-empty shared data key. |
+| \`value\` | \`object\` | Yes | JSON-serializable object to store. |
+
+\`\`\`js
+await ConciergeSDK.sharedData.set("workspace", initialWorkspace);
+
+await ConciergeSDK.sharedData.set("workspace", nextWorkspace);
+\`\`\`
+
+#### \`ConciergeSDK.sharedData.reset(key, value)\`
+
+Clear or reset shared data through the explicit reset path. Use this only for user-confirmed reset actions. Reset also creates a recovery snapshot first.
+
+**Returns:** \`Promise<{ success: boolean, value: object, revision: string }>\`
+
+#### \`ConciergeSDK.sharedData.backups(key)\`
+
+List recent recovery snapshots for a shared data key.
+
+**Returns:** \`Promise<Array>\`
+
+#### \`ConciergeSDK.sharedData.restore(key, backupId)\`
+
+Restore a recovery snapshot. You can pass either \`backupId\` or \`revision\`. Restoring also creates a backup of the state being replaced.
+
+**Returns:** \`Promise<{ success: boolean, value: object, revision: string }>\`
+
+#### \`ConciergeSDK.files.list()\`
+
+List files stored for this applet and user.
+
+**Returns:** \`Promise<Array>\` — file metadata objects (e.g. \`originalName\`, \`size\`, \`mimeType\`, \`_id\`).
+
+#### \`ConciergeSDK.files.upload(file)\`
+
+Upload a browser \`File\` (from \`<input type="file">\` or \`new File(...)\`).
+
+**Returns:** \`Promise<{ file: Object, files: Array }>\`
+
+#### \`ConciergeSDK.files.getContentUrl(fileId)\`
+
+Build the **relative URL** to fetch raw file bytes (e.g. for \`<img src>\` or \`fetch\`). Synchronous.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| \`fileId\` | \`string\` | The file document’s \`_id\` from \`list()\` or \`upload()\`. |
+
+**Returns:** \`string\` — path like \`/api/canvas-applets/<appletId>/files/<fileId>/content\`
+
+#### \`ConciergeSDK.files.delete(filename)\`
+
+Remove a file by its **stored filename** (not necessarily the original display name — use the value returned by the API / \`list()\`).
+
+**Returns:** \`Promise<{ files: Array }>\` — remaining files list.
+
+### Applet ID (\`<meta name="applet-id">\`)
+
+\`data\` and \`files\` require a registered canvas applet. Add a meta tag in \`<head>\`:
+
+\`\`\`html
+<meta name="applet-id" content="YOUR_APPLET_MONGO_ID">
+\`\`\`
+
+Replace \`YOUR_APPLET_MONGO_ID\` with your applet’s \`_id\` from the Applets UI or from saved applet HTML. Without this tag, the SDK throws: \`No applet-id meta tag found\`.
+
+In the **SDK Playground**, set the same value in the template’s meta tag so data/file API calls resolve to your applet.
+
+### Important Notes
+
+- **Stateless direct model calls**: \`models.generate\` does not use the user's personal agent, tools, connectors, or memory. To maintain conversation context, pass the full message history in \`messages\`.
+- **Agent chat context**: \`agent.chat\` also does NOT persist memory between calls. To maintain conversation context, pass the full message history in \`messages\`.
+- **User-isolated**: Each user gets their own applet data/file context. The applet author's data is never exposed to other users.
+- **Personal agent tools**: \`agent.chat\` runs as the currently logged-in user's agent and may use that user's available tools/connectors. Tool access still depends on the user's normal permissions and connection state.
+- **SDK safety limits**: Concierge rate-limits and concurrency-limits applet SDK APIs. The SDK automatically backs off and retries limited AI and read calls, but service-token, write, upload, and delete calls surface the error without retrying. Avoid tight render loops, recursive prefetch, and unbounded timers. Repeated limit violations temporarily suspend SDK access for the applet for about 15 minutes; after fixing the applet, clear the suspension with \`UpdateAppletMetadata { clearSdkSuspension: true }\` or wait for it to expire.
+
+---
+
+## Applet Architecture
+
+- Applets are **single-file HTML documents** rendered in sandboxed iframes.
+- **Tailwind CSS v4** is automatically injected via the browser CDN.
+- The SDK is injected into \`<head>\` (preferred), before \`</body>\`, or prepended as a fallback.
+- Applets support **light/dark mode** via the \`data-theme\` attribute on \`<html>\`.
+- Applets support **English/Arabic** via \`lang\` / \`dir\` on \`<html>\` and \`ConciergeSDK.locale\`.
+
+## Minimal Applet Template
+
+\`\`\`html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="concierge-type" content="applet">
+    <!-- Optional: required for ConciergeSDK.data / ConciergeSDK.files -->
+    <meta name="applet-id" content="YOUR_APPLET_MONGO_ID">
+    <title>My Applet</title>
+</head>
+<body>
+    <h1>Hello World</h1>
+    <script>
+        // SDK is auto-injected — ConciergeSDK is available globally
+        console.log("SDK version:", ConciergeSDK.version);
+
+        // Call the AI agent
+        async function askAgent() {
+            const response = await ConciergeSDK.agent.chat({
+                messages: [{ role: "user", content: "Say hello!" }],
+            });
+            // Note: response.result is Markdown — use a Markdown renderer for rich formatting
+            document.getElementById("output").textContent = response.result;
+        }
+    </script>
+    <button onclick="askAgent()">Ask Agent</button>
+    <pre id="output"></pre>
+</body>
+</html>
+\`\`\`
+
+## Guard Against Double-Loading
+
+The SDK guards against being loaded twice. If \`window.ConciergeSDK\` already exists, the script is a no-op.
+`;

--- a/src/graphql.js
+++ b/src/graphql.js
@@ -1193,6 +1193,14 @@ const DELETE_PATHWAY = gql`
     }
 `;
 
+const SYS_MODEL_METADATA = gql`
+    query SysModelMetadata($category: String) {
+        sys_model_metadata(category: $category) {
+            result
+        }
+    }
+`;
+
 const MUTATIONS = {
     CANCEL_REQUEST,
     PUT_PATHWAY,
@@ -1201,6 +1209,7 @@ const MUTATIONS = {
 
 export {
     getClient,
+    SYS_MODEL_METADATA,
     AZURE_VIDEO_TRANSLATE,
     CODE_HUMAN_INPUT,
     COGNITIVE_INSERT,

--- a/src/utils/appletHtmlUtils.js
+++ b/src/utils/appletHtmlUtils.js
@@ -1,0 +1,71 @@
+function escapeHtmlAttribute(value) {
+    return (value || "")
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/'/g, "&#39;")
+        .replace(/"/g, "&quot;");
+}
+
+function injectMetaTag(html, metaMarkup) {
+    if (!html || typeof html !== "string") {
+        return html;
+    }
+
+    if (/<\/head>/i.test(html)) {
+        return html.replace(/<\/head>/i, `    ${metaMarkup}\n</head>`);
+    }
+
+    if (/<body[^>]*>/i.test(html)) {
+        return html.replace(
+            /<body[^>]*>/i,
+            (match) => `${match}\n${metaMarkup}`,
+        );
+    }
+
+    return `${metaMarkup}\n${html}`;
+}
+
+export function injectAppletMetaTags(html, appletName) {
+    let taggedHtml = html;
+
+    if (!/<meta\s+name=["']concierge-type["']/i.test(taggedHtml)) {
+        taggedHtml = injectMetaTag(
+            taggedHtml,
+            '<meta name="concierge-type" content="applet">',
+        );
+    }
+
+    if (appletName && !/<meta\s+name=["']applet-name["']/i.test(taggedHtml)) {
+        taggedHtml = taggedHtml.replace(
+            /(<meta\s+name=["']concierge-type["'][^>]*>)/i,
+            `$1\n    <meta name="applet-name" content="${escapeHtmlAttribute(appletName)}">`,
+        );
+    }
+
+    return taggedHtml;
+}
+
+export function injectAppletIdMeta(html, appletId) {
+    if (!html || typeof html !== "string" || !appletId) {
+        return html;
+    }
+
+    if (/<meta\s+name=["']applet-id["']/i.test(html)) {
+        return html.replace(
+            /<meta\s+name=["']applet-id["']\s+content=["'][^"']*["']\s*\/?>/i,
+            `<meta name="applet-id" content="${escapeHtmlAttribute(appletId)}">`,
+        );
+    }
+
+    const appletIdMeta = `<meta name="applet-id" content="${escapeHtmlAttribute(appletId)}">`;
+
+    if (/<meta\s+name=["']concierge-type["'][^>]*>/i.test(html)) {
+        return html.replace(
+            /(<meta\s+name=["']concierge-type["'][^>]*>)/i,
+            `$1\n    ${appletIdMeta}`,
+        );
+    }
+
+    return injectMetaTag(html, appletIdMeta);
+}

--- a/src/utils/appletSdkUtils.js
+++ b/src/utils/appletSdkUtils.js
@@ -1,0 +1,39 @@
+import { injectAppletIdMeta } from "./appletHtmlUtils";
+
+/**
+ * Ensures the Concierge Applet SDK script tag is present in HTML content.
+ * If missing, injects <script src="/applet-sdk.js"></script> into <head>,
+ * or before </body>, or prepends it as a fallback.
+ * @param {string} html - The applet HTML content
+ * @returns {string} - HTML with the SDK script tag guaranteed to be present
+ */
+export function ensureAppletSdkScript(html) {
+    if (!html || typeof html !== "string") {
+        return html;
+    }
+
+    // Already has the SDK script tag — nothing to do
+    if (html.includes("applet-sdk.js")) {
+        return html;
+    }
+
+    const scriptTag = '<script src="/applet-sdk.js"></script>';
+
+    // Try to inject into <head> (before </head>)
+    if (/<\/head>/i.test(html)) {
+        return html.replace(/<\/head>/i, `    ${scriptTag}\n</head>`);
+    }
+
+    // No <head> — try before </body>
+    if (/<\/body>/i.test(html)) {
+        return html.replace(/<\/body>/i, `${scriptTag}\n</body>`);
+    }
+
+    // No structural tags — prepend
+    return scriptTag + "\n" + html;
+}
+
+export function ensureAppletRuntimeHtml(html, { appletId = null } = {}) {
+    const withSdk = ensureAppletSdkScript(html);
+    return injectAppletIdMeta(withSdk, appletId);
+}

--- a/src/utils/mcpPresets.js
+++ b/src/utils/mcpPresets.js
@@ -1,0 +1,50 @@
+/**
+ * MCP server presets for quick configuration.
+ * These define known MCP servers that users can connect with one click.
+ *
+ * `descriptionKey` is a translation key resolved by the UI via i18n.
+ * `description` is the English fallback (used server-side when sending
+ * descriptions to the AI prompt). `name` is a brand name; not translated.
+ */
+export const MCP_PRESETS = {
+    atlassian: {
+        id: "atlassian",
+        name: "Atlassian JIRA & Confluence",
+        type: "streamable-http",
+        url: "https://mcp.atlassian.com/v1/mcp",
+        authType: "oauth2",
+        mcpOAuthInit: "/api/auth/atlassian/mcp-init",
+        mcpOAuthRedirect: "/code/jira",
+        descriptionKey: "mcp_preset_atlassian_desc",
+        description:
+            "Search, create, and update JIRA issues and Confluence pages. Connect to your Atlassian Cloud site.",
+        icon: "jira",
+    },
+    slack: {
+        id: "slack",
+        name: "Slack",
+        type: "streamable-http",
+        url: "https://mcp.slack.com/mcp",
+        authType: "oauth2",
+        oauthUrl: "/api/auth/slack",
+        descriptionKey: "mcp_preset_slack_desc",
+        description:
+            "Search messages, channels, and users in your Slack workspace, and send messages on your behalf via the Concierge bot (with a 'Sent by you via Concierge' attribution block).",
+        icon: "slack",
+    },
+    github: {
+        id: "github",
+        name: "GitHub",
+        type: "streamable-http",
+        url: "https://api.githubcopilot.com/mcp/",
+        authType: "oauth2",
+        mcpOAuthInit: "/api/auth/github/mcp-init",
+        mcpOAuthRedirect: "/code/github",
+        descriptionKey: "mcp_preset_github_desc",
+        description:
+            "Manage repositories, issues, pull requests, and code on GitHub.",
+        icon: "github",
+    },
+};
+
+export const FEATURED_PRESET_IDS = ["atlassian", "slack", "github"];

--- a/src/utils/reasoningEffortI18n.js
+++ b/src/utils/reasoningEffortI18n.js
@@ -1,0 +1,47 @@
+/**
+ * API/storage values for reasoning effort (aligned with Cortex entity options).
+ * @type {Readonly<["none", "low", "medium", "high"]>}
+ */
+export const REASONING_EFFORT_LEVELS = Object.freeze([
+    "none",
+    "low",
+    "medium",
+    "high",
+]);
+
+/**
+ * i18n key for the display label of a reasoning effort level (not the API value).
+ * @param {string} level
+ * @returns {string}
+ */
+export function reasoningEffortLevelLabelKey(level) {
+    return `reasoning_effort_level_${level}`;
+}
+
+export function getReasoningEffortLevelsForModel(model) {
+    const configuredLevels = model?.supportedReasoningEfforts;
+
+    if (!Array.isArray(configuredLevels) || configuredLevels.length === 0) {
+        return REASONING_EFFORT_LEVELS;
+    }
+
+    const configuredLevelSet = new Set(configuredLevels);
+    const supportedLevels = REASONING_EFFORT_LEVELS.filter((level) =>
+        configuredLevelSet.has(level),
+    );
+
+    return supportedLevels.length > 0
+        ? supportedLevels
+        : REASONING_EFFORT_LEVELS;
+}
+
+export function normalizeReasoningEffortForModel(
+    model,
+    reasoningEffort,
+    fallback = "low",
+) {
+    const levels = getReasoningEffortLevelsForModel(model);
+    const candidate = reasoningEffort || fallback;
+
+    return levels.includes(candidate) ? candidate : levels[0];
+}

--- a/src/utils/runWorkspacePromptQuery.js
+++ b/src/utils/runWorkspacePromptQuery.js
@@ -1,0 +1,37 @@
+import { gql } from "@apollo/client";
+
+export const RUN_WORKSPACE_PROMPT_PATHWAY = "run_workspace_prompt";
+
+export function isUnsupportedReasoningEffortError(error) {
+    return /reasoningEffort|Unknown argument|Unknown variable|is not defined/i.test(
+        error?.message || "",
+    );
+}
+
+export function getRunWorkspacePromptQuery(
+    pathwayName = RUN_WORKSPACE_PROMPT_PATHWAY,
+    { includeReasoningEffort = false, includeStream = false } = {},
+) {
+    return gql`
+        query ${pathwayName}(
+            $chatHistory: [MultiMessage]
+            $async: Boolean
+            $model: String
+            $fileAccessPlan: [FileAccessTargetInput]
+            ${includeReasoningEffort ? "$reasoningEffort: String" : ""}
+            ${includeStream ? "$stream: Boolean" : ""}
+        ) {
+            ${pathwayName}(
+                chatHistory: $chatHistory
+                async: $async
+                model: $model
+                fileAccessPlan: $fileAccessPlan
+                ${includeReasoningEffort ? "reasoningEffort: $reasoningEffort" : ""}
+                ${includeStream ? "stream: $stream" : ""}
+            ) {
+                result
+                tool
+            }
+        }
+    `;
+}

--- a/src/utils/skills.js
+++ b/src/utils/skills.js
@@ -1,0 +1,695 @@
+// skills.js
+// Skills system for Concierge chat - similar to Claude Code skills
+// Skills provide specialized instructions that can be loaded into chat context on demand
+
+import { APPLET_SDK_DOCUMENTATION } from "../content/appletSdkDocumentation.js";
+
+// ============================================================================
+// Applets skill — composed sections (SDK reference is shared with admin SDK Playground)
+// ============================================================================
+
+/** Intro through theme support; ends before canonical SDK documentation. */
+const APPLETS_SKILL_HEAD = `# Applets Skill
+
+## What Are Applets?
+
+Applets are interactive HTML-based mini-applications the user builds in chat. Each applet is a **canvas record** (Mongo \`appletRecord\`) backed by a single HTML file in the user's workspace (\`workspacePath\`). Workspaces can host many applets — they're independent records, not a one-per-workspace feature.
+
+- The **workspace HTML file** is the editable source of truth.
+- The **applet record** tracks \`htmlVersions[]\` (saved checkpoints), \`publishedVersionIndex\`, and any app-store metadata.
+- The **canvas preview** runs in the same sandboxed iframe used by the live \`/published/applets/{id}\` page, so what you see in canvas matches what gets published.
+
+Editing the workspace file alone changes Draft only. It does **not** create an immutable version or change what the public link serves. Saving a version and publishing are explicit applet management actions.
+
+## Canvas Applet Tools
+
+When the canvas has an active applet, \`appletId\` defaults to it across applet management tools — you usually don't need to pass it.
+
+For a brand new applet request, strongly prefer \`CreateApplet\` with \`prompt\`. It creates the workspace HTML file, registers the applet, and opens the live streaming canvas preview. Only hand-build HTML first when the user specifically asks for a file-first workflow or when you already have a complete HTML file that needs registration.
+
+| Tool | Use when |
+|---|---|
+| \`CreateApplet\` (\`prompt\`) | User wants a brand new applet, no applet exists yet, or user explicitly asks to start over from scratch. Opens a canvas tab with a live streaming preview and imports the result. **The applet is already in the canvas when this returns — do NOT follow up with \`OpenCanvasFile\`.** |
+| \`CreateApplet\` (\`workspacePath\`) | Import an existing HTML workspace file as a new applet. **Also opens it in the canvas — do NOT follow up with \`OpenCanvasFile\`.** |
+| \`ListApplets\` (no args) | List the user's applets. |
+| \`GetApplet\` (\`appletId\`) | Inspect one applet's metadata, Draft path, version list, publish state, and app-store state. Does not return saved version HTML. |
+| \`GetAppletState\` | Inspect Draft, saved versions, published version, app-store state, and recommended next action. |
+| \`OpenAppletDraft\` | Open the current mutable Draft in canvas and return its \`workspacePath\`. Does not copy saved versions over Draft. |
+| \`GetAppletVersionSource\` (\`version\`) | Inspect storage/source metadata for an immutable saved version without returning the full HTML and without changing Draft. |
+| \`SaveAppletDraftAsVersion\` | Snapshot the mutable Draft workspace HTML as a new immutable version. Does not publish. |
+| \`CopyAppletVersionToDraft\` (\`version\`) | Copy an immutable saved version into Draft so it can be edited. Does not create a new version number. |
+| \`PublishAppletVersion\` (\`version\`) | Publish an immutable saved version. |
+| \`PublishAppletVersion\` (no \`version\`) | Snapshot Draft if needed, then publish that immutable version. |
+| \`DeleteAppletVersion\` (\`version\`) | Delete an accidental saved checkpoint. Asks for confirmation; never deletes Draft or the applet. |
+| \`UnpublishApplet\` | Clear the directly published version. |
+| \`UpdateAppletMetadata\` (\`name\`) | Rename the applet (also updates the open canvas tab). |
+| \`UpdateAppletMetadata\` (\`workspacePath\`) | Relink the applet to a different workspace HTML file. |
+| \`UpdateAppletMetadata\` (\`publishToAppStore\`, \`appName\`, \`appSlug\`, \`appDescription\`) | Publish to \`/apps/<slug>\` (auto-publishes the version). |
+| \`UpdateAppletMetadata\` (\`clearSdkSuspension\`) | Clear a temporary SDK suspension after fixing runaway applet code. |
+| \`DeleteApplet\` | Delete the applet. Asks the user to confirm in a dialog. |
+| \`GetCanvasState\` | Lightweight active canvas state without a screenshot. |
+| \`InspectCanvas\` | Debug screenshot, applet console errors, and network failures. |
+
+## CRITICAL — Editing vs. Creating
+
+**Default for existing applets: EDIT in place.** If an applet is already open in the canvas (or the user references one that exists), edit its workspace file. Do not call \`CreateApplet\` to make changes to that existing applet — it creates a separate applet instead of preserving the current one.
+
+| Scenario | Approach |
+|---|---|
+| Change colors / styling / layout | Edit the Draft workspace file. Save only when the user wants a checkpoint. |
+| Add a feature | Edit the Draft workspace file. Save only when the user wants a checkpoint. |
+| Fix a bug | Edit the Draft workspace file. Save only when the user wants a checkpoint. |
+| Small tweak (text, copy, etc.) | Edit the Draft workspace file. Save only when the user wants a checkpoint. |
+| User wants a brand new applet (none exists yet) | Strongly prefer \`CreateApplet\` with \`prompt\`. |
+| User explicitly asks to start over / rebuild | \`CreateApplet\` with \`prompt\`. If an applet is already active, also pass \`createNew: true\` to confirm this is not an edit. |
+| Register an existing HTML file as an applet | \`CreateApplet\` with \`workspacePath\`. |
+
+## Editing Recipe — Draft, Save, Publish
+
+Follow this order whenever you change an applet:
+
+1. **Read Draft.** Use the workspace shell (\`cat <workspacePath>\`). \`workspacePath\` is in the HTML Canvas Context. For a non-active applet, call \`GetAppletState { appletId }\` or \`OpenAppletDraft { appletId }\` to discover its Draft path.
+2. **Make targeted edits.** Write the modified HTML back to the same path with the workspace shell. Preserve everything outside the user's request — minimize your diff.
+3. **Let preview refresh automatically.** The canvas follows the workspace file after tool runs. Do not call a refresh/sync tool.
+4. **Save when needed.** \`SaveAppletDraftAsVersion\` snapshots Draft as a new immutable version. Editing Draft alone does not create a version.
+5. **Publish when the user asks to.** \`PublishAppletVersion { version }\` publishes an existing immutable version. \`PublishAppletVersion\` with no version snapshots Draft first when needed, then publishes the resulting version.
+6. **Verify when needed.** Use \`GetAppletState\` for state; use \`InspectCanvas\` only for screenshots, console errors, or network failures.
+
+**Common mistakes to avoid:**
+
+- Calling \`CreateApplet\` to "edit" an existing applet → creates a separate applet instead of preserving the current one.
+- Manually copying HTML out of \`ListApplets\` to restore a version → use \`CopyAppletVersionToDraft { version }\`; it owns the registry-to-Draft write.
+- Calling old refresh/sync tools or workspace generator scripts immediately after \`CopyAppletVersionToDraft\` → can overwrite Draft with stale regenerated HTML. Copy already put the version into Draft.
+- Deleting a whole applet just to remove one bad checkpoint → use \`DeleteAppletVersion { version }\`.
+- Guessing a \`/workspace/files/global/...\` path for an applet → use the exact \`workspacePath\` from HTML Canvas Context or \`ListApplets\` instead; current file-backed applets normally live under \`/workspace/files/applets/...\`.
+- Treating \`/published/applets/{id}\` as auto-following workspace edits → it serves only the published immutable version. Republish to update it.
+- Outputting raw HTML in chat instead of writing to the workspace file → the user can't see it in the canvas.
+
+## Architecture
+
+- **Single HTML file** — each applet is one self-contained HTML document.
+- **Sandboxed iframe** — \`allow-scripts allow-popups allow-forms allow-same-origin allow-downloads allow-presentation\`. Same sandbox in canvas preview and on \`/published/applets/{id}\`.
+- **Tailwind CSS v4** — the browser build is auto-injected; use Tailwind utility classes freely.
+- **Concierge Applet SDK** — auto-injected at runtime; platform functions live on the global \`ConciergeSDK\` object (see SDK section below).
+- **Theme-aware** — applets receive the current theme (light/dark) and respond to theme changes.
+- **Versioned by checkpoint** — versions are explicit (\`SaveAppletDraftAsVersion\`, or \`PublishAppletVersion\` when publishing Draft), not one-per-edit. Users can copy older versions back into Draft.
+- **Publishable** — direct link via \`PublishAppletVersion\`, or to the app store via applet store publishing metadata.
+
+## Data Persistence
+
+Choose the smallest persistence API that matches the workflow:
+
+| Need | Use |
+|---|---|
+| Private preferences, filters, draft inputs, or progress for the current user only | \`ConciergeSDK.data\` |
+| Shared applet workspace state that every user of the applet should see | \`ConciergeSDK.sharedData\` |
+
+\`ConciergeSDK.data\` is per applet and per current user. It is last-write-wins and has no revision or restore history.
+
+\`ConciergeSDK.sharedData\` is per applet and key. Call \`sharedData.get(key)\` and \`sharedData.set(key, value)\`; the SDK handles revision tokens and backups. \`sharedData.set(key, value)\` cannot clear non-empty shared state; use \`sharedData.reset(key, value)\` only for user-confirmed clear or reset actions. Use it for collaborative or shared workspace-style applets.
+
+## HTML Structure
+
+Always output a complete, well-structured HTML document:
+
+- **Required:** Include \`<meta name="concierge-type" content="applet">\` in the head.
+- **Forbidden:** Do NOT include \`<meta id="title">\`, \`<meta id="subhead">\`, or \`<meta id="featuredImage">\` tags — those are reserved for articles.
+
+\`\`\`html
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="concierge-type" content="applet">
+    <title>My Applet</title>
+    <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
+    <style type="text/tailwindcss">
+        @custom-variant dark (&:where([data-theme="dark"], [data-theme="dark"] *));
+    </style>
+    <style>
+        /* Use regular CSS here only when Tailwind utility classes are not enough. */
+    </style>
+</head>
+<body>
+    <!-- Your applet content -->
+    <script>
+        // Your JavaScript
+    </script>
+</body>
+</html>
+\`\`\`
+
+## Theme Support
+
+Applets MUST support both light and dark themes. The platform provides:
+
+- \`window.LABEEB_THEME\` — current theme string: \`"light"\` or \`"dark"\`
+- \`html[data-theme="dark"]\` attribute on the root element
+- \`--prefers-color-scheme\` CSS custom property
+- \`color-scheme\` CSS property is automatically set
+- Theme change events via \`window.addEventListener('message', ...)\`
+
+### How to handle themes:
+
+**IMPORTANT:** To make Tailwind \`dark:\` utility classes work with the CDN build, you MUST include this style block in \`<head>\`:
+\`\`\`html
+<style type="text/tailwindcss">
+    @custom-variant dark (&:where([data-theme="dark"], [data-theme="dark"] *));
+</style>
+\`\`\`
+Without this, \`dark:\` classes will follow the OS system preference instead of the app's theme setting.
+
+**CSS approach (preferred):**
+\`\`\`html
+<style type="text/tailwindcss">
+    @custom-variant dark (&:where([data-theme="dark"], [data-theme="dark"] *));
+</style>
+
+<body class="bg-white text-gray-900 dark:bg-gray-900 dark:text-gray-100">
+    ...
+</body>
+\`\`\`
+
+Or use regular CSS with the data-theme attribute:
+\`\`\`css
+html[data-theme="dark"] body {
+    background: #111827;
+    color: #f9fafb;
+}
+\`\`\`
+
+**Icon dark mode:** For Lucide icons loaded as \`<img>\`, add the \`icon-invert\` class and include this CSS:
+\`\`\`css
+html[data-theme="dark"] .icon-invert { filter: invert(1) brightness(1.5); }
+\`\`\`
+
+**JavaScript approach:**
+\`\`\`javascript
+// Check current theme
+const isDark = window.LABEEB_THEME === 'dark';
+
+// Listen for theme changes
+window.addEventListener('message', (event) => {
+    if (event.data?.type === 'theme-change') {
+        const newTheme = event.data.theme; // 'light' or 'dark'
+        // Update your UI accordingly
+    }
+});
+
+// Or listen for the custom event dispatched inside the sandbox:
+document.addEventListener('concierge-theme-change', (event) => {
+    const newTheme = event.detail?.theme;
+});
+\`\`\`
+`;
+
+const APPLETS_SKILL_LOCALE = `## Language and Direction (Arabic / English)
+
+Applets MUST support both English and Arabic, matching the host Concierge app language. The platform provides:
+
+- \`window.LABEEB_LANGUAGE\` — \`"en"\` or \`"ar"\`
+- \`window.LABEEB_DIRECTION\` — \`"ltr"\` or \`"rtl"\`
+- \`html[lang="ar"][dir="rtl"]\` on the sandbox root element
+- \`ConciergeSDK.locale.get()\`, \`.getLanguage()\`, \`.getDirection()\`, \`.isRtl()\`
+- Locale change events via \`locale-change\` postMessage or \`concierge-locale-change\` custom event
+
+### How to handle language/direction:
+
+**Tailwind logical properties (preferred for RTL):**
+\`\`\`html
+<div class="text-start ms-4 pe-2 border-s border-gray-300">
+    <!-- text-start, ms/me, ps/pe, border-s/border-e adapt to dir -->
+</div>
+\`\`\`
+
+**JavaScript approach:**
+\`\`\`javascript
+const { language, direction } = ConciergeSDK.locale.get();
+const isArabic = language === 'ar';
+
+document.addEventListener('concierge-locale-change', (event) => {
+    const { language, direction } = event.detail || {};
+    // Re-render labels, swap copy, reflow layout
+});
+
+window.addEventListener('message', (event) => {
+    if (event.data?.type === 'locale-change') {
+        const { language, direction } = event.data;
+    }
+});
+\`\`\`
+
+For translation applets, branch UI strings and default prompts on \`ConciergeSDK.locale.getLanguage()\`.
+`;
+
+const APPLETS_SKILL_URL_PARAMS = `## URL Parameters
+
+When an applet is loaded directly or embedded in an iframe, query parameters on the applet page URL are available to the applet at runtime. For example, \`/apps/dmv-applet?team=team-alpha\` or:
+
+\`\`\`html
+<iframe src="https://your-concierge-host/apps/dmv-applet?team=team-alpha"></iframe>
+\`\`\`
+
+\`\`\`javascript
+// Preferred: ConciergeSDK.params
+const team = ConciergeSDK.params.get("team");
+
+// Also available as window.APPLET_PARAMS
+const params = window.APPLET_PARAMS || {};
+const userId = params.userId;
+\`\`\`
+`;
+
+const APPLETS_SKILL_AGENT_SUPPLEMENT = `## Applets skill — agent integration (supplement)
+
+The **Concierge Applet SDK** section above is the canonical API reference (same Markdown as the admin SDK Playground).
+
+### Rendering \`agent.chat\` results
+
+\`response.result\` is **Markdown** (headings, lists, inline images, Mermaid, code blocks, links). Use \`marked\`, \`markdown-it\`, or similar — never append as plain text.
+
+### Entity agent
+
+Calls use the Concierge entity agent (\`sys_entity_agent\`) with the full tool suite. Each call is **stateless** — pass the full \`messages\` array for multi-turn context.
+
+### \`getAccessToken\` — OAuth UI errors
+
+Besides SDK-documented error codes, OAuth may throw: \`POPUP_BLOCKED\`, \`OAUTH_CANCELLED\`, \`OAUTH_TIMEOUT\`, \`OAUTH_FAILED\`.
+
+**Official REST docs** (for service integrations): Atlassian https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro · GitHub https://docs.github.com/en/rest · Slack https://api.slack.com/methods
+
+**Jira JQL search in applets:** Legacy \`/rest/api/3/search\` was **removed** (410). Implement issue search with \`/rest/api/3/search/jql\` (\`GET\` or \`POST\` + JSON body). Reference: [Issue search API](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-search/) · [CHANGELOG-2046](https://developer.atlassian.com/changelog/#CHANGE-2046).
+
+### Agent capabilities
+
+| Capability | What it does | Example prompt |
+|---|---|---|
+| **Image Generation** | Images from text, edits, variations | "Watercolor cat illustration" |
+| **Video Generation** | Short video with audio | "Ocean waves clip" |
+| **Web Search** | Search / browse | "Weather in Doha" |
+| **Code Execution** | Python, Node, shell | "Factorial of 20 in Python" |
+| **File Analysis** | User-uploaded files | "Summarize this CSV" |
+| **File Management** | User file collection | "List my files" |
+| **Image Viewing** | Uploaded images | "Describe this image" |
+| **Mermaid** | Diagrams | "Login flowchart" |
+| **Slides / infographics** | Visual decks | "Climate infographic" |
+| **URL validation** | Reachability | "Is example.com up?" |
+| **Cognitive search** | Semantic KB | "AI ethics articles" |
+
+**Tips:** Natural-language prompts; descriptive image prompts; tools may chain in one call. **Limits:** ~120s per tool, ~500 budget units per request.
+`;
+
+const APPLETS_SKILL_CONTENT =
+    APPLETS_SKILL_HEAD +
+    "\n\n" +
+    APPLETS_SKILL_LOCALE +
+    "\n\n" +
+    APPLETS_SKILL_URL_PARAMS +
+    "\n\n" +
+    APPLET_SDK_DOCUMENTATION +
+    "\n\n" +
+    APPLETS_SKILL_AGENT_SUPPLEMENT;
+
+const APPLETS_SKILL_TAIL = `## Styling Guidelines
+
+### Tailwind CSS
+- Use TailwindCSS v4 browser build: \`<script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>\`
+- **Only use standard Tailwind CSS utility classes.** No plugins are available (no @tailwindcss/typography, @tailwindcss/forms, etc.). Do NOT use plugin classes like \`prose\`, \`form-input\`, \`form-select\`, \`aspect-w-*\`. Do NOT use abstract component classes like \`card\`, \`btn\`, \`badge\`, \`alert\` — these don't exist in Tailwind. Compose styles from individual utilities instead.
+- **Put Tailwind utility classes directly on HTML elements. Do NOT use \`@apply\` or invent custom component classes for first-pass applets.** A bad \`@apply\` can prevent Tailwind from generating styles and leave the applet unstyled. If a style cannot be expressed with utilities, write plain CSS in a normal \`<style>\` block.
+
+### Color Scheme
+- **Primary:** sky-500 (sky-600 hover, sky-700 active)
+- **Secondary:** gray-500
+- **Success:** green-500
+- **Warning:** yellow-500
+- **Error:** red-500
+- **Borders:** gray-300 (dark: gray-700)
+
+### Component Recipes
+- **Form elements (input/select/textarea):** \`w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-sky-500 focus:border-sky-500\`
+- **Buttons:** \`px-4 py-2 bg-sky-500 text-white rounded-md hover:bg-sky-600 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-2\`
+- **Page layout:** \`max-w-7xl mx-auto px-4 sm:px-6 lg:px-8\`
+- **Cards:** \`bg-white rounded-lg shadow-md border border-gray-200 p-6\`
+- **Corners:** \`rounded-md\`
+- **Shadows:** \`shadow-md\` for subtle elevation
+- **Hover states:** \`hover:bg-sky-50\`
+- **Focus states:** \`focus:ring-2 focus:ring-sky-500\`
+
+### Typography
+- Headings: \`text-lg\` and proper heading hierarchy (h1-h6)
+- Body text: \`text-base\`
+- Captions/labels: \`text-sm\`
+
+### Icons
+- Use Lucide icons from the local route: \`<img src="/api/icons/icon-name" class="w-5 h-5" />\` (spinal-case names, e.g. \`/api/icons/house\`, \`/api/icons/bar-chart-2\`; use \`loader-circle\` not \`loader-2\`)
+- Add \`icon-invert\` class for dark mode support
+- Or use inline SVGs for better performance and theme support
+- Or use emoji for simple icons
+
+## Best Practices
+
+### DO:
+- **Always implement actual functionality** — never use placeholders, mock data, or TODO comments. Every UI component must be fully functional and ready for production use.
+- **Thoroughly implement dark mode for EVERY element** — every background, text, border, input, placeholder, shadow, and SVG must have explicit dark mode styles. Do not rely on browser defaults — they will break. Test that ALL text is readable against its background in both light and dark themes. Common mistakes: forgetting dark variants on input fields, table cells, modal overlays, tooltips, dropdown menus, scrollbar tracks, and placeholder text. Use Tailwind \`dark:\` variants or \`html[data-theme="dark"]\` selectors
+- **Support English and Arabic** — use \`ConciergeSDK.locale.getLanguage()\` for copy, prefer logical Tailwind properties (\`text-start\`, \`ms-*\`, \`pe-*\`, \`border-s\`) over hard-coded left/right, and listen for \`concierge-locale-change\` when switching language at runtime
+- **Use Tailwind CSS directly in markup** — compose visual styling from standard utility classes on each element. Keep \`<style type="text/tailwindcss">\` only for the required \`@custom-variant dark\` declaration.
+- **Make it responsive** — use Tailwind responsive classes (\`sm:\`, \`md:\`, \`lg:\`) with actual breakpoints
+- **Add accessibility features** — ARIA labels, keyboard navigation, proper focus management
+- **Implement form validation** — with real-time feedback where appropriate
+- **Sanitize user inputs** — prevent XSS and other injection attacks
+- **Keep it self-contained** — all HTML, CSS, and JS in one file
+- **Use semantic HTML** — proper headings, sections, buttons, labels
+- **Handle loading states** — show spinners/skeletons when fetching data
+- **Debounce API calls** — especially data saves during user input
+- **Use \`try/catch\`** — wrap all API calls in error handling
+- **Provide empty states** — show helpful messages when there's no data yet
+- **Use CDN libraries** — load external libraries from CDN (e.g., Chart.js, D3, etc.)
+- **Set proper viewport meta** — already handled by the platform, but don't override it
+
+### DON'T:
+- **Don't use React/Vue/Angular** — stick to vanilla HTML/CSS/JS or lightweight libraries
+- **Don't use ES modules** (import/export) — they don't work in the sandbox
+- **Don't try to access parent window** — the sandbox restricts cross-frame access
+- **Don't store secrets in applet state** — use platform service tokens or dedicated secret storage instead of \`data\` or \`sharedData\`.
+- **Don't use \`localStorage\`** — use the Data API instead for persistence across sessions
+- **Don't make the page scrollable unless needed** — the iframe auto-sizes to content height
+- **Don't hardcode colors** — always use theme-aware styles
+- **Don't use massive libraries** — keep applets lightweight and fast
+
+
+## Applet File Format
+
+An applet has a mutable Draft HTML file in the user's workspace, plus immutable saved versions in the Mongo applet record. \`CreateApplet\` handles both the file write and the record. To change an existing applet, edit the Draft workspace file; the canvas preview follows the file automatically. Call \`SaveAppletDraftAsVersion\` only when the user wants a new immutable checkpoint, and \`PublishAppletVersion\` when the user wants to ship a saved version. Do not output HTML in chat — the user sees the result in the canvas.
+
+## Suggestions
+
+When creating or updating an applet, you can suggest follow-up actions. These appear as clickable buttons in the workspace UI:
+
+\`\`\`json
+{
+    "suggestions": [
+        { "name": "Add dark mode", "uxDescription": "Enhance with dark theme support" },
+        { "name": "Make responsive", "uxDescription": "Optimize for mobile devices" },
+        { "name": "Add data persistence", "uxDescription": "Save user data between sessions" }
+    ]
+}
+\`\`\`
+
+## Publishing
+
+Applets can be published in two ways. Publishing always points at an immutable saved version — never edit publish state by writing the file alone.
+
+1. **Direct link** — \`/published/applets/{id}\`. Anyone with the link can use it.
+   - Publish a saved version: \`PublishAppletVersion { version }\`.
+   - Publish Draft: \`PublishAppletVersion\` (saves Draft as a version first if needed).
+   - Unpublish: \`UnpublishApplet\` (clears the published version).
+2. **App Store** — \`/apps/{slug}\`, with a name, slug, icon, and description.
+   - Publish a version first with \`PublishAppletVersion\`, then update app-store metadata with \`UpdateAppletMetadata { publishToAppStore: true, appName, appSlug, appDescription }\`.
+   - Remove from store: \`UpdateAppletMetadata { publishToAppStore: false }\`.
+
+When publishing to the app store:
+- App name must not conflict with built-in apps (Translate, Transcribe, Write, Workspaces, Images, Jira).
+- Slug must be unique across all published apps.
+- Include a clear description and an appropriate icon.
+
+## Example: Simple Counter Applet
+
+\`\`\`html
+<!DOCTYPE html>
+<html>
+<head>
+    <style type="text/tailwindcss">
+        @custom-variant dark (&:where([data-theme="dark"], [data-theme="dark"] *));
+    </style>
+</head>
+<body class="flex min-h-[200px] items-center justify-center bg-white text-gray-900 dark:bg-gray-900 dark:text-gray-100">
+    <div class="rounded-xl border border-gray-200 bg-gray-50 p-8 text-center shadow-sm dark:border-gray-700 dark:bg-gray-800">
+        <div class="mb-6 text-6xl font-bold text-gray-900 dark:text-white" id="count">0</div>
+        <div class="flex justify-center gap-3">
+            <button class="rounded-lg bg-sky-500 px-6 py-2 font-medium text-white transition-colors hover:bg-sky-600 active:bg-sky-700" onclick="decrement()">-</button>
+            <button class="rounded-lg bg-gray-400 px-6 py-2 font-medium text-white transition-colors hover:bg-gray-500" onclick="reset()">Reset</button>
+            <button class="rounded-lg bg-sky-500 px-6 py-2 font-medium text-white transition-colors hover:bg-sky-600 active:bg-sky-700" onclick="increment()">+</button>
+        </div>
+    </div>
+    <script>
+        let count = 0;
+        const el = document.getElementById('count');
+
+        function increment() { el.textContent = ++count; }
+        function decrement() { el.textContent = --count; }
+        function reset() { count = 0; el.textContent = count; }
+    </script>
+</body>
+</html>
+\`\`\`
+`;
+
+const APPLETS_SKILL_BODY = APPLETS_SKILL_CONTENT + "\n\n" + APPLETS_SKILL_TAIL;
+
+// ============================================================================
+// Articles skill — composed sections (mirrors the applets pattern)
+// ============================================================================
+
+const ARTICLES_SKILL_BODY = `# Articles Skill
+
+## What Are Articles?
+
+Articles are HTML files at **\`/workspace/files/articles/<slug>.html\`** in the user's workspace. The file IS the article — there is no separate registry, no in-memory editor state, no Set* page tools. Every read and every mutation goes through the **workspace shell**. The canvas re-reads the file after each shell write, so the user sees your edits live.
+
+- **The file is the source of truth.** If a field isn't in the file, it doesn't exist.
+- **Mutations are file rewrites.** \`cat > path << 'HTMLEOF' ... HTMLEOF\` is the workhorse. Partial writes that drop the meta tags will break the editor.
+- **The slug is the filename.** Pass a meaningful \`title\` to \`CreateArticle\` so you get \`world-cup-2026-recap.html\` instead of \`untitled-xyz.html\`.
+
+## Workflow
+
+| Goal | Steps |
+|---|---|
+| Start a new article | Call \`CreateArticle\` (returns \`workspacePath\`) → \`mkdir -p /workspace/files/articles\` (once) → \`cat > <workspacePath> << 'HTMLEOF' ... HTMLEOF\`. |
+| Open an existing article | List \`/workspace/files/articles/\` (or use \`SearchFileCollection\`) → call \`OpenCanvasFile\` with the file. HTML files under that directory open in the article editor automatically. |
+| Edit any part of an article | \`cat <workspacePath>\` to read the current contents → produce the updated HTML in your reasoning → rewrite the whole file with one \`cat > ... << 'HTMLEOF'\` call. |
+| Verify visual layout | Call \`InspectCanvas\` for a rendered screenshot. |
+
+**Don't:**
+
+- Don't paste article HTML into the chat — the user can't see it that way.
+- Don't write partial files (e.g. \`echo "<p>...</p>" >> file.html\`) — you'll corrupt the structure and lose the meta tags.
+- Don't try to use \`SetTitle\`/\`SetContent\`/\`SetSubhead\`/\`SetFeaturedImage\`/\`InsertRawHtml\`/\`UpdateRawHtml\`/\`ReadFullContent\` — those tools no longer exist. The file is the API.
+- Don't put \`<meta name="concierge-type" content="applet">\` in an article. That flips the renderer to applet mode.
+
+## Article HTML Format
+
+Every article file MUST use exactly this structure. Drop or rename a meta tag and the editor will misread the file.
+
+\`\`\`html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="concierge-type" content="article">
+    <meta id="title" content="Your Article Title">
+    <meta id="subhead" content="Optional subhead">
+    <meta id="featuredImage" content="https://...">
+    <title>Your Article Title</title>
+</head>
+<body>
+<p>Body HTML — p, h2, h3, ul, ol, li, strong, em, blockquote, figure, a, etc.</p>
+</body>
+</html>
+\`\`\`
+
+- **\`<meta name="concierge-type" content="article">\`** — required. Tells Concierge the file is an article.
+- **\`<meta id="title">\`** — the headline shown above the body in the editor.
+- **\`<meta id="subhead">\`** — optional subtitle.
+- **\`<meta id="featuredImage">\`** — optional hero image URL (empty string clears it).
+- **Body** — plain article HTML. Embed rich blocks (charts, callouts, interactive widgets) as inline \`<div>\`/\`<section>\` blocks with their own \`<style>\` and \`<script>\`.
+
+## Embedded HTML Widgets
+
+You can drop self-contained HTML/CSS/JS blocks directly into the article body for rich content (charts, callout cards, interactive comparisons, etc.). They render alongside the prose.
+
+**Requirements:**
+
+- **Self-contained:** all CSS in a \`<style>\` block, all JS in a \`<script>\` block. CDN dependencies are OK; no build step.
+- **Typography:** \`Roboto\` for headings, \`Georgia\` for body text, to match the article shell. Both are pre-loaded — use them directly.
+- **Polished and interactive:** these ship in a published article. Rich design, hover states, real interactivity. No skeletons or placeholders.
+- **Responsive:** mobile and desktop both must work. Use fluid units or media queries.
+
+To replace a widget, just rewrite the file with the new widget HTML in place of the old one.
+
+## Identifier Model
+
+- **\`workspacePath\`** — \`/workspace/files/articles/<slug>.html\`. The only identifier you need to read or edit the article.
+- **\`blobPath\`** / **\`fileHash\`** — surfaced for cloud-storage references. The user-save flow writes a copy to the cloud; you don't need these for editing.
+
+The Article Canvas Context surfaces \`workspacePath\` whenever an article is open — that's your handle for every read/write.
+`;
+
+export const BUILT_IN_SKILLS = [
+    {
+        name: "applets",
+        description:
+            "Comprehensive guide for building, editing, and publishing Concierge applets. Load this skill when the user wants to create, modify, debug, or publish an applet, or when working in a workspace that has an applet.",
+        builtIn: true,
+        content: APPLETS_SKILL_BODY,
+    },
+    {
+        name: "articles",
+        description:
+            "How to create, read, and edit Concierge articles. Articles are HTML files at /workspace/files/articles/<slug>.html — covers the workspace-shell editing workflow, the required article HTML format, embedded HTML widget rules, and common pitfalls. Load this skill whenever the user asks to write, edit, or style an article.",
+        builtIn: true,
+        content: ARTICLES_SKILL_BODY,
+    },
+];
+
+// ============================================================================
+// Skill Tool Generation
+// ============================================================================
+
+/**
+ * Generates the LoadSkill client-side tool definition with a dynamic description
+ * that lists all available skills (built-in + user-defined)
+ * @param {Array} userSkills - Array of user-defined skills { name, description }
+ * @returns {Object} Tool definition for the LoadSkill tool
+ */
+export function getLoadSkillTool(userSkills = []) {
+    const allSkills = [
+        ...BUILT_IN_SKILLS.map((s) => ({
+            name: s.name,
+            description: s.description,
+        })),
+        ...userSkills.map((s) => ({
+            name: s.name,
+            description: s.description,
+        })),
+    ];
+
+    const skillList = allSkills
+        .map((s) => `- **${s.name}**: ${s.description}`)
+        .join("\n");
+
+    const enBody = `Load a skill to get specialized instructions and best practices for a specific task. When you determine that a skill is relevant to the user's request, load it to get detailed guidance.
+
+Available skills:
+${skillList}
+
+Call this tool with the skill name to load its full instructions into the conversation. You should follow the loaded skill's guidelines when performing the relevant task.`;
+
+    const arBody = `حمّل مهارة للحصول على تعليمات مفصّلة وأفضل الممارسات لمهمة معيّنة. عندما ترى أن المهارة مناسبة لطلب المستخدم، حمّلها للحصول على التوجيه.
+
+المهارات المتاحة (قد تبقى أسماءها أو أوصافها بالإنجليزية):
+${skillList}
+
+استدعِ الأداة باسم المهارة لتحميل التعليمات الكاملة. اتبع إرشادات المهارة عند التنفيذ.`;
+
+    return {
+        type: "function",
+        icon: "📚",
+        function: {
+            name: "LoadSkill",
+            description: enBody,
+            descriptionAr: arBody,
+            parameters: {
+                type: "object",
+                properties: {
+                    name: {
+                        type: "string",
+                        description: `The name of the skill to load. Available: ${allSkills.map((s) => s.name).join(", ")}`,
+                    },
+                    userMessage: {
+                        type: "string",
+                        description:
+                            "A brief message explaining why you're loading this skill",
+                    },
+                },
+                required: ["name"],
+            },
+        },
+    };
+}
+
+// ============================================================================
+// Skill Loading
+// ============================================================================
+
+/**
+ * Load a skill's content by name. Checks built-in skills first, then user skills via API.
+ * @param {string} name - The skill name to load
+ * @param {Object} [options]
+ * @param {string} [options.userContextId] - User context ID for resolving workspace file paths
+ * @returns {Promise<{success: boolean, data: object}>} The skill content or error
+ */
+export async function loadSkill(name, { userContextId } = {}) {
+    if (!name) {
+        // Return list of available skills
+        return {
+            success: true,
+            data: {
+                skills: BUILT_IN_SKILLS.map((s) => ({
+                    name: s.name,
+                    description: s.description,
+                    builtIn: true,
+                })),
+                description:
+                    "Here are the available skills. Call LoadSkill with a specific skill name to load its full content.",
+            },
+        };
+    }
+
+    const normalizedName = name.toLowerCase().trim();
+
+    // Check built-in skills first
+    const builtIn = BUILT_IN_SKILLS.find(
+        (s) => s.name.toLowerCase() === normalizedName,
+    );
+
+    if (builtIn) {
+        return {
+            success: true,
+            data: {
+                name: builtIn.name,
+                description: builtIn.description,
+                content: builtIn.content,
+                builtIn: true,
+                instructions: `Skill "${builtIn.name}" loaded successfully. Follow the instructions above when working on ${builtIn.name}-related tasks.`,
+            },
+        };
+    }
+
+    // Try to fetch user skill from API
+    try {
+        const response = await fetch(
+            `/api/skills/${encodeURIComponent(normalizedName)}`,
+        );
+        if (response.ok) {
+            const skill = await response.json();
+            const skillDir = userContextId
+                ? `/workspace/files/skills/${normalizedName}`
+                : null;
+            const skillMdPath = skillDir ? `${skillDir}/SKILL.md` : null;
+            return {
+                success: true,
+                data: {
+                    name: skill.name,
+                    description: skill.description,
+                    content: skill.content,
+                    files: skill.files || [],
+                    builtIn: false,
+                    skillDirectory: skillDir,
+                    skillMdPath,
+                    instructions: `Skill "${skill.name}" loaded successfully. Follow the instructions above.${skillDir ? ` Skill files are at **${skillDir}/**. Main content: **${skillMdPath}**. You can read, edit, or add files to this directory using the workspace shell.` : ""}`,
+                },
+            };
+        }
+    } catch (error) {
+        console.error("Error fetching user skill:", error);
+    }
+
+    return {
+        success: false,
+        data: {
+            error: `Skill "${name}" not found. Available built-in skills: ${BUILT_IN_SKILLS.map((s) => s.name).join(", ")}`,
+        },
+    };
+}


### PR DESCRIPTION
## Summary

- adds generic Concierge applet backend APIs, canvas-applet routing, shared data revisions, published applet endpoints, and applet generation support
- adds the public `ConciergeSDK` runtime script plus SDK docs/utilities for applet data, shared data, files, model calls, agent chat, params, locale, and optional service tokens
- updates existing workspace applet routes to use scoped storage resolution and generic model/prompt helpers

## Stack

- Stacked on #14 / `concierge-file-manager-storage-stacked`
- Intentionally excludes the `/applets` UI until the broader app shell, chat, and canvas architecture is upstreamed

## Public repo hygiene

- Replaced Labeeb/AJ-specific SDK names and events with Concierge names
- Kept OAuth integrations generic and optional
- Removed Al Jazeera-specific examples from the copied SDK documentation/prompts
- Did not use `push-opensource.sh`

## Validation

- `npm test -- app/api/__tests__/appletFileContent.test.js -- --runInBand --silent --openHandlesTimeout=1000`
- `noglob npm test -- app/api/applet app/api/canvas-applets app/api/workspaces/[id]/applet -- --runInBand --silent --openHandlesTimeout=1000`
- `npm test -- --runInBand --silent --openHandlesTimeout=1000`
- `npm run build`
- `git diff --check concierge-file-manager-storage-stacked`
- changed-file brand/sensitive-string scan
