### PR TITLE
Add generic media generation plumbing

### DIFF
--- a/app/api/models/media-item.mjs
+++ b/app/api/models/media-item.mjs
@@ -1,5 +1,32 @@
 import mongoose from "mongoose";
 
+const MAX_INPUT_IMAGE_REFERENCES = 14;
+const MAX_INPUT_VIDEO_REFERENCES = 1;
+const inputImageUrlFields = Object.fromEntries(
+    Array.from({ length: MAX_INPUT_IMAGE_REFERENCES }, (_, index) => [
+        index === 0 ? "inputImageUrl" : `inputImageUrl${index + 1}`,
+        String,
+    ]),
+);
+const inputImageRoleFields = Object.fromEntries(
+    Array.from({ length: MAX_INPUT_IMAGE_REFERENCES }, (_, index) => [
+        index === 0 ? "inputImageRole" : `inputImageRole${index + 1}`,
+        String,
+    ]),
+);
+const inputVideoUrlFields = Object.fromEntries(
+    Array.from({ length: MAX_INPUT_VIDEO_REFERENCES }, (_, index) => [
+        index === 0 ? "inputVideoUrl" : `inputVideoUrl${index + 1}`,
+        String,
+    ]),
+);
+const inputVideoRoleFields = Object.fromEntries(
+    Array.from({ length: MAX_INPUT_VIDEO_REFERENCES }, (_, index) => [
+        index === 0 ? "inputVideoRole" : `inputVideoRole${index + 1}`,
+        String,
+    ]),
+);
+
 const mediaItemSchema = new mongoose.Schema(
     {
         user: {
@@ -24,7 +51,7 @@ const mediaItemSchema = new mongoose.Schema(
         },
         type: {
             type: String,
-            enum: ["image", "video"],
+            enum: ["image", "video", "audio"],
             required: true,
         },
         model: {
@@ -40,15 +67,30 @@ const mediaItemSchema = new mongoose.Schema(
         url: String,
         azureUrl: String,
         gcsUrl: String,
+        thumbnailUrl: String,
+        thumbnailAzureUrl: String,
+        thumbnailGcsUrl: String,
+        thumbnailBlobPath: String,
+        thumbnailHash: String,
+        // File hash for file collection integration
+        hash: String,
+        blobPath: String,
+        outputFolder: String,
         // Video-specific fields
         duration: Number,
         generateAudio: Boolean,
         resolution: String,
         cameraFixed: Boolean,
-        // Input images for video generation
-        inputImageUrl: String,
-        inputImageUrl2: String,
-        inputImageUrl3: String,
+        // Input image references used for derivative image/video/audio generation
+        ...inputImageUrlFields,
+        ...inputImageRoleFields,
+        // Input video references used for video extension
+        ...inputVideoUrlFields,
+        ...inputVideoRoleFields,
+        // Input audio reference used for audio-to-audio generation
+        inputAudioUrl: String,
+        inputAudioBlobPath: String,
+        inputAudioHash: String,
         // Metadata
         created: {
             type: Number,

--- a/app/queries/modelMetadata.js
+++ b/app/queries/modelMetadata.js
@@ -1,0 +1,276 @@
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { useApolloClient } from "@apollo/client";
+import { SYS_MODEL_METADATA } from "../../src/graphql";
+
+/**
+ * Fetch all model metadata from cortex.
+ * Returns { models: [...], redirects: {...} }
+ */
+export function useModelMetadata() {
+    const client = useApolloClient();
+
+    return useQuery({
+        queryKey: ["modelMetadata"],
+        queryFn: async () => {
+            const { data } = await client.query({
+                query: SYS_MODEL_METADATA,
+                fetchPolicy: "network-only",
+            });
+            return JSON.parse(data.sys_model_metadata.result);
+        },
+        staleTime: 30 * 1000,
+        refetchOnMount: "always",
+    });
+}
+
+/**
+ * Models with isAgentic: true — for the agent model picker.
+ */
+export function useAgentModels() {
+    const { data, ...rest } = useModelMetadata();
+    const agentModels = useMemo(
+        () =>
+            (data?.models?.filter((m) => m.isAgentic) || []).sort((a, b) => {
+                if (Boolean(a.isModelGroup) !== Boolean(b.isModelGroup)) {
+                    return a.isModelGroup ? -1 : 1;
+                }
+
+                const aName = a.displayName || a.modelId || "";
+                const bName = b.displayName || b.modelId || "";
+                const byName = aName.localeCompare(bName, undefined, {
+                    sensitivity: "base",
+                });
+
+                if (byName !== 0) return byName;
+
+                return (a.modelId || "").localeCompare(b.modelId || "");
+            }),
+        [data],
+    );
+    const redirects = data?.redirects || {};
+    return { data: agentModels, redirects, ...rest };
+}
+
+/**
+ * Chat models — for the workspace LLM selector.
+ */
+export function useChatModels() {
+    const { data, ...rest } = useModelMetadata();
+    const chatModels = useMemo(
+        () => data?.models?.filter((m) => m.category === "chat") || [],
+        [data],
+    );
+    const redirects = data?.redirects || {};
+    return { data: chatModels, redirects, ...rest };
+}
+
+/**
+ * Image, video, music, and speech models — for the media page.
+ */
+export function useMediaModels() {
+    const { data, ...rest } = useModelMetadata();
+    const mediaModels = useMemo(
+        () =>
+            data?.models?.filter(
+                (m) =>
+                    m.isAvailable !== false &&
+                    (m.category === "image" ||
+                        m.category === "video" ||
+                        m.category === "audio" ||
+                        m.category === "tts"),
+            ) || [],
+        [data],
+    );
+    return { data: mediaModels, ...rest };
+}
+
+/**
+ * Resolve a stored model ID to a valid one: returns the original if it still
+ * exists, follows a redirect if one is defined, or falls back to the default.
+ * Works for any model category (agent, chat, etc.).
+ */
+export function resolveModelId(modelId, models, redirects) {
+    if (!models || models.length === 0) return modelId;
+
+    // Check if model exists directly
+    if (modelId && models.some((m) => m.modelId === modelId)) {
+        return modelId;
+    }
+
+    // Check redirects
+    const redirected = redirects?.[modelId];
+    if (redirected && models.some((m) => m.modelId === redirected)) {
+        return redirected;
+    }
+
+    // Return default agent model
+    const defaultModel = models.find((m) => m.isDefault);
+    return defaultModel?.modelId || models[0]?.modelId || modelId;
+}
+
+function normalizeText(value) {
+    return String(value || "").toLowerCase();
+}
+
+function getModelSearchText(modelOrId) {
+    if (!modelOrId) return "";
+    if (typeof modelOrId === "string") return normalizeText(modelOrId);
+    return normalizeText(
+        [
+            modelOrId.modelId,
+            modelOrId.displayName,
+            modelOrId.name,
+            modelOrId.provider,
+        ].join(" "),
+    );
+}
+
+function inferProvider(modelOrId) {
+    const text = getModelSearchText(modelOrId);
+    const explicitProvider =
+        typeof modelOrId === "object" ? normalizeText(modelOrId.provider) : "";
+
+    if (explicitProvider && explicitProvider !== "cortex") {
+        return explicitProvider;
+    }
+    if (text.includes("claude") || text.includes("anthropic")) {
+        return "anthropic";
+    }
+    if (text.includes("gemini") || text.includes("google")) {
+        return "google";
+    }
+    if (text.includes("grok") || text.includes("xai")) {
+        return "xai";
+    }
+    if (text.includes("kimi") || text.includes("moonshot")) {
+        return "moonshot";
+    }
+    if (text.includes("llama") || text.includes("meta")) {
+        return "meta";
+    }
+    if (
+        text.includes("gpt") ||
+        text.includes("openai") ||
+        /^o\d/.test(text) ||
+        text.includes("oai-")
+    ) {
+        return "openai";
+    }
+
+    return explicitProvider || null;
+}
+
+function inferModelFamily(modelOrId) {
+    const text = getModelSearchText(modelOrId);
+    const families = [
+        "opus",
+        "sonnet",
+        "haiku",
+        "gpt",
+        "gemini",
+        "grok",
+        "kimi",
+        "llama",
+        "mistral",
+        "deepseek",
+    ];
+
+    return families.find((family) => text.includes(family)) || null;
+}
+
+function versionParts(model) {
+    const text = getModelSearchText(model);
+    return (text.match(/\d+/g) || []).map((part) => Number(part));
+}
+
+function compareVersionParts(a, b) {
+    const left = versionParts(a);
+    const right = versionParts(b);
+    const length = Math.max(left.length, right.length);
+
+    for (let index = 0; index < length; index += 1) {
+        const diff = (left[index] || 0) - (right[index] || 0);
+        if (diff !== 0) return diff;
+    }
+
+    return getModelSearchText(a).localeCompare(getModelSearchText(b));
+}
+
+/**
+ * Resolve the chat send model against the current agent model picker options.
+ *
+ * Stale saved models should not be sent back to Cortex. Prefer exact matches,
+ * then Cortex-provided redirects, then the newest accepted model from the same
+ * provider and family, and finally the system default.
+ */
+export function resolveAgentModelForSend(
+    modelId,
+    agentModels,
+    redirects,
+    fallbackModelId,
+) {
+    if (!agentModels || agentModels.length === 0) {
+        return fallbackModelId || modelId;
+    }
+
+    if (modelId && agentModels.some((model) => model.modelId === modelId)) {
+        return modelId;
+    }
+
+    const redirected = redirects?.[modelId];
+    if (
+        redirected &&
+        agentModels.some((model) => model.modelId === redirected)
+    ) {
+        return redirected;
+    }
+
+    const provider = inferProvider(modelId);
+    const family = inferModelFamily(modelId);
+
+    if (provider && family) {
+        const sameFamilyModels = agentModels
+            .filter((model) => !model.isModelGroup)
+            .filter(
+                (model) =>
+                    inferProvider(model) === provider &&
+                    inferModelFamily(model) === family,
+            )
+            .sort(compareVersionParts);
+
+        const latestSameFamily =
+            sameFamilyModels[sameFamilyModels.length - 1]?.modelId;
+        if (latestSameFamily) {
+            return latestSameFamily;
+        }
+    }
+
+    const defaultModel = fallbackModelId
+        ? agentModels.find((model) => model.modelId === fallbackModelId)
+        : agentModels.find((model) => model.isDefault);
+
+    return (
+        defaultModel?.modelId ||
+        agentModels.find((model) => model.isDefault)?.modelId ||
+        fallbackModelId ||
+        agentModels[0]?.modelId ||
+        modelId
+    );
+}
+
+/**
+ * Look up display name for a model ID.
+ */
+export function getDisplayNameFromModelId(modelId, models) {
+    const model = models?.find((m) => m.modelId === modelId);
+    return model?.displayName || modelId;
+}
+
+/**
+ * Look up provider for a model ID.
+ */
+export function getProviderFromModelId(modelId, models) {
+    const model = models?.find((m) => m.modelId === modelId);
+    return model?.provider || inferProvider(modelId) || "openai";
+}

--- a/jobs/__tests__/media-generate-quality-wiring.test.js
+++ b/jobs/__tests__/media-generate-quality-wiring.test.js
@@ -1,0 +1,473 @@
+// Static wiring assertions for the media_generate request path.
+//
+// `quality` is the per-model render-quality preset (low|medium|high|auto)
+// that gpt-image-2 (and other Azure /images/generations callers) accept.
+// It must flow end-to-end:
+//   user setting → buildMediaVariables → MEDIA_GENERATE GraphQL → cortex.
+// Until 2026-04, this was silently dropped at the worker layer. These
+// regressions-in-disguise are easy to lose to drift, so we lock the wiring
+// with a structural test that doesn't depend on running the worker.
+//
+// We assert by reading the source rather than importing — the worker module
+// has unrelated runtime side effects on import that are heavy for jest.
+
+const fs = require("fs");
+const path = require("path");
+
+const repoRoot = path.resolve(__dirname, "../..");
+const read = (relPath) => fs.readFileSync(path.join(repoRoot, relPath), "utf8");
+
+describe("media_generate quality wiring", () => {
+    test("worker buildMediaVariables forwards settings.quality", () => {
+        const src = read("jobs/tasks/media-generation.mjs");
+        const builderMatch = src.match(
+            /function\s+buildMediaVariables\([^)]*\)\s*{[\s\S]*?\n}/,
+        );
+        expect(builderMatch).toBeTruthy();
+        expect(builderMatch[0]).toMatch(/quality\s*:\s*settings\.quality/);
+    });
+
+    for (const file of ["jobs/graphql.mjs", "src/graphql.js"]) {
+        test(`MEDIA_GENERATE in ${file} declares and passes $quality`, () => {
+            const src = read(file);
+            const queryMatch = src.match(
+                /MEDIA_GENERATE\s*=\s*gql`([\s\S]*?)`/,
+            );
+            expect(queryMatch).toBeTruthy();
+            const query = queryMatch[1];
+            // The query must declare $quality as a variable…
+            expect(query).toMatch(/\$quality\s*:\s*String/);
+            // …and forward it into the media_generate field call.
+            expect(query).toMatch(/quality\s*:\s*\$quality/);
+        });
+    }
+});
+
+describe("media_generate input image refresh wiring", () => {
+    test("worker accepts stable blob/hash identifiers for every input image slot", () => {
+        const src = read("jobs/tasks/media-generation.mjs");
+
+        expect(src).toMatch(/function\s+normalizeInputImageReference/);
+        expect(src).toMatch(/MAX_INPUT_IMAGE_REFERENCES\s*=\s*14/);
+        expect(src).toMatch(
+            /pickInputImageValues\(metadata,\s*"inputImageUrl"\)/,
+        );
+        expect(src).toMatch(
+            /pickInputImageValues\(\s*metadata,\s*"inputImageBlobPath"/,
+        );
+        expect(src).toMatch(
+            /pickInputImageValues\(\s*metadata,\s*"inputImageHash"/,
+        );
+        expect(src).toMatch(
+            /blobPath:\s*inputImageBlobPaths\[index\][\s\S]*hash:\s*inputImageHashes\[index\]/,
+        );
+    });
+
+    test("worker refresh fallbacks keep the Cortex inputImages contract as URLs", () => {
+        const src = read("jobs/tasks/media-generation.mjs");
+        const refreshListMatch = src.match(
+            /async function refreshInputImageUrls\([^)]*\)\s*{[\s\S]*?\n}/,
+        );
+
+        expect(refreshListMatch).toBeTruthy();
+        expect(refreshListMatch[0]).toMatch(
+            /normalizeInputImageReference\(inputImage\)\.url/,
+        );
+        expect(refreshListMatch[0]).toMatch(/return fallbackUrls/);
+    });
+});
+
+describe("media_generate input image role wiring", () => {
+    test("worker forwards numbered input image roles to Cortex", () => {
+        const src = read("jobs/tasks/media-generation.mjs");
+        const builderMatch = src.match(
+            /function\s+buildMediaVariables\([^)]*\)\s*{[\s\S]*?\n}/,
+        );
+
+        expect(builderMatch).toBeTruthy();
+        expect(builderMatch[0]).toMatch(/inputImageRoles\s*:/);
+        expect(src).toMatch(
+            /pickInputImageValues\(\s*metadata,\s*"inputImageRole"/,
+        );
+        expect(src).toMatch(/inputImageRoles\[index\]/);
+    });
+
+    for (const file of ["jobs/graphql.mjs", "src/graphql.js"]) {
+        test(`MEDIA_GENERATE in ${file} declares and passes $inputImageRoles`, () => {
+            const src = read(file);
+            const queryMatch = src.match(
+                /MEDIA_GENERATE\s*=\s*gql`([\s\S]*?)`/,
+            );
+            expect(queryMatch).toBeTruthy();
+            const query = queryMatch[1];
+            expect(query).toMatch(/\$inputImageRoles\s*:\s*\[String\]/);
+            expect(query).toMatch(/inputImageRoles\s*:\s*\$inputImageRoles/);
+        });
+    }
+});
+
+describe("media_generate input video wiring", () => {
+    test("worker forwards input videos to Cortex", () => {
+        const src = read("jobs/tasks/media-generation.mjs");
+        const builderMatch = src.match(
+            /function\s+buildMediaVariables\([^)]*\)\s*{[\s\S]*?\n}/,
+        );
+
+        expect(builderMatch).toBeTruthy();
+        expect(builderMatch[0]).toMatch(/inputVideos\s*:/);
+        expect(src).toMatch(
+            /pickInputVideoValues\(\s*metadata,\s*"inputVideoUrl"/,
+        );
+        expect(src).toMatch(/refreshInputVideoUrls/);
+    });
+
+    for (const file of ["jobs/graphql.mjs", "src/graphql.js"]) {
+        test(`MEDIA_GENERATE in ${file} declares and passes $inputVideos`, () => {
+            const src = read(file);
+            const queryMatch = src.match(
+                /MEDIA_GENERATE\s*=\s*gql`([\s\S]*?)`/,
+            );
+            expect(queryMatch).toBeTruthy();
+            const query = queryMatch[1];
+            expect(query).toMatch(/\$inputVideos\s*:\s*\[String\]/);
+            expect(query).toMatch(/inputVideos\s*:\s*\$inputVideos/);
+        });
+    }
+});
+
+describe("media_generate Lyria wiring", () => {
+    test("worker validation allows image-only audio generation", () => {
+        const src = read("jobs/tasks/media-generation.mjs");
+
+        expect(src).toMatch(/isImageOnlyAudioGeneration/);
+        expect(src).toMatch(/outputType\s*===\s*"audio"\s*&&\s*hasInputImage/);
+        expect(src).toMatch(
+            /!prompt\s*&&\s*!isImageOnlyAudioGeneration\s*&&\s*!hasInputAudio/,
+        );
+    });
+
+    test("worker does not forward fake audio controls to Cortex media_generate", () => {
+        const src = read("jobs/tasks/media-generation.mjs");
+        const builderMatch = src.match(
+            /function\s+buildMediaVariables\([^)]*\)\s*{[\s\S]*?\n}/,
+        );
+        expect(builderMatch).toBeTruthy();
+        expect(builderMatch[0]).not.toMatch(/audioUseCase\s*:/);
+        expect(builderMatch[0]).not.toMatch(/audioStyle\s*:/);
+        expect(builderMatch[0]).not.toMatch(/audioMood\s*:/);
+    });
+
+    for (const file of ["jobs/graphql.mjs", "src/graphql.js"]) {
+        test(`MEDIA_GENERATE in ${file} does not declare fake audio variables`, () => {
+            const src = read(file);
+            const queryMatch = src.match(
+                /MEDIA_GENERATE\s*=\s*gql`([\s\S]*?)`/,
+            );
+            expect(queryMatch).toBeTruthy();
+            const query = queryMatch[1];
+            expect(query).not.toMatch(/\$audioUseCase\s*:\s*String/);
+            expect(query).not.toMatch(/\$audioStyle\s*:\s*String/);
+            expect(query).not.toMatch(/\$audioMood\s*:\s*String/);
+            expect(query).not.toMatch(/audioUseCase\s*:\s*\$audioUseCase/);
+            expect(query).not.toMatch(/audioStyle\s*:\s*\$audioStyle/);
+            expect(query).not.toMatch(/audioMood\s*:\s*\$audioMood/);
+        });
+    }
+});
+
+describe("media_generate speech wiring", () => {
+    test("worker forwards Qwen TTS clone and design controls to Cortex", () => {
+        const src = read("jobs/tasks/media-generation.mjs");
+        const builderMatch = src.match(
+            /function\s+buildMediaVariables\([^)]*\)\s*{[\s\S]*?\n}/,
+        );
+
+        expect(builderMatch).toBeTruthy();
+        expect(builderMatch[0]).toMatch(/mode\s*:\s*settings\.mode/);
+        expect(builderMatch[0]).toMatch(/language\s*:\s*settings\.language/);
+        expect(builderMatch[0]).toMatch(/speaker\s*:\s*settings\.speaker/);
+        expect(builderMatch[0]).toMatch(/referenceText\s*:/);
+        expect(builderMatch[0]).toMatch(/styleInstruction\s*:/);
+        expect(builderMatch[0]).toMatch(/voiceDescription\s*:/);
+    });
+
+    for (const file of ["jobs/graphql.mjs", "src/graphql.js"]) {
+        test(`MEDIA_GENERATE in ${file} declares and passes Qwen TTS controls`, () => {
+            const src = read(file);
+            const queryMatch = src.match(
+                /MEDIA_GENERATE\s*=\s*gql`([\s\S]*?)`/,
+            );
+            expect(queryMatch).toBeTruthy();
+            const query = queryMatch[1];
+            for (const variable of [
+                "mode",
+                "language",
+                "speaker",
+                "referenceText",
+                "styleInstruction",
+                "voiceDescription",
+            ]) {
+                expect(query).toMatch(
+                    new RegExp(`\\$${variable}\\s*:\\s*String`),
+                );
+                expect(query).toMatch(
+                    new RegExp(`${variable}\\s*:\\s*\\$${variable}`),
+                );
+            }
+        });
+    }
+});
+
+describe("media_generate music parameter wiring", () => {
+    test("worker buildMediaVariables forwards music parameters", () => {
+        const src = read("jobs/tasks/media-generation.mjs");
+        const builderMatch = src.match(
+            /function\s+buildMediaVariables\([^)]*\)\s*{[\s\S]*?\n}/,
+        );
+
+        expect(builderMatch).toBeTruthy();
+        expect(builderMatch[0]).toMatch(/lyrics\s*:\s*settings\.lyrics/);
+        expect(builderMatch[0]).toMatch(
+            /isInstrumental\s*:\s*settings\.isInstrumental\s*\?\?\s*settings\.is_instrumental/,
+        );
+        expect(builderMatch[0]).toMatch(
+            /lyricsOptimizer\s*:\s*settings\.lyricsOptimizer\s*\?\?\s*settings\.lyrics_optimizer/,
+        );
+        expect(builderMatch[0]).toMatch(
+            /forceInstrumental\s*:\s*settings\.forceInstrumental\s*\?\?\s*settings\.force_instrumental/,
+        );
+        expect(builderMatch[0]).toMatch(
+            /audioUrl\s*:\s*settings\.audioUrl\s*\|\|\s*settings\.audio_url/,
+        );
+        expect(builderMatch[0]).toMatch(
+            /inputAudioUrl\s*:\s*inputAudioUrl\s*\|\|\s*settings\.inputAudioUrl\s*\|\|\s*settings\.input_audio_url/,
+        );
+        expect(builderMatch[0]).toMatch(
+            /audioFormat\s*:\s*settings\.audioFormat\s*\|\|\s*settings\.audio_format/,
+        );
+        expect(builderMatch[0]).toMatch(
+            /sampleRate\s*:\s*settings\.sampleRate\s*\|\|\s*settings\.sample_rate/,
+        );
+        expect(builderMatch[0]).toMatch(/bitrate\s*:\s*settings\.bitrate/);
+    });
+
+    for (const file of ["jobs/graphql.mjs", "src/graphql.js"]) {
+        test(`MEDIA_GENERATE in ${file} declares and passes music variables`, () => {
+            const src = read(file);
+            const queryMatch = src.match(
+                /MEDIA_GENERATE\s*=\s*gql`([\s\S]*?)`/,
+            );
+            expect(queryMatch).toBeTruthy();
+            const query = queryMatch[1];
+            expect(query).toMatch(/\$lyrics\s*:\s*String/);
+            expect(query).toMatch(/\$isInstrumental\s*:\s*Boolean/);
+            expect(query).toMatch(/\$lyricsOptimizer\s*:\s*Boolean/);
+            expect(query).toMatch(/\$forceInstrumental\s*:\s*Boolean/);
+            expect(query).toMatch(/\$audioUrl\s*:\s*String/);
+            expect(query).toMatch(/\$inputAudioUrl\s*:\s*String/);
+            expect(query).toMatch(/\$audioFormat\s*:\s*String/);
+            expect(query).toMatch(/\$sampleRate\s*:\s*Int/);
+            expect(query).toMatch(/\$bitrate\s*:\s*Int/);
+            expect(query).toMatch(/lyrics\s*:\s*\$lyrics/);
+            expect(query).toMatch(/isInstrumental\s*:\s*\$isInstrumental/);
+            expect(query).toMatch(/lyricsOptimizer\s*:\s*\$lyricsOptimizer/);
+            expect(query).toMatch(
+                /forceInstrumental\s*:\s*\$forceInstrumental/,
+            );
+            expect(query).toMatch(/audioUrl\s*:\s*\$audioUrl/);
+            expect(query).toMatch(/inputAudioUrl\s*:\s*\$inputAudioUrl/);
+            expect(query).toMatch(/audioFormat\s*:\s*\$audioFormat/);
+            expect(query).toMatch(/sampleRate\s*:\s*\$sampleRate/);
+            expect(query).toMatch(/bitrate\s*:\s*\$bitrate/);
+        });
+    }
+});
+
+describe("media_generate speech parameter wiring", () => {
+    test("worker buildMediaVariables forwards metadata-backed speech controls", () => {
+        const src = read("jobs/tasks/media-generation.mjs");
+        const builderMatch = src.match(
+            /function\s+buildMediaVariables\([^)]*\)\s*{[\s\S]*?\n}/,
+        );
+
+        expect(builderMatch).toBeTruthy();
+        expect(builderMatch[0]).toMatch(/voiceName\s*:\s*settings\.voiceName/);
+        expect(builderMatch[0]).toMatch(
+            /speaker1Name\s*:\s*settings\.speaker1Name/,
+        );
+        expect(builderMatch[0]).toMatch(
+            /speaker1VoiceName\s*:\s*settings\.speaker1VoiceName/,
+        );
+        expect(builderMatch[0]).toMatch(
+            /speaker2Name\s*:\s*settings\.speaker2Name/,
+        );
+        expect(builderMatch[0]).toMatch(
+            /speaker2VoiceName\s*:\s*settings\.speaker2VoiceName/,
+        );
+        expect(builderMatch[0]).toMatch(/voice\s*:\s*settings\.voice/);
+        expect(builderMatch[0]).toMatch(/stability\s*:\s*settings\.stability/);
+        expect(builderMatch[0]).toMatch(/similarityBoost\s*:/);
+        expect(builderMatch[0]).toMatch(/style\s*:\s*settings\.style/);
+        expect(builderMatch[0]).toMatch(/speed\s*:\s*settings\.speed/);
+        expect(builderMatch[0]).toMatch(/previousText\s*:/);
+        expect(builderMatch[0]).toMatch(/nextText\s*:/);
+        expect(builderMatch[0]).toMatch(/languageCode\s*:/);
+        expect(builderMatch[0]).toMatch(/voiceId\s*:/);
+        expect(builderMatch[0]).toMatch(/customVoiceId\s*:/);
+        expect(builderMatch[0]).toMatch(/volume\s*:\s*settings\.volume/);
+        expect(builderMatch[0]).toMatch(/pitch\s*:\s*settings\.pitch/);
+        expect(builderMatch[0]).toMatch(/emotion\s*:\s*settings\.emotion/);
+        expect(builderMatch[0]).toMatch(/channel\s*:\s*settings\.channel/);
+        expect(builderMatch[0]).toMatch(/languageBoost\s*:/);
+        expect(builderMatch[0]).toMatch(/subtitleEnable\s*:/);
+        expect(builderMatch[0]).toMatch(/englishNormalization\s*:/);
+    });
+
+    for (const file of ["jobs/graphql.mjs", "src/graphql.js"]) {
+        test(`MEDIA_GENERATE in ${file} declares and passes speech variables`, () => {
+            const src = read(file);
+            const queryMatch = src.match(
+                /MEDIA_GENERATE\s*=\s*gql`([\s\S]*?)`/,
+            );
+            expect(queryMatch).toBeTruthy();
+            const query = queryMatch[1];
+            expect(query).toMatch(/\$voiceName\s*:\s*String/);
+            expect(query).toMatch(/\$speaker1Name\s*:\s*String/);
+            expect(query).toMatch(/\$speaker1VoiceName\s*:\s*String/);
+            expect(query).toMatch(/\$speaker2Name\s*:\s*String/);
+            expect(query).toMatch(/\$speaker2VoiceName\s*:\s*String/);
+            expect(query).toMatch(/\$voice\s*:\s*String/);
+            expect(query).toMatch(/\$stability\s*:\s*Float/);
+            expect(query).toMatch(/\$similarityBoost\s*:\s*Float/);
+            expect(query).toMatch(/\$style\s*:\s*Float/);
+            expect(query).toMatch(/\$speed\s*:\s*Float/);
+            expect(query).toMatch(/\$previousText\s*:\s*String/);
+            expect(query).toMatch(/\$nextText\s*:\s*String/);
+            expect(query).toMatch(/\$languageCode\s*:\s*String/);
+            expect(query).toMatch(/\$voiceId\s*:\s*String/);
+            expect(query).toMatch(/\$customVoiceId\s*:\s*String/);
+            expect(query).toMatch(/\$volume\s*:\s*Float/);
+            expect(query).toMatch(/\$pitch\s*:\s*Int/);
+            expect(query).toMatch(/\$emotion\s*:\s*String/);
+            expect(query).toMatch(/\$channel\s*:\s*String/);
+            expect(query).toMatch(/\$languageBoost\s*:\s*String/);
+            expect(query).toMatch(/\$subtitleEnable\s*:\s*Boolean/);
+            expect(query).toMatch(/\$englishNormalization\s*:\s*Boolean/);
+            expect(query).toMatch(/voiceName\s*:\s*\$voiceName/);
+            expect(query).toMatch(/speaker1Name\s*:\s*\$speaker1Name/);
+            expect(query).toMatch(
+                /speaker1VoiceName\s*:\s*\$speaker1VoiceName/,
+            );
+            expect(query).toMatch(/speaker2Name\s*:\s*\$speaker2Name/);
+            expect(query).toMatch(
+                /speaker2VoiceName\s*:\s*\$speaker2VoiceName/,
+            );
+            expect(query).toMatch(/voice\s*:\s*\$voice/);
+            expect(query).toMatch(/stability\s*:\s*\$stability/);
+            expect(query).toMatch(/similarityBoost\s*:\s*\$similarityBoost/);
+            expect(query).toMatch(/style\s*:\s*\$style/);
+            expect(query).toMatch(/speed\s*:\s*\$speed/);
+            expect(query).toMatch(/previousText\s*:\s*\$previousText/);
+            expect(query).toMatch(/nextText\s*:\s*\$nextText/);
+            expect(query).toMatch(/languageCode\s*:\s*\$languageCode/);
+            expect(query).toMatch(/voiceId\s*:\s*\$voiceId/);
+            expect(query).toMatch(/customVoiceId\s*:\s*\$customVoiceId/);
+            expect(query).toMatch(/volume\s*:\s*\$volume/);
+            expect(query).toMatch(/pitch\s*:\s*\$pitch/);
+            expect(query).toMatch(/emotion\s*:\s*\$emotion/);
+            expect(query).toMatch(/channel\s*:\s*\$channel/);
+            expect(query).toMatch(/languageBoost\s*:\s*\$languageBoost/);
+            expect(query).toMatch(/subtitleEnable\s*:\s*\$subtitleEnable/);
+            expect(query).toMatch(
+                /englishNormalization\s*:\s*\$englishNormalization/,
+            );
+        });
+    }
+});
+
+describe("media_generate input audio reference wiring", () => {
+    test("worker refreshes selected input audio before submission", () => {
+        const src = read("jobs/tasks/media-generation.mjs");
+
+        expect(src).toMatch(/async function refreshInputAudioUrls/);
+        expect(src).toMatch(/metadata\.inputAudioUrl/);
+        expect(src).toMatch(/metadata\.inputAudioBlobPath/);
+        expect(src).toMatch(/metadata\.inputAudioHash/);
+        expect(src).toMatch(/pickInputAudioMetadataFields/);
+        expect(src).toMatch(/modelMeta\?\.mediaDefaults\?\.inputAudio/);
+        expect(src).toMatch(/hasInputAudio/);
+    });
+});
+
+describe("media_generate output folder wiring", () => {
+    test("worker moves completed media into the requested output folder before persistence", () => {
+        const src = read("jobs/tasks/media-generation.mjs");
+
+        expect(src).toMatch(/function\s+getMediaFolderTargetBlobPath/);
+        expect(src).toMatch(/moveUploadedMediaToOutputFolder/);
+        expect(src).toMatch(/metadata\.outputFolder/);
+        expect(src).toMatch(/targetBlobPath/);
+        expect(src).toMatch(/outputFolder:\s*metadata\.outputFolder/);
+    });
+
+    test("worker falls back to multipart upload when CFH cannot fetch provider URLs", () => {
+        const src = read("jobs/tasks/media-generation.mjs");
+
+        expect(src).toMatch(/async\s+uploadBufferData\(/);
+        expect(src).toMatch(/import\s+mime\s+from\s+"mime-types"/);
+        expect(src).toMatch(/mime\.extension\(normalized\)/);
+        expect(src).toMatch(/Remote fetch upload failed/);
+        expect(src).toMatch(
+            /return\s+this\.uploadBufferData\(\s*buffer,\s*serverUrl,\s*routingParams,\s*prompt,\s*extension,\s*hash,\s*contentType/s,
+        );
+        expect(src).toMatch(
+            /metadata\.displayPrompt\s*\|\|\s*metadata\.prompt/,
+        );
+        expect(src).toMatch(/getGeneratedMediaTaskSuffix\(metadata\.taskId\)/);
+        expect(src).toMatch(
+            /getGeneratedMediaFilename\(\s*prompt,\s*extension,\s*\{\s*uniqueSuffix:\s*filenameSuffix\s*\|\|\s*mediaHash,\s*\}\s*\)/,
+        );
+    });
+});
+
+describe("media generation auto-tagging wiring", () => {
+    test("worker calls the cheap prompt-tag pathway and merges existing tags", () => {
+        const src = read("jobs/tasks/media-generation.mjs");
+
+        expect(src).toMatch(/MEDIA_PROMPT_TAGS/);
+        expect(src).toMatch(/async\s+getPromptTags\(client,\s*prompt\)/);
+        expect(src).toMatch(/media_prompt_tags\?\.result/);
+        expect(src).toMatch(/const\s+existingMediaItem\s*=/);
+        expect(src).toMatch(
+            /mergeMediaTags\(\s*existingMediaItem\?\.tags,\s*inheritedTags,\s*promptTags,\s*\)/,
+        );
+    });
+
+    for (const file of ["jobs/graphql.mjs", "src/graphql.js"]) {
+        test(`${file} exposes the media_prompt_tags pathway`, () => {
+            const src = read(file);
+            const queryMatch = src.match(
+                /MEDIA_PROMPT_TAGS\s*=\s*gql`([\s\S]*?)`/,
+            );
+
+            expect(queryMatch).toBeTruthy();
+            expect(queryMatch[1]).toMatch(/media_prompt_tags\(text:\s*\$text/);
+            expect(src).toMatch(/MEDIA_PROMPT_TAGS,/);
+        });
+    }
+});
+
+describe("media generation blob path persistence", () => {
+    test("worker falls back to file handler name or storage URL when blobPath is absent", () => {
+        const src = read("jobs/tasks/media-generation.mjs");
+        const validateMatch = src.match(
+            /validateCloudUrls\(data\)\s*{[\s\S]*?\n {4}}/,
+        );
+
+        expect(validateMatch).toBeTruthy();
+        expect(validateMatch[0]).toMatch(/responseData\.blobPath/);
+        expect(validateMatch[0]).toMatch(/responseData\.name/);
+        expect(validateMatch[0]).toMatch(/extractBlobPathFromUrl\(azureUrl\)/);
+        expect(validateMatch[0]).toMatch(/extractBlobPathFromUrl\(gcsUrl\)/);
+    });
+});

--- a/jobs/graphql.mjs
+++ b/jobs/graphql.mjs
@@ -844,6 +844,155 @@ const VIDEO_SEEDANCE = gql`
     }
 `;
 
+const MEDIA_GENERATE = gql`
+    query MediaGenerate(
+        $model: String!
+        $text: String!
+        $async: Boolean
+        $inputImages: [String]
+        $inputImageRoles: [String]
+        $inputVideos: [String]
+        $aspectRatio: String
+        $duration: Int
+        $outputFormat: String
+        $outputQuality: Int
+        $quality: String
+        $negativePrompt: String
+        $numberResults: Int
+        $seed: Int
+        $optimizePrompt: Boolean
+        $generateAudio: Boolean
+        $forceInstrumental: Boolean
+        $resolution: String
+        $cameraFixed: Boolean
+        $enhancePrompt: Boolean
+        $imageSize: String
+        $width: Int
+        $height: Int
+        $size: String
+        $lyrics: String
+        $isInstrumental: Boolean
+        $lyricsOptimizer: Boolean
+        $audioUrl: String
+        $inputAudioUrl: String
+        $audioFormat: String
+        $sampleRate: Int
+        $bitrate: Int
+        $voiceName: String
+        $speaker1Name: String
+        $speaker1VoiceName: String
+        $speaker2Name: String
+        $speaker2VoiceName: String
+        $mode: String
+        $language: String
+        $speaker: String
+        $referenceText: String
+        $styleInstruction: String
+        $voiceDescription: String
+        $voice: String
+        $stability: Float
+        $similarityBoost: Float
+        $style: Float
+        $speed: Float
+        $previousText: String
+        $nextText: String
+        $languageCode: String
+        $voiceId: String
+        $customVoiceId: String
+        $volume: Float
+        $pitch: Int
+        $emotion: String
+        $channel: String
+        $languageBoost: String
+        $subtitleEnable: Boolean
+        $englishNormalization: Boolean
+        $contextId: String
+    ) {
+        media_generate(
+            model: $model
+            text: $text
+            async: $async
+            inputImages: $inputImages
+            inputImageRoles: $inputImageRoles
+            inputVideos: $inputVideos
+            aspectRatio: $aspectRatio
+            duration: $duration
+            outputFormat: $outputFormat
+            outputQuality: $outputQuality
+            quality: $quality
+            negativePrompt: $negativePrompt
+            numberResults: $numberResults
+            seed: $seed
+            optimizePrompt: $optimizePrompt
+            generateAudio: $generateAudio
+            forceInstrumental: $forceInstrumental
+            resolution: $resolution
+            cameraFixed: $cameraFixed
+            enhancePrompt: $enhancePrompt
+            imageSize: $imageSize
+            width: $width
+            height: $height
+            size: $size
+            lyrics: $lyrics
+            isInstrumental: $isInstrumental
+            lyricsOptimizer: $lyricsOptimizer
+            audioUrl: $audioUrl
+            inputAudioUrl: $inputAudioUrl
+            audioFormat: $audioFormat
+            sampleRate: $sampleRate
+            bitrate: $bitrate
+            voiceName: $voiceName
+            speaker1Name: $speaker1Name
+            speaker1VoiceName: $speaker1VoiceName
+            speaker2Name: $speaker2Name
+            speaker2VoiceName: $speaker2VoiceName
+            mode: $mode
+            language: $language
+            speaker: $speaker
+            referenceText: $referenceText
+            styleInstruction: $styleInstruction
+            voiceDescription: $voiceDescription
+            voice: $voice
+            stability: $stability
+            similarityBoost: $similarityBoost
+            style: $style
+            speed: $speed
+            previousText: $previousText
+            nextText: $nextText
+            languageCode: $languageCode
+            voiceId: $voiceId
+            customVoiceId: $customVoiceId
+            volume: $volume
+            pitch: $pitch
+            emotion: $emotion
+            channel: $channel
+            languageBoost: $languageBoost
+            subtitleEnable: $subtitleEnable
+            englishNormalization: $englishNormalization
+            contextId: $contextId
+        ) {
+            result
+            resultData
+        }
+    }
+`;
+
+const MEDIA_PROMPT_TAGS = gql`
+    query MediaPromptTags($text: String!) {
+        media_prompt_tags(text: $text) {
+            result
+        }
+    }
+`;
+
+const SYS_MODEL_METADATA = gql`
+    query SysModelMetadata($category: String) {
+        sys_model_metadata(category: $category) {
+            result
+        }
+    }
+`;
+
 const JIRA_STORY = gql`
     query JiraStory(
         $text: String!
@@ -935,8 +1084,11 @@ const QUERIES = {
     IMAGE_GEMINI_3,
     IMAGE_QWEN,
     IMAGE_SEEDREAM4,
+    MEDIA_GENERATE,
+    MEDIA_PROMPT_TAGS,
     VIDEO_VEO,
     VIDEO_SEEDANCE,
+    SYS_MODEL_METADATA,
     SYS_SAVE_MEMORY,
     SYS_ENTITY_AGENT,
     EXPAND_STORY,
@@ -1000,8 +1152,11 @@ export {
     IMAGE_GEMINI_3,
     IMAGE_QWEN,
     IMAGE_SEEDREAM4,
+    MEDIA_GENERATE,
+    MEDIA_PROMPT_TAGS,
     VIDEO_VEO,
     VIDEO_SEEDANCE,
+    SYS_MODEL_METADATA,
     GRAMMAR,
     SPELLING,
     PARAPHRASE,

--- a/jobs/tasks/media-generation.mjs
+++ b/jobs/tasks/media-generation.mjs
@@ -1,14 +1,98 @@
 import { BaseTask } from "./base-task.mjs";
 import {
-    IMAGE_FLUX,
-    IMAGE_GEMINI_25,
-    IMAGE_GEMINI_3,
-    IMAGE_QWEN,
-    IMAGE_SEEDREAM4,
-    VIDEO_VEO,
-    VIDEO_SEEDANCE,
+    MEDIA_GENERATE,
+    MEDIA_PROMPT_TAGS,
+    SYS_MODEL_METADATA,
 } from "../graphql.mjs";
 import MediaItem from "../../app/api/models/media-item.mjs";
+import crypto from "crypto";
+import {
+    buildMediaHelperFileParams,
+    createMediaStorageTarget,
+} from "../../src/utils/storageTargets.js";
+import { sanitizeMediaSettings } from "../../src/utils/mediaGenerationSettings.js";
+import {
+    mergeMediaTags,
+    parseMediaPromptTagsResult,
+} from "../../src/utils/mediaPromptTags.js";
+import {
+    getGeneratedMediaFilename,
+    getGeneratedMediaTaskSuffix,
+} from "../../src/utils/mediaGeneratedFilename.js";
+import mime from "mime-types";
+
+function normalizeOutputFolder(value) {
+    const normalized = String(value || "")
+        .trim()
+        .replace(/\\/g, "/")
+        .replace(/^\/+|\/+$/g, "")
+        .replace(/\/+/g, "/");
+    if (!normalized) return "";
+
+    const segments = normalized.split("/").filter(Boolean);
+    if (
+        segments.some(
+            (segment) =>
+                segment === "." ||
+                segment === ".." ||
+                Array.from(segment).some(
+                    (character) =>
+                        '<>:"|?*'.includes(character) ||
+                        character.charCodeAt(0) < 32,
+                ),
+        )
+    ) {
+        return "";
+    }
+    return segments.join("/");
+}
+
+function getBlobPathFilename(blobPath) {
+    const filename = String(blobPath || "")
+        .split("/")
+        .filter(Boolean)
+        .pop();
+    if (!filename) return "";
+    try {
+        return decodeURIComponent(filename);
+    } catch {
+        return filename;
+    }
+}
+
+function getExtensionFromContentType(contentType = "") {
+    const normalized = String(contentType).split(";")[0].trim().toLowerCase();
+    return mime.extension(normalized) || "";
+}
+
+function getExtensionFromUrl(mediaUrl, fallback = "") {
+    try {
+        const extension = new URL(mediaUrl).pathname.split(".").pop();
+        if (extension && extension !== new URL(mediaUrl).pathname) {
+            return extension.toLowerCase();
+        }
+    } catch {
+        // Fall through to fallback.
+    }
+    return fallback;
+}
+
+function getMediaFolderTargetBlobPath(blobPath, outputFolder) {
+    const normalizedOutputFolder = normalizeOutputFolder(outputFolder);
+    const filename = getBlobPathFilename(blobPath);
+    if (!blobPath || !normalizedOutputFolder || !filename) return "";
+
+    const parts = String(blobPath).split("/").filter(Boolean);
+    const mediaIndex = parts.indexOf("media");
+    const baseParts =
+        mediaIndex >= 0 ? parts.slice(0, mediaIndex + 1) : parts.slice(0, -1);
+
+    return [
+        ...baseParts,
+        ...normalizedOutputFolder.split("/").filter(Boolean),
+        filename,
+    ].join("/");
+}
 
 // User model for getting contextId
 let User;
@@ -20,536 +104,485 @@ async function initializeUserModel() {
     return User;
 }
 
-// Model configuration mapping
-const MODEL_CONFIG = {
-    // Image models
-    "gemini-25-flash-image-preview": {
-        query: IMAGE_GEMINI_25,
-        resultKey: "image_gemini_25",
-        type: "image",
-        buildVariables: (prompt, settings, inputImages) => {
-            const modelSettings =
-                settings?.models?.["gemini-25-flash-image-preview"] || {};
-            const variables = {
-                text: prompt,
-                async: true,
-                optimizePrompt: modelSettings.optimizePrompt !== false, // Default to true if not specified
-            };
+// Cached metadata from API (15-minute TTL)
+const METADATA_CACHE_TTL_MS = 15 * 60 * 1000;
+let _metadataCache = null;
+let _metadataCacheTime = 0;
+const GRAPHQL_SUBMIT_MAX_ATTEMPTS = 3;
+const GRAPHQL_SUBMIT_RETRY_DELAY_MS = 1500;
+const MAX_INPUT_IMAGE_REFERENCES = 14;
+const MAX_INPUT_VIDEO_REFERENCES = 1;
 
-            // Only add input_image parameters if they exist
-            // Note: The UI should already be passing GCS URLs for Gemini models
-            if (inputImages[0]) {
-                variables.input_image = inputImages[0];
-            }
-            if (inputImages[1]) {
-                variables.input_image_2 = inputImages[1];
-            }
-            // Gemini supports up to 3 input images, but we're not using the third one
+const ALLOWED_BLOB_DOMAINS = [
+    "blob.core.windows.net",
+    "storage.googleapis.com",
+    "storage.cloud.google.com",
+    "127.0.0.1",
+    "localhost",
+];
 
-            return variables;
-        },
-    },
-    "gemini-3-pro-image-preview": {
-        query: IMAGE_GEMINI_3,
-        resultKey: "image_gemini_3",
-        type: "image",
-        buildVariables: (prompt, settings, inputImages) => {
-            const modelSettings =
-                settings?.models?.["gemini-3-pro-image-preview"] || {};
-            const variables = {
-                text: prompt,
-                async: true,
-                optimizePrompt: modelSettings.optimizePrompt !== false, // Default to true if not specified
-            };
+function isAllowedBlobDomain(hostname) {
+    return ALLOWED_BLOB_DOMAINS.some((domain) => {
+        return hostname === domain || hostname.endsWith(`.${domain}`);
+    });
+}
 
-            // Add aspectRatio if specified
-            if (modelSettings.aspectRatio) {
-                variables.aspectRatio = modelSettings.aspectRatio;
-            }
+function isTransientGraphqlSubmitError(error) {
+    const message = error?.message || error?.toString() || "";
+    return (
+        message.includes("fetch failed") ||
+        message.includes("ECONNRESET") ||
+        message.includes("ECONNREFUSED") ||
+        message.includes("ETIMEDOUT") ||
+        message.includes("socket hang up")
+    );
+}
 
-            // Add image_size if specified
-            if (modelSettings.image_size) {
-                variables.image_size = modelSettings.image_size;
-            }
+function wait(ms) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
 
-            // Add up to 14 input images
-            // Note: The UI should already be passing GCS URLs for Gemini models
-            if (inputImages[0]) {
-                variables.input_image = inputImages[0];
-            }
-            if (inputImages[1]) {
-                variables.input_image_2 = inputImages[1];
-            }
-            if (inputImages[2]) {
-                variables.input_image_3 = inputImages[2];
-            }
-            if (inputImages[3]) {
-                variables.input_image_4 = inputImages[3];
-            }
-            if (inputImages[4]) {
-                variables.input_image_5 = inputImages[4];
-            }
-            if (inputImages[5]) {
-                variables.input_image_6 = inputImages[5];
-            }
-            if (inputImages[6]) {
-                variables.input_image_7 = inputImages[6];
-            }
-            if (inputImages[7]) {
-                variables.input_image_8 = inputImages[7];
-            }
-            if (inputImages[8]) {
-                variables.input_image_9 = inputImages[8];
-            }
-            if (inputImages[9]) {
-                variables.input_image_10 = inputImages[9];
-            }
-            if (inputImages[10]) {
-                variables.input_image_11 = inputImages[10];
-            }
-            if (inputImages[11]) {
-                variables.input_image_12 = inputImages[11];
-            }
-            if (inputImages[12]) {
-                variables.input_image_13 = inputImages[12];
-            }
-            if (inputImages[13]) {
-                variables.input_image_14 = inputImages[13];
-            }
+function getInputImageFieldName(base, index) {
+    return index === 0 ? base : `${base}${index + 1}`;
+}
 
-            return variables;
-        },
-    },
-    "replicate-qwen-image": {
-        query: IMAGE_QWEN,
-        resultKey: "image_qwen",
-        type: "image",
-        buildVariables: (prompt, settings, inputImages) => ({
-            text: prompt,
-            model: "replicate-qwen-image",
-            async: true,
-        }),
-    },
-    "replicate-qwen-image-edit-plus": {
-        query: IMAGE_QWEN,
-        resultKey: "image_qwen",
-        type: "image",
-        buildVariables: (prompt, settings, inputImages) => ({
-            text: prompt,
-            model: "replicate-qwen-image-edit-plus",
-            async: true,
-            input_image: inputImages[0] || "",
-            input_image_2: inputImages[1] || "",
-            input_image_3: inputImages[2] || "",
-        }),
-    },
-    "replicate-qwen-image-edit-2511": {
-        query: IMAGE_QWEN,
-        resultKey: "image_qwen",
-        type: "image",
-        buildVariables: (prompt, settings, inputImages) => {
-            const modelSettings = settings?.models?.[
-                "replicate-qwen-image-edit-2511"
-            ] || {
-                aspectRatio: "match_input_image",
-                output_format: "webp",
-                output_quality: 95,
-                go_fast: true,
-                disable_safety_checker: false,
-            };
-            let aspectRatio = modelSettings.aspectRatio;
-            if (aspectRatio === "match_input_image" && !inputImages[0]) {
-                aspectRatio = "1:1";
-            }
-            return {
-                text: prompt,
-                model: "replicate-qwen-image-edit-2511",
-                async: true,
-                input_image: inputImages[0] || "",
-                input_image_2: inputImages[1] || "",
-                input_image_3: inputImages[2] || "",
-                aspectRatio: aspectRatio,
-                output_format: modelSettings.output_format,
-                output_quality: modelSettings.output_quality,
-                go_fast: modelSettings.go_fast,
-                disable_safety_checker: modelSettings.disable_safety_checker,
-            };
-        },
-    },
-    "replicate-seedream-4": {
-        query: IMAGE_SEEDREAM4,
-        resultKey: "image_seedream4",
-        type: "image",
-        buildVariables: (prompt, settings, inputImages) => {
-            const modelSettings =
-                settings?.models?.["replicate-seedream-4"] || {};
-            return {
-                text: prompt,
-                model: "replicate-seedream-4",
-                async: true,
-                size: modelSettings.size || "2K",
-                width: modelSettings.width || 2048,
-                height: modelSettings.height || 2048,
-                aspectRatio: modelSettings.aspectRatio || "4:3",
-                maxImages:
-                    modelSettings.maxImages || modelSettings.numberResults || 1,
-                numberResults:
-                    modelSettings.numberResults || modelSettings.maxImages || 1,
-                input_image: inputImages[0] || "",
-                input_image_1: inputImages[0] || "",
-                input_image_2: inputImages[1] || "",
-                input_image_3: inputImages[2] || "",
-                sequentialImageGeneration:
-                    modelSettings.sequentialImageGeneration || "disabled",
-                seed: modelSettings.seed || 0,
-            };
-        },
-    },
-    "replicate-flux-kontext-max": {
-        query: IMAGE_FLUX,
-        resultKey: "image_flux",
-        type: "image",
-        buildVariables: (prompt, settings, inputImages) => {
-            const modelSettings = settings?.models?.[
-                "replicate-flux-kontext-max"
-            ] || { aspectRatio: "match_input_image" };
-            let aspectRatio = modelSettings.aspectRatio;
-            if (aspectRatio === "match_input_image" && !inputImages[0]) {
-                aspectRatio = "1:1";
-            }
-            return {
-                text: prompt,
-                async: true,
-                model: "replicate-flux-kontext-max",
-                input_image: inputImages[0] || "",
-                input_image_2: inputImages[1] || "",
-                input_image_3: inputImages[2] || "",
-                aspectRatio: aspectRatio,
-            };
-        },
-    },
-    "replicate-multi-image-kontext-max": {
-        query: IMAGE_FLUX,
-        resultKey: "image_flux",
-        type: "image",
-        buildVariables: (prompt, settings, inputImages) => {
-            const modelSettings = settings?.models?.[
-                "replicate-multi-image-kontext-max"
-            ] || { aspectRatio: "1:1" };
-            let aspectRatio = modelSettings.aspectRatio;
-            if (aspectRatio === "match_input_image" && !inputImages[0]) {
-                aspectRatio = "1:1";
-            }
-            return {
-                text: prompt,
-                async: true,
-                model: "replicate-multi-image-kontext-max",
-                input_image: inputImages[0] || "",
-                input_image_2: inputImages[1] || "",
-                input_image_3: inputImages[2] || "",
-                aspectRatio: aspectRatio,
-            };
-        },
-    },
-    "replicate-flux-11-pro": {
-        query: IMAGE_FLUX,
-        resultKey: "image_flux",
-        type: "image",
-        buildVariables: (prompt, settings, inputImages) => {
-            const modelSettings = settings?.models?.[
-                "replicate-flux-11-pro"
-            ] || { aspectRatio: "1:1" };
-            let aspectRatio = modelSettings.aspectRatio;
-            if (aspectRatio === "match_input_image" && !inputImages[0]) {
-                aspectRatio = "1:1";
-            }
-            return {
-                text: prompt,
-                async: true,
-                model: "replicate-flux-11-pro",
-                input_image: inputImages[0] || "",
-                input_image_2: inputImages[1] || "",
-                input_image_3: inputImages[2] || "",
-                aspectRatio: aspectRatio,
-            };
-        },
-    },
-    "replicate-flux-2-pro": {
-        query: IMAGE_FLUX,
-        resultKey: "image_flux",
-        type: "image",
-        buildVariables: (prompt, settings, inputImages) => {
-            const modelSettings = settings?.models?.[
-                "replicate-flux-2-pro"
-            ] || {
-                aspectRatio: "1:1",
-                resolution: "1 MP",
-                output_format: "webp",
-                output_quality: 80,
-                safety_tolerance: 2,
-            };
-            let aspectRatio = modelSettings.aspectRatio;
-            if (aspectRatio === "match_input_image" && !inputImages[0]) {
-                aspectRatio = "1:1";
-            }
-            const variables = {
-                text: prompt,
-                async: true,
-                model: "replicate-flux-2-pro",
-                aspectRatio: aspectRatio,
-                resolution: modelSettings.resolution || "1 MP",
-                output_format: modelSettings.output_format || "webp",
-                output_quality: modelSettings.output_quality || 80,
-                safety_tolerance: modelSettings.safety_tolerance || 2,
-            };
-            // Add input images if provided (flux-2-pro supports up to 8 via input_images array)
-            if (inputImages.length > 0) {
-                variables.input_images = inputImages.slice(0, 8);
-            }
-            return variables;
-        },
-    },
-    // Video models
-    "replicate-seedance-1-pro": {
-        query: VIDEO_SEEDANCE,
-        resultKey: "video_seedance",
-        type: "video",
-        buildVariables: (prompt, settings, inputImages) => {
-            const modelSettings = settings?.models?.[
-                "replicate-seedance-1-pro"
-            ] || {
-                aspectRatio: "16:9",
-                duration: 5,
-                generateAudio: false,
-                resolution: "1080p",
-                cameraFixed: false,
-            };
-            return {
-                text: prompt,
-                async: true,
-                model: "replicate-seedance-1-pro",
-                resolution: modelSettings.resolution,
-                aspectRatio: modelSettings.aspectRatio,
-                duration: modelSettings.duration,
-                camera_fixed: modelSettings.cameraFixed,
-                image: inputImages[0] || "",
-                seed: -1,
-            };
-        },
-    },
-    "replicate-seedance-1.5-pro": {
-        query: VIDEO_SEEDANCE,
-        resultKey: "video_seedance",
-        type: "video",
-        buildVariables: (prompt, settings, inputImages) => {
-            const modelSettings = settings?.models?.[
-                "replicate-seedance-1.5-pro"
-            ] || {
-                aspectRatio: "16:9",
-                duration: 5,
-                generateAudio: false,
-                cameraFixed: false,
-            };
-            return {
-                text: prompt,
-                async: true,
-                model: "replicate-seedance-1.5-pro",
-                aspectRatio: modelSettings.aspectRatio,
-                duration: modelSettings.duration,
-                camera_fixed: modelSettings.cameraFixed,
-                generate_audio: modelSettings.generateAudio,
-                image: inputImages[0] || "",
-                seed: -1,
-            };
-        },
-    },
-    // Veo models (default for video)
-    "veo-2.0-generate": {
-        query: VIDEO_VEO,
-        resultKey: "video_veo",
-        type: "video",
-        buildVariables: (prompt, settings, inputImages) => {
-            const modelSettings = settings?.models?.["veo-2.0-generate"] || {
-                aspectRatio: "16:9",
-                duration: 5,
-                generateAudio: false,
-                resolution: "1080p",
-                cameraFixed: false,
-            };
-            return {
-                text: prompt,
-                async: true,
-                image: formatImageForVeo(inputImages[0]),
-                video: "",
-                lastFrame: "",
-                model: "veo-2.0-generate",
-                aspectRatio: modelSettings.aspectRatio,
-                durationSeconds: modelSettings.duration,
-                enhancePrompt: true,
-                generateAudio: modelSettings.generateAudio,
-                negativePrompt: "",
-                personGeneration: "allow_all",
-                sampleCount: 1,
-                storageUri: "",
-                location: "us-central1",
-                seed: -1,
-            };
-        },
-    },
-    "veo-3.0-generate": {
-        query: VIDEO_VEO,
-        resultKey: "video_veo",
-        type: "video",
-        buildVariables: (prompt, settings, inputImages) => {
-            const modelSettings = settings?.models?.["veo-3.0-generate"] || {
-                aspectRatio: "16:9",
-                duration: 5,
-                generateAudio: false,
-                resolution: "1080p",
-                cameraFixed: false,
-            };
-            return {
-                text: prompt,
-                async: true,
-                image: formatImageForVeo(inputImages[0]),
-                video: "",
-                lastFrame: "",
-                model: "veo-3.0-generate",
-                aspectRatio: modelSettings.aspectRatio,
-                durationSeconds: modelSettings.duration,
-                enhancePrompt: true,
-                generateAudio: modelSettings.generateAudio,
-                negativePrompt: "",
-                personGeneration: "allow_all",
-                sampleCount: 1,
-                storageUri: "",
-                location: "us-central1",
-                seed: -1,
-            };
-        },
-    },
-    "veo-3.1-generate": {
-        query: VIDEO_VEO,
-        resultKey: "video_veo",
-        type: "video",
-        buildVariables: (prompt, settings, inputImages) => {
-            const modelSettings = settings?.models?.["veo-3.1-generate"] || {
-                aspectRatio: "16:9",
-                duration: 8,
-                generateAudio: true,
-                resolution: "1080p",
-                cameraFixed: false,
-            };
-            return {
-                text: prompt,
-                async: true,
-                image: formatImageForVeo(inputImages[0]),
-                video: "",
-                lastFrame: "",
-                model: "veo-3.1-generate",
-                aspectRatio: modelSettings.aspectRatio,
-                durationSeconds: modelSettings.duration,
-                enhancePrompt: true,
-                generateAudio: modelSettings.generateAudio,
-                negativePrompt: "",
-                personGeneration: "allow_all",
-                sampleCount: 1,
-                storageUri: "",
-                location: "us-central1",
-                seed: -1,
-            };
-        },
-    },
-    "veo-3.1-fast-generate": {
-        query: VIDEO_VEO,
-        resultKey: "video_veo",
-        type: "video",
-        buildVariables: (prompt, settings, inputImages) => {
-            const modelSettings = settings?.models?.[
-                "veo-3.1-fast-generate"
-            ] || {
-                aspectRatio: "16:9",
-                duration: 8,
-                generateAudio: true,
-                resolution: "1080p",
-                cameraFixed: false,
-            };
-            return {
-                text: prompt,
-                async: true,
-                image: formatImageForVeo(inputImages[0]),
-                video: "",
-                lastFrame: "",
-                model: "veo-3.1-fast-generate",
-                aspectRatio: modelSettings.aspectRatio,
-                durationSeconds: modelSettings.duration,
-                enhancePrompt: true,
-                generateAudio: modelSettings.generateAudio,
-                negativePrompt: "",
-                personGeneration: "allow_all",
-                sampleCount: 1,
-                storageUri: "",
-                location: "us-central1",
-                seed: -1,
-            };
-        },
-    },
-};
+function getInputVideoFieldName(base, index) {
+    return index === 0 ? base : `${base}${index + 1}`;
+}
 
-// Utility functions
-const formatImageForVeo = (imageUrl) => {
-    if (!imageUrl) return "";
+function pickInputImageMetadataFields(metadata) {
+    const fields = {};
+    for (let index = 0; index < MAX_INPUT_IMAGE_REFERENCES; index++) {
+        for (const base of ["inputImageUrl", "inputImageRole"]) {
+            const fieldName = getInputImageFieldName(base, index);
+            if (metadata?.[fieldName]) {
+                fields[fieldName] = metadata[fieldName];
+            }
+        }
+    }
+    return fields;
+}
 
-    // Check if it's already in gs:// format
-    if (imageUrl.startsWith("gs://")) {
-        const extension = imageUrl.split(".").pop().toLowerCase();
-        const mimeType =
-            {
-                jpg: "image/jpeg",
-                jpeg: "image/jpeg",
-                png: "image/png",
-                webp: "image/webp",
-                gif: "image/gif",
-            }[extension] || "image/jpeg";
+function pickInputVideoMetadataFields(metadata) {
+    const fields = {};
+    for (let index = 0; index < MAX_INPUT_VIDEO_REFERENCES; index++) {
+        for (const base of ["inputVideoUrl", "inputVideoRole"]) {
+            const fieldName = getInputVideoFieldName(base, index);
+            if (metadata?.[fieldName]) {
+                fields[fieldName] = metadata[fieldName];
+            }
+        }
+    }
+    return fields;
+}
 
-        return JSON.stringify({ gcsUri: imageUrl, mimeType });
+function pickInputAudioMetadataFields(metadata) {
+    const fields = {};
+    for (const fieldName of [
+        "inputAudioUrl",
+        "inputAudioBlobPath",
+        "inputAudioHash",
+    ]) {
+        if (metadata?.[fieldName]) {
+            fields[fieldName] = metadata[fieldName];
+        }
+    }
+    return fields;
+}
+
+function pickInputImageValues(metadata, base) {
+    return Array.from({ length: MAX_INPUT_IMAGE_REFERENCES }, (_, index) => {
+        return metadata?.[getInputImageFieldName(base, index)];
+    });
+}
+
+function pickInputVideoValues(metadata, base) {
+    return Array.from({ length: MAX_INPUT_VIDEO_REFERENCES }, (_, index) => {
+        return metadata?.[getInputVideoFieldName(base, index)];
+    });
+}
+
+function extractBlobPathFromUrl(blobUrl) {
+    try {
+        const urlObj = new URL(blobUrl);
+        const segments = urlObj.pathname.split("/").filter(Boolean);
+        if (urlObj.protocol === "gs:") {
+            return segments.map(decodeURIComponent).join("/") || null;
+        }
+        const isAzurite =
+            urlObj.hostname === "127.0.0.1" || urlObj.hostname === "localhost";
+        const skip = isAzurite ? 2 : 1;
+        if (segments.length <= skip) return null;
+        return segments.slice(skip).map(decodeURIComponent).join("/");
+    } catch {
+        return null;
+    }
+}
+
+function extractHashFromBlobUrl(blobUrl) {
+    try {
+        const urlObj = new URL(blobUrl);
+        const lastSegment = urlObj.pathname.split("/").pop();
+        if (!lastSegment) return null;
+        const decoded = decodeURIComponent(lastSegment);
+        const idx = decoded.indexOf("_");
+        if (idx > 0) {
+            const prefix = decoded.substring(0, idx);
+            if (/^[0-9a-f]+$/i.test(prefix)) {
+                return prefix;
+            }
+        }
+    } catch {
+        // ignore parse errors
+    }
+    return null;
+}
+
+async function fetchShortLivedUrl({ blobPath, hash, contextId } = {}) {
+    const attempts = [];
+    if (blobPath) {
+        attempts.push({ blobPath });
+    }
+    if (hash) {
+        attempts.push({ hash });
     }
 
     try {
-        const url = new URL(imageUrl);
-        if (url.hostname === "storage.googleapis.com") {
-            const gcsUri = `gs://${url.pathname.substring(1)}`;
-            const extension = url.pathname.split(".").pop().toLowerCase();
-            const mimeType =
-                {
-                    jpg: "image/jpeg",
-                    jpeg: "image/jpeg",
-                    png: "image/png",
-                    webp: "image/webp",
-                    gif: "image/gif",
-                }[extension] || "image/jpeg";
-
-            return JSON.stringify({ gcsUri, mimeType });
+        const mediaHelperUrl = process.env.CORTEX_MEDIA_API_URL;
+        if (!mediaHelperUrl) {
+            console.warn(
+                "[MediaGenerationHandler] CORTEX_MEDIA_API_URL not configured, using original URL",
+            );
+            return null;
         }
+
+        for (const attempt of attempts) {
+            const url = new URL(mediaHelperUrl);
+            if (attempt.blobPath) {
+                url.searchParams.set("blobPath", attempt.blobPath);
+            } else if (attempt.hash) {
+                url.searchParams.set("hash", attempt.hash);
+                url.searchParams.set("checkHash", "true");
+            }
+            if (contextId) {
+                url.searchParams.set("contextId", contextId);
+            }
+            url.searchParams.set("shortLived", "true");
+            url.searchParams.set("duration", "300");
+
+            const response = await fetch(url.toString());
+            if (!response.ok) {
+                if (!attempt.hash || attempts.length === 1) {
+                    const errorText = await response.text().catch(() => "");
+                    console.warn(
+                        "[MediaGenerationHandler] Short-lived URL fetch failed:",
+                        response.status,
+                        errorText,
+                    );
+                }
+                continue;
+            }
+
+            const data = await response.json().catch(() => null);
+            const resolvedUrl = data?.shortLivedUrl || data?.url || null;
+            if (!resolvedUrl) {
+                continue;
+            }
+
+            return {
+                url: resolvedUrl,
+                gcs: data?.gcs || null,
+            };
+        }
+
+        return null;
     } catch (error) {
-        console.warn("Error parsing image URL for Veo format:", error);
+        console.warn(
+            "[MediaGenerationHandler] Failed to fetch short-lived URL:",
+            error?.message || error,
+        );
+        return null;
+    }
+}
+
+async function fetchModelMetadata(client) {
+    if (
+        _metadataCache &&
+        Date.now() - _metadataCacheTime < METADATA_CACHE_TTL_MS
+    )
+        return _metadataCache;
+    try {
+        const { data } = await client.query({
+            query: SYS_MODEL_METADATA,
+            fetchPolicy: "no-cache",
+        });
+        _metadataCache = JSON.parse(data.sys_model_metadata.result);
+        _metadataCacheTime = Date.now();
+        return _metadataCache;
+    } catch (e) {
+        console.warn(
+            "[MediaGenerationHandler] Failed to fetch model metadata, using hardcoded config:",
+            e.message,
+        );
+        return null;
+    }
+}
+
+function normalizeInputImageReference(inputImage) {
+    if (!inputImage || typeof inputImage === "string") {
+        return {
+            url: inputImage || "",
+            blobPath: null,
+            hash: null,
+        };
     }
 
-    return imageUrl;
-};
+    return {
+        url: inputImage.url || "",
+        blobPath: inputImage.blobPath || null,
+        hash: inputImage.hash || null,
+    };
+}
 
-const convertGcsToHttp = (gcsUri) => {
-    return gcsUri.replace("gs://", "https://storage.googleapis.com/");
-};
+async function refreshInputImageUrl(inputImage, contextId, preferGcs = false) {
+    const {
+        url,
+        blobPath: providedBlobPath,
+        hash: providedHash,
+    } = normalizeInputImageReference(inputImage);
 
-const extractVideoUrl = (video) => {
-    if (video.bytesBase64Encoded) {
-        return `data:video/mp4;base64,${video.bytesBase64Encoded}`;
-    } else if (video.gcsUri) {
-        return convertGcsToHttp(video.gcsUri);
+    if (!url || !contextId) {
+        return url;
     }
-    return null;
-};
+
+    if (!providedBlobPath && !providedHash) {
+        try {
+            const parsedUrl = new URL(url);
+            if (!isAllowedBlobDomain(parsedUrl.hostname)) {
+                return url;
+            }
+        } catch {
+            return url;
+        }
+    }
+
+    const blobPath = providedBlobPath || extractBlobPathFromUrl(url);
+    const hash = providedHash || extractHashFromBlobUrl(url);
+    if (!blobPath && !hash) {
+        return url;
+    }
+
+    try {
+        const refreshed = await fetchShortLivedUrl({
+            blobPath,
+            hash,
+            contextId,
+        });
+        if (!refreshed) {
+            return url;
+        }
+        return preferGcs
+            ? refreshed.gcs || refreshed.url || url
+            : refreshed.url || refreshed.gcs || url;
+    } catch (error) {
+        console.warn(
+            "[MediaGenerationHandler] Failed to refresh input image URL:",
+            error?.message || error,
+        );
+        return url;
+    }
+}
+
+async function refreshInputImageUrls(inputImages, userId, preferGcs = false) {
+    const fallbackUrls = (inputImages || [])
+        .map((inputImage) => normalizeInputImageReference(inputImage).url)
+        .filter(Boolean);
+
+    if (!inputImages?.length || !userId) {
+        return fallbackUrls;
+    }
+
+    try {
+        await initializeUserModel();
+        const user = await User.findById(userId).select("contextId").lean();
+        if (!user?.contextId) {
+            return fallbackUrls;
+        }
+
+        return Promise.all(
+            inputImages.map((url) =>
+                refreshInputImageUrl(url, user.contextId, preferGcs),
+            ),
+        );
+    } catch (error) {
+        console.warn(
+            "[MediaGenerationHandler] Failed to load user context for input image refresh:",
+            error?.message || error,
+        );
+        return fallbackUrls;
+    }
+}
+
+async function refreshInputVideoUrls(inputVideos, userId, preferGcs = false) {
+    const fallbackUrls = (inputVideos || [])
+        .map((inputVideo) => normalizeInputImageReference(inputVideo).url)
+        .filter(Boolean);
+
+    if (!inputVideos?.length || !userId) {
+        return fallbackUrls;
+    }
+
+    try {
+        await initializeUserModel();
+        const user = await User.findById(userId).select("contextId").lean();
+        if (!user?.contextId) {
+            return fallbackUrls;
+        }
+
+        return Promise.all(
+            inputVideos.map((inputVideo) =>
+                refreshInputImageUrl(inputVideo, user.contextId, preferGcs),
+            ),
+        );
+    } catch (error) {
+        console.warn(
+            "[MediaGenerationHandler] Failed to load user context for input video refresh:",
+            error?.message || error,
+        );
+        return fallbackUrls;
+    }
+}
+
+async function refreshInputAudioUrls(inputAudio, userId) {
+    const fallbackUrls = (inputAudio || [])
+        .map((item) => normalizeInputImageReference(item).url)
+        .filter(Boolean);
+
+    if (!inputAudio?.length || !userId) {
+        return fallbackUrls;
+    }
+
+    try {
+        await initializeUserModel();
+        const user = await User.findById(userId).select("contextId").lean();
+        if (!user?.contextId) {
+            return fallbackUrls;
+        }
+
+        return Promise.all(
+            inputAudio.map((item) =>
+                refreshInputImageUrl(item, user.contextId, false),
+            ),
+        );
+    } catch (error) {
+        console.warn(
+            "[MediaGenerationHandler] Failed to load user context for input audio refresh:",
+            error?.message || error,
+        );
+        return fallbackUrls;
+    }
+}
+
+// Standard variable builder for all models — maps user settings to media_generate params
+function buildMediaVariables(
+    model,
+    prompt,
+    settings,
+    inputImages,
+    inputImageRoles,
+    inputVideos,
+    inputAudioUrl,
+) {
+    return {
+        model,
+        text: prompt,
+        async: true,
+        inputImages: inputImages || [],
+        inputImageRoles: inputImageRoles || [],
+        inputVideos: inputVideos || [],
+        aspectRatio: settings.aspectRatio,
+        duration: settings.duration,
+        outputFormat: settings.outputFormat || settings.output_format,
+        outputQuality: settings.outputQuality || settings.output_quality,
+        quality: settings.quality, // model render quality preset (low|medium|high|auto)
+        negativePrompt: settings.negativePrompt,
+        numberResults: settings.numberResults,
+        seed: settings.seed,
+        optimizePrompt: settings.optimizePrompt,
+        generateAudio: settings.generateAudio,
+        forceInstrumental:
+            settings.forceInstrumental ?? settings.force_instrumental,
+        resolution: settings.resolution,
+        cameraFixed: settings.cameraFixed,
+        imageSize: settings.imageSize || settings.image_size,
+        width: settings.width,
+        height: settings.height,
+        size: settings.size,
+        lyrics: settings.lyrics,
+        isInstrumental: settings.isInstrumental ?? settings.is_instrumental,
+        lyricsOptimizer: settings.lyricsOptimizer ?? settings.lyrics_optimizer,
+        audioUrl: settings.audioUrl || settings.audio_url,
+        inputAudioUrl:
+            inputAudioUrl || settings.inputAudioUrl || settings.input_audio_url,
+        audioFormat: settings.audioFormat || settings.audio_format,
+        sampleRate: settings.sampleRate || settings.sample_rate,
+        bitrate: settings.bitrate,
+        voiceName: settings.voiceName,
+        speaker1Name: settings.speaker1Name,
+        speaker1VoiceName: settings.speaker1VoiceName,
+        speaker2Name: settings.speaker2Name,
+        speaker2VoiceName: settings.speaker2VoiceName,
+        mode: settings.mode,
+        language: settings.language,
+        speaker: settings.speaker,
+        referenceText: settings.referenceText || settings.reference_text,
+        styleInstruction:
+            settings.styleInstruction || settings.style_instruction,
+        voiceDescription:
+            settings.voiceDescription || settings.voice_description,
+        voice: settings.voice,
+        stability: settings.stability,
+        similarityBoost: settings.similarityBoost ?? settings.similarity_boost,
+        style: settings.style,
+        speed: settings.speed,
+        previousText: settings.previousText || settings.previous_text,
+        nextText: settings.nextText || settings.next_text,
+        languageCode: settings.languageCode || settings.language_code,
+        voiceId: settings.voiceId || settings.voice_id,
+        customVoiceId: settings.customVoiceId || settings.custom_voice_id,
+        volume: settings.volume,
+        pitch: settings.pitch,
+        emotion: settings.emotion,
+        channel: settings.channel,
+        languageBoost: settings.languageBoost || settings.language_boost,
+        subtitleEnable: settings.subtitleEnable ?? settings.subtitle_enable,
+        englishNormalization:
+            settings.englishNormalization ?? settings.english_normalization,
+    };
+}
+
+function describeAudioInputRequirement(min, max) {
+    if (min === 1 && max === 1) return "exactly one selected audio item";
+    if (min === max) return `${min} selected audio items`;
+    if (min > 0 && Number.isFinite(max)) {
+        return `between ${min} and ${max} selected audio items`;
+    }
+    if (min > 0) return `at least ${min} selected audio items`;
+    return `no more than ${max} selected audio items`;
+}
+
+function getInputRequirementRange(requirement) {
+    if (Array.isArray(requirement)) {
+        return [
+            Number(requirement[0] ?? 0) || 0,
+            Number(requirement[1] ?? requirement[0] ?? 0),
+        ];
+    }
+    if (requirement === undefined || requirement === null) return null;
+    const value = Number(requirement);
+    if (!Number.isFinite(value)) return null;
+    return [value, value];
+}
 
 class MediaGenerationHandler extends BaseTask {
     get displayName() {
@@ -560,52 +593,57 @@ class MediaGenerationHandler extends BaseTask {
         return true;
     }
 
-    getModelConfig(model, outputType) {
-        // Return specific model config or default based on output type
-        if (MODEL_CONFIG[model]) {
-            return MODEL_CONFIG[model];
-        }
-
-        // Default fallbacks
-        if (outputType === "image") {
-            return MODEL_CONFIG["replicate-flux-11-pro"];
-        } else {
-            return MODEL_CONFIG["veo-3.0-generate"];
-        }
+    getModelConfig(model, outputType, metadata) {
+        const apiModel = metadata?.models?.find((m) => m.modelId === model);
+        return {
+            query: MEDIA_GENERATE,
+            resultKey: "media_generate",
+            type: apiModel?.category || outputType,
+            buildVariables: (
+                prompt,
+                settings,
+                inputImages,
+                inputImageRoles,
+                inputVideos,
+                inputAudioUrl,
+            ) => {
+                const sanitizedSettings = sanitizeMediaSettings(settings || {});
+                const ms = {
+                    ...(apiModel?.mediaDefaults || {}),
+                    ...(sanitizedSettings?.models?.[model] || {}),
+                };
+                return buildMediaVariables(
+                    model,
+                    prompt,
+                    ms,
+                    inputImages,
+                    inputImageRoles,
+                    inputVideos,
+                    inputAudioUrl,
+                );
+            },
+        };
     }
 
-    getResultKey(outputType, model) {
-        const config = this.getModelConfig(model, outputType);
-        return config.resultKey;
+    getResultKey() {
+        return "media_generate";
     }
 
     async startRequest(job) {
         const { taskId, metadata, userId } = job.data;
-        const {
-            prompt,
-            outputType,
-            model,
-            inputImageUrl,
-            inputImageUrl2,
-            inputImageUrl3,
-            inputImageUrl4,
-            inputImageUrl5,
-            inputImageUrl6,
-            inputImageUrl7,
-            inputImageUrl8,
-            inputImageUrl9,
-            inputImageUrl10,
-            inputImageUrl11,
-            inputImageUrl12,
-            inputImageUrl13,
-            inputImageUrl14,
-            settings,
-        } = metadata;
+        const { prompt, outputType, model, settings } = metadata;
 
         metadata.taskId = taskId;
         metadata.userId = userId;
 
-        if (!prompt) {
+        const inputImageUrls = pickInputImageValues(metadata, "inputImageUrl");
+        const hasInputImage = inputImageUrls.some(Boolean);
+        const inputAudioUrl = metadata.inputAudioUrl || "";
+        const hasInputAudio = Boolean(inputAudioUrl);
+        const isImageOnlyAudioGeneration =
+            outputType === "audio" && hasInputImage;
+
+        if (!prompt && !isImageOnlyAudioGeneration && !hasInputAudio) {
             const error = new Error("Prompt is required for media generation");
             await this.updateMediaItemOnError(
                 metadata,
@@ -620,67 +658,191 @@ class MediaGenerationHandler extends BaseTask {
             (outputType === "image"
                 ? "replicate-flux-11-pro"
                 : "replicate-seedance-1-pro");
-        const config = this.getModelConfig(modelName, outputType);
+        const apiMetadata = await fetchModelMetadata(job.client);
+        const modelMeta = apiMetadata?.models?.find(
+            (item) => item.modelId === modelName,
+        );
+        const config = this.getModelConfig(modelName, outputType, apiMetadata);
+        const sanitizedSettings = sanitizeMediaSettings(settings || {});
+        metadata.settings = sanitizedSettings;
 
-        const inputImages = [
-            inputImageUrl,
-            inputImageUrl2,
-            inputImageUrl3,
-            inputImageUrl4,
-            inputImageUrl5,
-            inputImageUrl6,
-            inputImageUrl7,
-            inputImageUrl8,
-            inputImageUrl9,
-            inputImageUrl10,
-            inputImageUrl11,
-            inputImageUrl12,
-            inputImageUrl13,
-            inputImageUrl14,
-        ].filter(Boolean);
-
-        const variables = config.buildVariables(prompt, settings, inputImages);
-
-        let data;
-        try {
-            const result = await job.client.query({
-                query: config.query,
-                variables,
-                fetchPolicy: "no-cache",
-            });
-            data = result.data;
-
-            if (result.errors) {
-                console.debug(
-                    `[MediaGenerationHandler] GraphQL errors encountered`,
-                    result.errors,
-                );
+        const inputImageBlobPaths = pickInputImageValues(
+            metadata,
+            "inputImageBlobPath",
+        );
+        const inputImageHashes = pickInputImageValues(
+            metadata,
+            "inputImageHash",
+        );
+        const inputImageRoles = pickInputImageValues(
+            metadata,
+            "inputImageRole",
+        );
+        const inputImages = inputImageUrls
+            .map((url, index) => ({
+                url,
+                blobPath: inputImageBlobPaths[index],
+                hash: inputImageHashes[index],
+                role: inputImageRoles[index],
+            }))
+            .filter((item) => item.url);
+        const refreshedInputImageRoles = inputImages.map(
+            (inputImage) => inputImage.role || "",
+        );
+        const preferGcs = modelMeta?.preferredUrlFormat === "gcs";
+        const refreshedInputImages = await refreshInputImageUrls(
+            inputImages,
+            userId,
+            preferGcs,
+        );
+        const inputVideoUrls = pickInputVideoValues(metadata, "inputVideoUrl");
+        const inputVideoBlobPaths = pickInputVideoValues(
+            metadata,
+            "inputVideoBlobPath",
+        );
+        const inputVideoHashes = pickInputVideoValues(
+            metadata,
+            "inputVideoHash",
+        );
+        const inputVideos = inputVideoUrls
+            .map((url, index) => ({
+                url,
+                blobPath: inputVideoBlobPaths[index],
+                hash: inputVideoHashes[index],
+            }))
+            .filter((item) => item.url);
+        const refreshedInputVideos = await refreshInputVideoUrls(
+            inputVideos,
+            userId,
+            preferGcs,
+        );
+        const inputAudio = inputAudioUrl
+            ? [
+                  {
+                      url: inputAudioUrl,
+                      blobPath: metadata.inputAudioBlobPath,
+                      hash: metadata.inputAudioHash,
+                  },
+              ]
+            : [];
+        const audioRequirement =
+            modelMeta?.mediaDefaults?.inputAudio ??
+            sanitizedSettings?.models?.[modelName]?.inputAudio;
+        const audioRequirementRange =
+            getInputRequirementRange(audioRequirement);
+        if (audioRequirementRange) {
+            const [minAudio = 0, maxAudio = Number.POSITIVE_INFINITY] =
+                audioRequirementRange;
+            if (inputAudio.length < minAudio || inputAudio.length > maxAudio) {
+                const displayName = modelMeta?.displayName || modelName;
                 const error = new Error(
-                    `GraphQL errors: ${JSON.stringify(result.errors)}`,
+                    `${displayName} requires ${describeAudioInputRequirement(
+                        minAudio,
+                        maxAudio,
+                    )}`,
                 );
                 await this.updateMediaItemOnError(
                     metadata,
                     error,
-                    "GRAPHQL_ERROR",
+                    "VALIDATION_ERROR",
                 );
                 throw error;
             }
-        } catch (error) {
-            console.error(
-                `[MediaGenerationHandler] GraphQL error:`,
-                error.message,
-                metadata,
-            );
-            // Update MediaItem if not already updated
-            await this.updateMediaItemOnError(
-                metadata,
-                error,
-                "REQUEST_FAILED",
-            );
-            throw error;
+        }
+        const refreshedInputAudioUrls = await refreshInputAudioUrls(
+            inputAudio,
+            userId,
+        );
+
+        const variables = config.buildVariables(
+            prompt,
+            sanitizedSettings,
+            refreshedInputImages,
+            refreshedInputImageRoles,
+            refreshedInputVideos,
+            refreshedInputAudioUrls[0],
+        );
+
+        console.log("[MediaGenerationHandler] Submitting media_generate", {
+            model: modelName,
+            outputType,
+            variableKeys: Object.entries(variables)
+                .filter(([, value]) => value !== undefined && value !== "")
+                .map(([key]) => key),
+            inputImagesCount: refreshedInputImages.length,
+            inputImageRoles: refreshedInputImageRoles.filter(Boolean),
+            inputVideosCount: refreshedInputVideos.length,
+            hasInputAudio: Boolean(refreshedInputAudioUrls[0]),
+            promptChars: prompt?.length || 0,
+        });
+
+        let data;
+        for (
+            let attempt = 1;
+            attempt <= GRAPHQL_SUBMIT_MAX_ATTEMPTS;
+            attempt++
+        ) {
+            try {
+                const result = await job.client.query({
+                    query: config.query,
+                    variables,
+                    fetchPolicy: "no-cache",
+                });
+                data = result.data;
+
+                if (result.errors) {
+                    console.debug(
+                        `[MediaGenerationHandler] GraphQL errors encountered`,
+                        result.errors,
+                    );
+                    const error = new Error(
+                        `GraphQL errors: ${JSON.stringify(result.errors)}`,
+                    );
+                    error.mediaItemErrorRecorded = true;
+                    await this.updateMediaItemOnError(
+                        metadata,
+                        error,
+                        "GRAPHQL_ERROR",
+                    );
+                    throw error;
+                }
+                break;
+            } catch (error) {
+                const retryable =
+                    attempt < GRAPHQL_SUBMIT_MAX_ATTEMPTS &&
+                    isTransientGraphqlSubmitError(error);
+                console.error(`[MediaGenerationHandler] GraphQL error:`, {
+                    attempt,
+                    maxAttempts: GRAPHQL_SUBMIT_MAX_ATTEMPTS,
+                    retryable,
+                    errorMessage: error?.message || error?.toString(),
+                    errorStack: error?.stack,
+                    errorCode: error?.code,
+                    errorName: error?.name,
+                    model: modelName,
+                    prompt: prompt?.substring(0, 100),
+                    inputImagesCount: refreshedInputImages.length,
+                    metadata: JSON.stringify(metadata).substring(0, 500),
+                });
+
+                if (retryable) {
+                    await wait(GRAPHQL_SUBMIT_RETRY_DELAY_MS * attempt);
+                    continue;
+                }
+
+                // Update MediaItem if not already updated
+                if (!error?.mediaItemErrorRecorded) {
+                    await this.updateMediaItemOnError(
+                        metadata,
+                        error,
+                        "REQUEST_FAILED",
+                    );
+                }
+                throw error;
+            }
         }
 
-        const resultKey = this.getResultKey(outputType, modelName);
+        const resultKey = this.getResultKey();
         const result = data?.[resultKey]?.result;
 
         if (!result) {
@@ -728,22 +890,16 @@ class MediaGenerationHandler extends BaseTask {
                     user: userId,
                     taskId: metadata.taskId,
                     cortexRequestId: metadata.taskId,
-                    prompt: metadata.prompt || "",
+                    prompt: metadata.displayPrompt || metadata.prompt || "",
                     type: metadata.outputType || "image",
                     model: metadata.model || "",
                     status: "failed",
                     error,
                     settings: metadata.settings,
-                    // Only include encrypted inputImageUrl fields if they have values (CSFLE can't encrypt null)
-                    ...(metadata.inputImageUrl && {
-                        inputImageUrl: metadata.inputImageUrl,
-                    }),
-                    ...(metadata.inputImageUrl2 && {
-                        inputImageUrl2: metadata.inputImageUrl2,
-                    }),
-                    ...(metadata.inputImageUrl3 && {
-                        inputImageUrl3: metadata.inputImageUrl3,
-                    }),
+                    // Only include encrypted input reference fields with values.
+                    ...pickInputImageMetadataFields(metadata),
+                    ...pickInputVideoMetadataFields(metadata),
+                    ...pickInputAudioMetadataFields(metadata),
                 });
                 await newMediaItem.save();
             }
@@ -777,200 +933,8 @@ class MediaGenerationHandler extends BaseTask {
         );
     }
 
-    async retryGeminiRequest(job, retryCount = 0) {
-        const { metadata } = job.data;
-        const {
-            prompt,
-            outputType,
-            model,
-            inputImageUrl,
-            inputImageUrl2,
-            inputImageUrl3,
-            inputImageUrl4,
-            inputImageUrl5,
-            inputImageUrl6,
-            inputImageUrl7,
-            inputImageUrl8,
-            inputImageUrl9,
-            inputImageUrl10,
-            inputImageUrl11,
-            inputImageUrl12,
-            inputImageUrl13,
-            inputImageUrl14,
-            settings,
-        } = metadata;
-
-        const modelName =
-            model ||
-            (outputType === "image"
-                ? "replicate-flux-11-pro"
-                : "replicate-seedance-1-pro");
-        const config = this.getModelConfig(modelName, outputType);
-
-        const inputImages = [
-            inputImageUrl,
-            inputImageUrl2,
-            inputImageUrl3,
-            inputImageUrl4,
-            inputImageUrl5,
-            inputImageUrl6,
-            inputImageUrl7,
-            inputImageUrl8,
-            inputImageUrl9,
-            inputImageUrl10,
-            inputImageUrl11,
-            inputImageUrl12,
-            inputImageUrl13,
-            inputImageUrl14,
-        ].filter(Boolean);
-        const variables = config.buildVariables(prompt, settings, inputImages);
-
-        try {
-            const result = await job.client.query({
-                query: config.query,
-                variables,
-                fetchPolicy: "no-cache",
-            });
-
-            if (result.errors) {
-                console.debug(
-                    `[MediaGenerationHandler] GraphQL errors in retry ${retryCount + 1}:`,
-                    result.errors,
-                );
-                throw new Error(
-                    `GraphQL errors: ${JSON.stringify(result.errors)}`,
-                );
-            }
-
-            return result.data;
-        } catch (error) {
-            console.error(
-                `[MediaGenerationHandler] Gemini retry ${retryCount + 1} failed:`,
-                error.message,
-            );
-            throw error;
-        }
-    }
-
     async handleCompletion(taskId, dataObject, infoObject, metadata, client) {
         const userId = metadata.userId;
-
-        // Check if this is a Gemini model that needs retry due to missing artifacts
-        if (
-            (metadata.model === "gemini-25-flash-image-preview" ||
-                metadata.model === "gemini-3-pro-image-preview") &&
-            !infoObject?.artifacts
-        ) {
-            const retryCount = metadata.geminiRetryCount || 0;
-            const maxRetries = 3;
-
-            if (retryCount < maxRetries) {
-                // Update retry count in metadata
-                metadata.geminiRetryCount = retryCount + 1;
-
-                // Create a new job for retry
-                const retryJob = {
-                    data: {
-                        taskId,
-                        metadata: {
-                            ...metadata,
-                            geminiRetryCount: retryCount + 1,
-                        },
-                    },
-                    client,
-                };
-
-                try {
-                    // Wait a bit before retrying (exponential backoff)
-                    const delay = Math.pow(2, retryCount) * 1000; // 1s, 2s, 4s
-                    await new Promise((resolve) => setTimeout(resolve, delay));
-
-                    const retryData = await this.retryGeminiRequest(
-                        retryJob,
-                        retryCount,
-                    );
-
-                    // Process the retry response
-                    if (userId) {
-                        const processedData = await this.processMediaData(
-                            retryData,
-                            infoObject,
-                            metadata,
-                        );
-
-                        // Check if the retry also failed to produce artifacts
-                        if (
-                            !processedData ||
-                            (!processedData.url &&
-                                !processedData.azureUrl &&
-                                !processedData.gcsUrl)
-                        ) {
-                            throw new Error(
-                                "Retry failed to produce artifacts",
-                            );
-                        }
-
-                        await this.handleMediaGenerationCompletion(
-                            userId,
-                            processedData,
-                            metadata,
-                        );
-
-                        const result = {
-                            message: "Media generation completed successfully",
-                            type: metadata.outputType,
-                            model: metadata.model,
-                            prompt: metadata.prompt,
-                            url: processedData?.url,
-                            azureUrl: processedData?.azureUrl,
-                            gcsUrl: processedData?.gcsUrl,
-                        };
-
-                        return result;
-                    }
-                } catch (retryError) {
-                    console.error(
-                        `[MediaGenerationHandler] Gemini retry ${retryCount + 1} failed:`,
-                        retryError.message,
-                    );
-
-                    // If this was the last retry, fall through to error handling
-                    if (retryCount + 1 >= maxRetries) {
-                        if (userId) {
-                            await this.updateOrCreateMediaItemWithError(
-                                userId,
-                                metadata,
-                                "GEMINI_RETRY_FAILED",
-                                "Gemini failed to generate image after 3 retries",
-                            );
-                        }
-
-                        return {
-                            error: "Gemini failed to generate image after 3 retries",
-                            type: metadata.outputType,
-                            model: metadata.model,
-                            prompt: metadata.prompt,
-                        };
-                    }
-                }
-            } else {
-                if (userId) {
-                    await this.updateOrCreateMediaItemWithError(
-                        userId,
-                        metadata,
-                        "GEMINI_RETRY_FAILED",
-                        "Gemini failed to generate image after 3 retries",
-                    );
-                }
-
-                return {
-                    error: "Gemini failed to generate image after 3 retries",
-                    type: metadata.outputType,
-                    model: metadata.model,
-                    prompt: metadata.prompt,
-                };
-            }
-        }
 
         let processedData = null;
         if (userId) {
@@ -979,10 +943,28 @@ class MediaGenerationHandler extends BaseTask {
                 infoObject,
                 metadata,
             );
+
+            // Detect empty completion — media generation succeeded on Cortex but
+            // no media data was received (e.g. WebSocket dropped during delivery)
+            if (
+                !processedData?.url &&
+                !processedData?.azureUrl &&
+                !processedData?.gcsUrl
+            ) {
+                console.error(
+                    "[MediaGenerationHandler] No media URLs in completion data — result was likely lost in transit",
+                    { model: metadata.model, prompt: metadata.prompt },
+                );
+                return {
+                    error: "Media generation completed but no media data was received. Please try again.",
+                };
+            }
+
             await this.handleMediaGenerationCompletion(
                 userId,
                 processedData,
                 metadata,
+                client,
             );
         }
 
@@ -990,11 +972,18 @@ class MediaGenerationHandler extends BaseTask {
             message: "Media generation completed successfully",
             type: metadata.outputType,
             model: metadata.model,
-            prompt: metadata.prompt,
+            prompt: metadata.displayPrompt || metadata.prompt,
             url: processedData?.url,
             azureUrl: processedData?.azureUrl,
             gcsUrl: processedData?.gcsUrl,
+            hash: processedData?.hash,
+            blobPath: processedData?.blobPath,
         };
+
+        console.log(
+            "[MediaGenerationHandler] Returning completion result with hash:",
+            result,
+        );
 
         return result;
     }
@@ -1071,226 +1060,123 @@ class MediaGenerationHandler extends BaseTask {
 
     async processMediaData(dataObject, infoObject, metadata) {
         try {
+            // The cortex media_generate router normalizes all responses to URLs
+            // (direct URLs or data: URIs). No model-specific parsing needed.
             let mediaUrl = null;
 
-            // Handle Gemini special case first - returns cloudUrls object directly
+            // dataObject is typically the raw result string from the router
+            if (typeof dataObject === "string" && dataObject.length > 0) {
+                mediaUrl = dataObject;
+            } else if (dataObject?.output) {
+                mediaUrl = Array.isArray(dataObject.output)
+                    ? dataObject.output[0]
+                    : dataObject.output;
+            } else if (dataObject?.result?.output) {
+                mediaUrl = Array.isArray(dataObject.result.output)
+                    ? dataObject.result.output[0]
+                    : dataObject.result.output;
+            }
+
+            // Upload to cloud storage
             let cloudUrls = null;
-            const isGeminiModel =
-                metadata.model === "gemini-25-flash-image-preview" ||
-                metadata.model === "gemini-3-pro-image-preview";
-
-            if (isGeminiModel && infoObject?.artifacts) {
-                const geminiResult = await this.processGeminiArtifacts(
-                    infoObject.artifacts,
-                    metadata.userId,
-                );
-                // processGeminiArtifacts returns:
-                // - { azureUrl, gcsUrl } object on success
-                // - data URL string on upload failure (fallback)
-                // - null if no artifacts
-                if (geminiResult && typeof geminiResult === "object") {
-                    cloudUrls = geminiResult;
-                    mediaUrl = cloudUrls.azureUrl || cloudUrls.gcsUrl;
-                } else if (typeof geminiResult === "string") {
-                    // Fallback data URL - will be uploaded below
-                    mediaUrl = geminiResult;
-                }
-            }
-
-            // Handle Veo video responses
-            if (
-                !mediaUrl &&
-                metadata.outputType === "video" &&
-                metadata.model?.includes("veo")
-            ) {
-                mediaUrl = this.processVeoVideoResponse(dataObject);
-            }
-
-            // Handle standard image/video responses
-            if (!mediaUrl) {
-                mediaUrl = this.processStandardResponse(dataObject);
-            }
-
-            // Upload to cloud storage if we have a valid URL (skip if Gemini already uploaded)
-            if (!cloudUrls && mediaUrl && typeof mediaUrl === "string") {
-                // Get user's contextId for file scoping
-                let contextId = null;
-                if (metadata.userId) {
-                    try {
-                        await initializeUserModel();
-                        const user = await User.findById(metadata.userId);
-                        if (user?.contextId) {
-                            contextId = user.contextId;
-                        }
-                    } catch (error) {
-                        console.error(
-                            "Error getting user contextId for media upload:",
-                            error,
-                        );
-                        // Continue without contextId if lookup fails
-                    }
-                }
+            if (mediaUrl && typeof mediaUrl === "string") {
+                const routingParams =
+                    await this.getUploadRoutingParams(metadata);
 
                 try {
+                    console.log(
+                        "[MediaGenerationHandler] Uploading media to cloud with routing params:",
+                        routingParams,
+                    );
                     cloudUrls = await this.uploadMediaToCloud(
                         mediaUrl,
-                        contextId,
+                        routingParams,
+                        metadata.displayPrompt || metadata.prompt,
+                        getGeneratedMediaTaskSuffix(metadata.taskId),
+                    );
+                    cloudUrls = await this.moveUploadedMediaToOutputFolder(
+                        cloudUrls,
+                        routingParams,
+                        metadata.outputFolder,
+                        process.env.CORTEX_MEDIA_API_URL,
+                    );
+                    console.log(
+                        "[MediaGenerationHandler] Upload completed, cloudUrls:",
+                        cloudUrls,
                     );
                 } catch (error) {
                     console.error("Failed to upload media to cloud:", error);
                 }
             }
 
-            // Return processed data with cloud URLs
-            const isGoogleModel = metadata.model?.includes("veo");
-            const finalUrl = isGoogleModel
-                ? cloudUrls?.gcsUrl || mediaUrl
-                : cloudUrls?.azureUrl ||
-                  (mediaUrl && !mediaUrl.startsWith("data:")
-                      ? mediaUrl
-                      : undefined);
+            // Determine primary URL — prefer cloud URLs over raw media URL
+            const finalUrl =
+                cloudUrls?.azureUrl ||
+                cloudUrls?.gcsUrl ||
+                (mediaUrl && !mediaUrl.startsWith("data:")
+                    ? mediaUrl
+                    : undefined);
 
             // Only include URL fields if they have truthy values (CSFLE can't encrypt null/undefined)
-            return {
+            const processedData = {
                 ...(finalUrl && { url: finalUrl }),
                 ...(cloudUrls?.azureUrl && { azureUrl: cloudUrls.azureUrl }),
                 ...(cloudUrls?.gcsUrl && { gcsUrl: cloudUrls.gcsUrl }),
-                ...(dataObject?.id && { id: dataObject.id }),
-                ...(dataObject?.model && { model: dataObject.model }),
-                ...(dataObject?.version && { version: dataObject.version }),
+                ...(cloudUrls?.hash && { hash: cloudUrls.hash }),
+                ...(cloudUrls?.blobPath && { blobPath: cloudUrls.blobPath }),
             };
+
+            console.log(
+                "[MediaGenerationHandler] Processed media data:",
+                processedData,
+            );
+
+            return processedData;
         } catch (error) {
             console.error("Error processing media data:", error);
             return dataObject;
         }
     }
 
-    async processGeminiArtifacts(artifacts, userId = null) {
+    /**
+     * Compute SHA-256 hash of buffer
+     * @param {Buffer} buffer - The buffer to hash
+     * @returns {string} - Hex string of hash
+     */
+    computeHash(buffer) {
+        return crypto.createHash("sha256").update(buffer).digest("hex");
+    }
+
+    async getUploadRoutingParams(metadata = {}) {
+        if (!metadata.userId) {
+            return {};
+        }
+
         try {
-            if (Array.isArray(artifacts)) {
-                const imageArtifact = artifacts.find(
-                    (artifact) => artifact.type === "image",
-                );
-
-                if (imageArtifact) {
-                    if (imageArtifact.data) {
-                        try {
-                            const dataUrl = `data:${imageArtifact.mimeType || "image/png"};base64,${imageArtifact.data}`;
-
-                            // Get user's contextId for file scoping
-                            let contextId = null;
-                            if (userId) {
-                                try {
-                                    await initializeUserModel();
-                                    const user = await User.findById(userId);
-                                    if (user?.contextId) {
-                                        contextId = user.contextId;
-                                    }
-                                } catch (error) {
-                                    console.error(
-                                        "Error getting user contextId for Gemini upload:",
-                                        error,
-                                    );
-                                    // Continue without contextId if lookup fails
-                                }
-                            }
-
-                            const cloudUrls = await this.uploadMediaToCloud(
-                                dataUrl,
-                                contextId,
-                            );
-
-                            if (cloudUrls) {
-                                // Return the full cloudUrls object so we preserve both URLs
-                                return cloudUrls;
-                            }
-                        } catch (uploadError) {
-                            console.error(
-                                "Failed to upload Gemini image to cloud:",
-                                uploadError,
-                            );
-
-                            const fallbackUrl = `data:${imageArtifact.mimeType};base64,${imageArtifact.data}`;
-                            return fallbackUrl;
-                        }
-                    } else {
-                        console.warn(`Image artifact has no data field`);
-                    }
-                } else {
-                    console.warn(`No image artifact found in artifacts array`);
-                }
-            } else {
-                console.warn(`Artifacts is not an array:`, typeof artifacts);
+            await initializeUserModel();
+            const user = await User.findById(metadata.userId);
+            if (!user?.contextId) {
+                return {};
             }
-        } catch (e) {
-            console.error("Error parsing Gemini infoObject artifacts:", e);
+
+            return buildMediaHelperFileParams({
+                storageTarget: createMediaStorageTarget(user.contextId),
+            });
+        } catch (error) {
+            console.error(
+                "Error getting user storage routing for media upload:",
+                error,
+            );
+            return {};
         }
-        return null;
     }
 
-    processVeoVideoResponse(dataObject) {
-        // Check for direct Veo response structure
-        if (
-            dataObject?.response?.videos &&
-            Array.isArray(dataObject.response.videos) &&
-            dataObject.response.videos.length > 0
-        ) {
-            return extractVideoUrl(dataObject.response.videos[0]);
-        }
-
-        // Check for result wrapper structure
-        if (
-            dataObject?.result?.response?.videos &&
-            Array.isArray(dataObject.result.response.videos) &&
-            dataObject.result.response.videos.length > 0
-        ) {
-            return extractVideoUrl(dataObject.result.response.videos[0]);
-        }
-
-        // Fallback: check if data.result.output is a string that needs parsing
-        if (
-            dataObject?.result?.output &&
-            typeof dataObject.result.output === "string"
-        ) {
-            try {
-                const parsed = JSON.parse(dataObject.result.output);
-
-                // Try different possible response structures
-                const structures = [
-                    parsed.response?.videos?.[0],
-                    parsed.videos?.[0],
-                    parsed.gcsUri ? { gcsUri: parsed.gcsUri } : null,
-                    parsed.url ? { url: parsed.url } : null,
-                ].filter(Boolean);
-
-                for (const structure of structures) {
-                    const url = extractVideoUrl(structure) || structure.url;
-                    if (url) return url;
-                }
-            } catch (e) {
-                console.error("Error parsing Veo video response:", e);
-            }
-        }
-
-        return null;
-    }
-
-    processStandardResponse(dataObject) {
-        // Try different possible structures
-        if (dataObject?.output) {
-            return Array.isArray(dataObject.output)
-                ? dataObject.output[0]
-                : dataObject.output;
-        }
-        if (dataObject?.result?.output) {
-            return Array.isArray(dataObject.result.output)
-                ? dataObject.result.output[0]
-                : dataObject.result.output;
-        }
-        return null;
-    }
-
-    async uploadMediaToCloud(mediaUrl, contextId = null) {
+    async uploadMediaToCloud(
+        mediaUrl,
+        routingParams = {},
+        prompt = null,
+        filenameSuffix = "",
+    ) {
         try {
             if (!process.env.CORTEX_MEDIA_API_URL) {
                 throw new Error(
@@ -1304,13 +1190,17 @@ class MediaGenerationHandler extends BaseTask {
                 return await this.uploadBase64Data(
                     mediaUrl,
                     serverUrl,
-                    contextId,
+                    routingParams,
+                    prompt,
+                    filenameSuffix,
                 );
             } else {
                 return await this.uploadRegularUrl(
                     mediaUrl,
                     serverUrl,
-                    contextId,
+                    routingParams,
+                    prompt,
+                    filenameSuffix,
                 );
             }
         } catch (error) {
@@ -1319,24 +1209,96 @@ class MediaGenerationHandler extends BaseTask {
         }
     }
 
-    async uploadBase64Data(mediaUrl, serverUrl, contextId = null) {
+    async moveUploadedMediaToOutputFolder(
+        cloudUrls,
+        routingParams = {},
+        outputFolder = "",
+        serverUrl = "",
+    ) {
+        const targetBlobPath = getMediaFolderTargetBlobPath(
+            cloudUrls?.blobPath,
+            outputFolder,
+        );
+        if (!targetBlobPath || targetBlobPath === cloudUrls?.blobPath) {
+            return cloudUrls;
+        }
+
+        const filename = getBlobPathFilename(cloudUrls.blobPath);
+        const renameUrl = new URL(serverUrl);
+        renameUrl.searchParams.set("rename", "true");
+        renameUrl.searchParams.set("blobPath", cloudUrls.blobPath);
+        renameUrl.searchParams.set("newFilename", filename);
+        renameUrl.searchParams.set("targetBlobPath", targetBlobPath);
+        for (const [key, value] of Object.entries(routingParams)) {
+            renameUrl.searchParams.set(key, value);
+        }
+
+        const response = await fetch(renameUrl.toString(), {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+            },
+        });
+
+        if (!response.ok) {
+            const errorBody = await response.text();
+            throw new Error(
+                `Move generated media failed: ${response.statusText}. Response body: ${errorBody}`,
+            );
+        }
+
+        const data = await response.json();
+        const movedData = data?.body || data;
+        return {
+            ...cloudUrls,
+            ...(movedData.url && {
+                azureUrl: movedData.url,
+                url: movedData.url,
+            }),
+            ...(movedData.gcs && { gcsUrl: movedData.gcs }),
+            ...(movedData.gcsUrl && { gcsUrl: movedData.gcsUrl }),
+            blobPath: movedData.blobPath || movedData.name || targetBlobPath,
+        };
+    }
+
+    async uploadBase64Data(
+        mediaUrl,
+        serverUrl,
+        routingParams = {},
+        prompt = null,
+        filenameSuffix = "",
+    ) {
         const response = await fetch(mediaUrl);
         const blob = await response.blob();
+
+        // Convert blob to buffer to compute hash
+        const arrayBuffer = await blob.arrayBuffer();
+        const buffer = Buffer.from(arrayBuffer);
+        const hash = this.computeHash(buffer);
+
+        console.log(
+            "[MediaGenerationHandler] Computed hash for base64 data:",
+            hash,
+        );
 
         const formData = new FormData();
         const mimeType = mediaUrl.split(";")[0].split(":")[1];
         const extension = mimeType.split("/")[1] || "bin";
-        const filename = `media.${extension}`;
+        const filename = getGeneratedMediaFilename(prompt, extension, {
+            uniqueSuffix: filenameSuffix || hash,
+        });
+
+        // CFH reads multipart fields before the file stream starts,
+        // so routing metadata and hash must come first.
+        formData.append("hash", hash);
+        for (const [key, value] of Object.entries(routingParams)) {
+            formData.append(key, value);
+        }
         formData.append("file", blob, filename);
 
-        // Add contextId if provided
-        if (contextId) {
-            formData.append("contextId", contextId);
-        }
-
         const uploadUrl = new URL(serverUrl);
-        if (contextId) {
-            uploadUrl.searchParams.set("contextId", contextId);
+        for (const [key, value] of Object.entries(routingParams)) {
+            uploadUrl.searchParams.set(key, value);
         }
 
         const uploadResponse = await fetch(uploadUrl.toString(), {
@@ -1357,16 +1319,111 @@ class MediaGenerationHandler extends BaseTask {
         const data = await uploadResponse.json();
 
         const validatedUrls = this.validateCloudUrls(data);
+
+        // Include the hash we computed
+        validatedUrls.hash = hash;
+
         return validatedUrls;
     }
 
-    async uploadRegularUrl(mediaUrl, serverUrl, contextId = null) {
+    async uploadBufferData(
+        buffer,
+        serverUrl,
+        routingParams = {},
+        prompt = null,
+        extension = "bin",
+        hash = null,
+        contentType = "application/octet-stream",
+        filenameSuffix = "",
+    ) {
+        const mediaHash = hash || this.computeHash(buffer);
+        const filename = getGeneratedMediaFilename(prompt, extension, {
+            uniqueSuffix: filenameSuffix || mediaHash,
+        });
+        const blob = new Blob([buffer], { type: contentType });
+        const formData = new FormData();
+
+        // CFH reads multipart fields before the file stream starts,
+        // so routing metadata and hash must come first.
+        formData.append("hash", mediaHash);
+        for (const [key, value] of Object.entries(routingParams)) {
+            formData.append(key, value);
+        }
+        formData.append("file", blob, filename);
+
+        const uploadUrl = new URL(serverUrl);
+        for (const [key, value] of Object.entries(routingParams)) {
+            uploadUrl.searchParams.set(key, value);
+        }
+
+        const uploadResponse = await fetch(uploadUrl.toString(), {
+            method: "POST",
+            body: formData,
+        });
+
+        if (!uploadResponse.ok) {
+            const errorBody = await uploadResponse.text();
+            throw new Error(
+                `Upload failed: ${uploadResponse.statusText}. Response body: ${errorBody}`,
+            );
+        }
+
+        const data = await uploadResponse.json();
+        const validatedUrls = this.validateCloudUrls(data);
+        validatedUrls.hash = mediaHash;
+
+        return validatedUrls;
+    }
+
+    async uploadRegularUrl(
+        mediaUrl,
+        serverUrl,
+        routingParams = {},
+        prompt = null,
+        filenameSuffix = "",
+    ) {
+        // First, fetch the media to compute its hash
+        const mediaResponse = await fetch(mediaUrl);
+        if (!mediaResponse.ok) {
+            throw new Error(
+                `Failed to fetch media from URL: ${mediaResponse.statusText}`,
+            );
+        }
+
+        const arrayBuffer = await mediaResponse.arrayBuffer();
+        const buffer = Buffer.from(arrayBuffer);
+        const hash = this.computeHash(buffer);
+        const contentType =
+            mediaResponse.headers.get("content-type") ||
+            "application/octet-stream";
+        const extension =
+            getExtensionFromUrl(mediaUrl) ||
+            getExtensionFromContentType(contentType) ||
+            "mp4";
+
+        console.log(
+            "[MediaGenerationHandler] Computed hash for URL media:",
+            hash,
+        );
+
+        // Now upload via the API
         const url = new URL(serverUrl);
         url.searchParams.set("fetch", mediaUrl);
+        for (const [key, value] of Object.entries(routingParams)) {
+            url.searchParams.set(key, value);
+        }
 
-        // Add contextId if provided
-        if (contextId) {
-            url.searchParams.set("contextId", contextId);
+        // Add hash to query params
+        url.searchParams.set("hash", hash);
+
+        // Pass descriptive filename derived from prompt
+        if (prompt) {
+            url.searchParams.set(
+                "filename",
+                getGeneratedMediaFilename(prompt, extension, {
+                    uniqueSuffix: filenameSuffix || hash,
+                }),
+            );
         }
 
         const response = await fetch(url.toString(), {
@@ -1378,44 +1435,287 @@ class MediaGenerationHandler extends BaseTask {
 
         if (!response.ok) {
             const errorBody = await response.text();
-            throw new Error(
-                `Upload failed: ${response.statusText}. Response body: ${errorBody}`,
+            console.warn(
+                `[MediaGenerationHandler] Remote fetch upload failed, falling back to multipart upload: ${response.status} ${errorBody}`,
+            );
+            return this.uploadBufferData(
+                buffer,
+                serverUrl,
+                routingParams,
+                prompt,
+                extension,
+                hash,
+                contentType,
+                filenameSuffix,
             );
         }
 
         const data = await response.json();
-        return this.validateCloudUrls(data);
+        const validatedUrls = this.validateCloudUrls(data);
+
+        // Include the hash we computed
+        validatedUrls.hash = hash;
+
+        return validatedUrls;
     }
 
     validateCloudUrls(data) {
-        const hasAzureUrl =
-            data.url && data.url.includes("blob.core.windows.net");
-        const hasGcsUrl = data.gcs;
+        // Handle nested body structure from some API responses
+        const responseData = data.body || data;
 
-        if (!hasAzureUrl || !hasGcsUrl) {
+        console.log(
+            "[MediaGenerationHandler] Validating cloud URLs from response:",
+            JSON.stringify(responseData),
+        );
+
+        const azureUrl = responseData.url;
+        const gcsUrl = responseData.gcs || responseData.gcsUrl;
+        const hash = responseData.hash;
+        const blobPath =
+            responseData.blobPath ||
+            responseData.name ||
+            extractBlobPathFromUrl(azureUrl) ||
+            extractBlobPathFromUrl(gcsUrl);
+
+        console.log("[MediaGenerationHandler] Extracted values:", {
+            azureUrl,
+            gcsUrl,
+            hash,
+            blobPath,
+        });
+
+        let azureHostname;
+        let azurePort;
+        if (typeof azureUrl === "string") {
+            try {
+                const parsedAzureUrl = new URL(azureUrl);
+                azureHostname = parsedAzureUrl.hostname;
+                azurePort = parsedAzureUrl.port;
+            } catch (e) {
+                // Invalid URL format; leave hostname/port undefined
+            }
+        }
+
+        const hasAzureUrl =
+            typeof azureUrl === "string" &&
+            !!azureHostname &&
+            // Standard Azure Blob Storage hostname: <account>.blob.core.windows.net
+            ((azureHostname.endsWith(".blob.core.windows.net") &&
+                // Ensure there is a non-empty account name before the suffix,
+                // and that it is a single DNS label (no additional dots).
+                azureHostname.slice(0, -".blob.core.windows.net".length)
+                    .length > 0 &&
+                !azureHostname
+                    .slice(0, -".blob.core.windows.net".length)
+                    .includes(".")) ||
+                // Azurite local by IP
+                (azureHostname === "127.0.0.1" && azurePort === "10000") ||
+                // Azurite local by hostname
+                (azureHostname === "localhost" && azurePort === "10000"));
+        const hasGcsUrl =
+            gcsUrl && typeof gcsUrl === "string" && gcsUrl.length > 0;
+
+        // Require at least one valid URL (Azure OR GCS)
+        if (!hasAzureUrl && !hasGcsUrl) {
+            console.error(
+                "[MediaGenerationHandler] Missing storage URLs. Response data:",
+                JSON.stringify(responseData),
+            );
             throw new Error(
                 "Media file upload failed: Missing required storage URLs",
             );
         }
 
-        return {
-            azureUrl: data.url,
-            gcsUrl: data.gcs,
+        const result = {
+            ...(azureUrl && { azureUrl }),
+            ...(gcsUrl && { gcsUrl }),
+            ...(hash && { hash }),
+            ...(blobPath && { blobPath }),
         };
+
+        console.log("[MediaGenerationHandler] Returning cloud URLs:", result);
+
+        return result;
     }
 
     async getInheritedTags(userId, inputImageUrls, inputTags = []) {
         // Use tags passed from the frontend instead of querying encrypted URL fields
         if (inputTags && inputTags.length > 0) {
-            return inputTags;
+            return mergeMediaTags(inputTags);
         }
 
         // Fallback: return empty array if no tags provided
         return [];
     }
 
-    async handleMediaGenerationCompletion(userId, dataObject, metadata) {
+    async getPromptTags(client, prompt) {
+        const text = String(prompt || "").trim();
+        if (!client || !text) {
+            return [];
+        }
+
         try {
+            const { data } = await client.query({
+                query: MEDIA_PROMPT_TAGS,
+                variables: { text },
+                fetchPolicy: "no-cache",
+            });
+            return parseMediaPromptTagsResult(data?.media_prompt_tags?.result);
+        } catch (error) {
+            console.warn(
+                "[MediaGenerationHandler] Failed to auto-tag media prompt:",
+                error?.message || error,
+            );
+            return [];
+        }
+    }
+
+    async retryDbOperation(operation, maxRetries = 3, retryDelay = 1000) {
+        let lastError;
+        for (let attempt = 1; attempt <= maxRetries; attempt++) {
+            try {
+                return await operation();
+            } catch (error) {
+                lastError = error;
+                console.warn(
+                    `[MediaGenerationHandler] DB operation attempt ${attempt}/${maxRetries} failed: ${error.message}`,
+                );
+
+                if (
+                    error.name === "MongoNotConnectedError" ||
+                    (error.message &&
+                        (error.message.includes("not connected") ||
+                            error.message.includes("must be connected") ||
+                            error.message.includes("disconnected")))
+                ) {
+                    console.log(
+                        "[MediaGenerationHandler] MongoDB connection issue, attempting to reconnect...",
+                    );
+                    try {
+                        const mongoose = (await import("mongoose")).default;
+                        if (mongoose.connection.readyState !== 1) {
+                            if (mongoose.connection.readyState !== 0) {
+                                await mongoose.connection
+                                    .close()
+                                    .catch(() => {});
+                            }
+                            const { connectToDatabase } = await import(
+                                "../../src/db.mjs"
+                            );
+                            await connectToDatabase();
+                            console.log(
+                                "[MediaGenerationHandler] Successfully reconnected to MongoDB",
+                            );
+                        }
+                    } catch (reconnectError) {
+                        console.error(
+                            "[MediaGenerationHandler] Failed to reconnect:",
+                            reconnectError.message,
+                        );
+                    }
+                }
+
+                if (attempt < maxRetries) {
+                    const currentRetryDelay = retryDelay;
+                    await new Promise((resolve) =>
+                        setTimeout(resolve, currentRetryDelay),
+                    );
+                    retryDelay *= 2;
+                }
+            }
+        }
+        throw lastError;
+    }
+
+    async handleMediaGenerationCompletion(
+        userId,
+        dataObject,
+        metadata,
+        client,
+    ) {
+        try {
+            const inputImageMetadataFields =
+                pickInputImageMetadataFields(metadata);
+            const inputVideoMetadataFields =
+                pickInputVideoMetadataFields(metadata);
+            const inputAudioMetadataFields =
+                pickInputAudioMetadataFields(metadata);
+            const completedAt = Math.floor(Date.now() / 1000);
+
+            const coreUpdateData = {
+                status: "completed",
+                completed: completedAt,
+                ...(dataObject.url && { url: dataObject.url }),
+                ...(dataObject.azureUrl && { azureUrl: dataObject.azureUrl }),
+                ...(dataObject.gcsUrl && { gcsUrl: dataObject.gcsUrl }),
+                ...(dataObject.hash && { hash: dataObject.hash }),
+                ...(dataObject.blobPath && { blobPath: dataObject.blobPath }),
+                ...(metadata.outputFolder && {
+                    outputFolder: metadata.outputFolder,
+                }),
+                ...(dataObject.duration !== undefined && {
+                    duration: dataObject.duration,
+                }),
+                ...(dataObject.generateAudio !== undefined && {
+                    generateAudio: dataObject.generateAudio,
+                }),
+                ...(dataObject.resolution && {
+                    resolution: dataObject.resolution,
+                }),
+                ...(dataObject.cameraFixed !== undefined && {
+                    cameraFixed: dataObject.cameraFixed,
+                }),
+            };
+
+            console.log(
+                "[MediaGenerationHandler] Updating media item with completed output:",
+                {
+                    userId,
+                    taskId: metadata.taskId,
+                    updateData: coreUpdateData,
+                },
+            );
+
+            let mediaItem = await this.retryDbOperation(() =>
+                MediaItem.findOneAndUpdate(
+                    { user: userId, taskId: metadata.taskId },
+                    coreUpdateData,
+                    { new: true, runValidators: true },
+                ),
+            );
+
+            if (!mediaItem) {
+                mediaItem = new MediaItem({
+                    user: userId,
+                    taskId: metadata.taskId,
+                    cortexRequestId: metadata.taskId,
+                    prompt: metadata.displayPrompt || metadata.prompt || "",
+                    type: metadata.outputType || "image",
+                    model: metadata.model || "",
+                    ...coreUpdateData,
+                    ...inputImageMetadataFields,
+                    ...inputVideoMetadataFields,
+                    ...inputAudioMetadataFields,
+                    settings: metadata.settings,
+                });
+                await this.retryDbOperation(() => mediaItem.save());
+            }
+
+            console.log(
+                "[MediaGenerationHandler] Media item output updated:",
+                mediaItem
+                    ? {
+                          _id: mediaItem._id,
+                          hash: mediaItem.hash,
+                          blobPath: mediaItem.blobPath,
+                          tags: mediaItem.tags,
+                          url: mediaItem.url,
+                          azureUrl: mediaItem.azureUrl,
+                          gcsUrl: mediaItem.gcsUrl,
+                      }
+                    : "NOT FOUND",
+            );
+
             // Get inherited tags from input images
             const inputImageUrls = [
                 metadata.inputImageUrl,
@@ -1439,62 +1739,36 @@ class MediaGenerationHandler extends BaseTask {
                 inputImageUrls,
                 metadata.inputTags,
             );
-
-            // Build update data - only include encrypted URL fields if they have values (CSFLE can't encrypt null)
-            const updateData = {
-                status: "completed",
-                completed: Math.floor(Date.now() / 1000),
-                // Inherit tags from input images
-                tags: inheritedTags,
-                // Only include encrypted URL fields if they have truthy values
-                ...(dataObject.url && { url: dataObject.url }),
-                ...(dataObject.azureUrl && { azureUrl: dataObject.azureUrl }),
-                ...(dataObject.gcsUrl && { gcsUrl: dataObject.gcsUrl }),
-                // Video-specific fields (not encrypted, so undefined is OK but be explicit)
-                ...(dataObject.duration !== undefined && {
-                    duration: dataObject.duration,
-                }),
-                ...(dataObject.generateAudio !== undefined && {
-                    generateAudio: dataObject.generateAudio,
-                }),
-                ...(dataObject.resolution && {
-                    resolution: dataObject.resolution,
-                }),
-                ...(dataObject.cameraFixed !== undefined && {
-                    cameraFixed: dataObject.cameraFixed,
-                }),
-            };
-
-            const mediaItem = await MediaItem.findOneAndUpdate(
-                { user: userId, taskId: metadata.taskId },
-                updateData,
-                { new: true, runValidators: true },
+            const promptTags = await this.getPromptTags(
+                client,
+                metadata.prompt || metadata.displayPrompt,
+            );
+            const existingMediaItem = mediaItem;
+            const tags = mergeMediaTags(
+                existingMediaItem?.tags,
+                inheritedTags,
+                promptTags,
             );
 
-            if (!mediaItem) {
-                // Create a new media item if it doesn't exist (fallback)
-                const newMediaItem = new MediaItem({
-                    user: userId,
-                    taskId: metadata.taskId,
-                    cortexRequestId: metadata.taskId,
-                    prompt: metadata.prompt || "",
-                    type: metadata.outputType || "image",
-                    model: metadata.model || "",
-                    ...updateData,
-                    settings: metadata.settings,
-                    // Only include encrypted inputImageUrl fields if they have values (CSFLE can't encrypt null)
-                    ...(metadata.inputImageUrl && {
-                        inputImageUrl: metadata.inputImageUrl,
-                    }),
-                    ...(metadata.inputImageUrl2 && {
-                        inputImageUrl2: metadata.inputImageUrl2,
-                    }),
-                    ...(metadata.inputImageUrl3 && {
-                        inputImageUrl3: metadata.inputImageUrl3,
-                    }),
-                });
-                await newMediaItem.save();
-            }
+            const taggedMediaItem = await this.retryDbOperation(() =>
+                MediaItem.findOneAndUpdate(
+                    { user: userId, taskId: metadata.taskId },
+                    { tags },
+                    { new: true, runValidators: true },
+                ),
+            );
+
+            console.log(
+                "[MediaGenerationHandler] Media item tags updated:",
+                taggedMediaItem
+                    ? {
+                          _id: taggedMediaItem._id,
+                          hash: taggedMediaItem.hash,
+                          blobPath: taggedMediaItem.blobPath,
+                          tags: taggedMediaItem.tags,
+                      }
+                    : "NOT FOUND",
+            );
         } catch (error) {
             console.error("Error updating media item:", error);
             throw error;

--- a/src/components/images/hooks/__tests__/useMediaGeneration.test.js
+++ b/src/components/images/hooks/__tests__/useMediaGeneration.test.js
@@ -1,0 +1,985 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import {
+    applyInputAudioReference,
+    applyInputImageReference,
+    applyInputImageRole,
+    applyStoredInputAudioReference,
+    applyInputVideoReference,
+    applyStoredInputImageReference,
+    applyStoredInputVideoReference,
+    getInputAudioUrl,
+    getInputImageUrl,
+    getInputVideoUrl,
+    hasUsableInputAudioUrl,
+    hasUsableInputImageUrl,
+    hasUsableInputVideoUrl,
+    useMediaGeneration,
+} from "../useMediaGeneration";
+import { act, renderHook } from "@testing-library/react";
+
+let mockMediaModels = [];
+
+jest.mock("../../../../../app/queries/modelMetadata", () => ({
+    useMediaModels: () => ({ data: mockMediaModels }),
+}));
+
+beforeEach(() => {
+    mockMediaModels = [];
+    jest.clearAllMocks();
+});
+
+describe("useMediaGeneration input image helpers", () => {
+    test("prefers Azure URLs by default and GCS URLs when requested", () => {
+        const image = {
+            url: "https://display.example/image.png",
+            azureUrl: "https://azure.example/image.png?stale=sas",
+            gcsUrl: "gs://bucket/image.png",
+        };
+
+        expect(getInputImageUrl(image)).toBe(
+            "https://azure.example/image.png?stale=sas",
+        );
+        expect(getInputImageUrl(image, true)).toBe("gs://bucket/image.png");
+    });
+
+    test("prefers GCS URLs for input videos when requested", () => {
+        const video = {
+            url: "https://display.example/video.mp4",
+            azureUrl: "https://azure.example/video.mp4?stale=sas",
+            gcsUrl: "gs://bucket/video.mp4",
+        };
+
+        expect(getInputVideoUrl(video)).toBe(
+            "https://azure.example/video.mp4?stale=sas",
+        );
+        expect(getInputVideoUrl(video, true)).toBe("gs://bucket/video.mp4");
+    });
+
+    test("accepts selected images with any stored input URL", () => {
+        expect(
+            hasUsableInputImageUrl({ azureUrl: "https://azure.example/a" }),
+        ).toBe(true);
+        expect(hasUsableInputImageUrl({ gcsUrl: "gs://bucket/a" })).toBe(true);
+        expect(
+            hasUsableInputImageUrl({ url: "https://display.example/a" }),
+        ).toBe(true);
+        expect(hasUsableInputImageUrl({ blobPath: "media/a.png" })).toBe(false);
+    });
+
+    test("accepts selected videos with any stored input URL", () => {
+        expect(
+            hasUsableInputVideoUrl({ azureUrl: "https://azure.example/a.mp4" }),
+        ).toBe(true);
+        expect(hasUsableInputVideoUrl({ gcsUrl: "gs://bucket/a.mp4" })).toBe(
+            true,
+        );
+        expect(
+            hasUsableInputVideoUrl({
+                url: "https://display.example/a.mp4",
+            }),
+        ).toBe(true);
+        expect(hasUsableInputVideoUrl({ blobPath: "media/a.mp4" })).toBe(false);
+    });
+
+    test("accepts selected audio with any stored input URL", () => {
+        expect(
+            hasUsableInputAudioUrl({
+                type: "audio",
+                azureUrl: "https://azure.example/a.wav",
+            }),
+        ).toBe(true);
+        expect(
+            hasUsableInputAudioUrl({
+                type: "audio",
+                gcsUrl: "gs://bucket/a.wav",
+            }),
+        ).toBe(true);
+        expect(
+            hasUsableInputAudioUrl({
+                type: "audio",
+                url: "https://display.example/a.wav",
+            }),
+        ).toBe(true);
+        expect(
+            hasUsableInputAudioUrl({
+                type: "image",
+                url: "https://display.example/a.png",
+            }),
+        ).toBe(false);
+        expect(hasUsableInputAudioUrl({ type: "audio" })).toBe(false);
+    });
+
+    test("adds stable file identifiers next to the input audio URL", () => {
+        const taskData = {};
+        const audio = {
+            type: "audio",
+            url: "https://display.example/source.wav",
+            azureUrl: "https://azure.example/source.wav?stale=sas",
+            blobPath: "media/source.wav",
+            hash: "hash-source",
+        };
+
+        expect(getInputAudioUrl(audio)).toBe(
+            "https://azure.example/source.wav?stale=sas",
+        );
+
+        applyInputAudioReference(taskData, audio);
+
+        expect(taskData).toEqual({
+            inputAudioUrl: "https://azure.example/source.wav?stale=sas",
+            inputAudioBlobPath: "media/source.wav",
+            inputAudioHash: "hash-source",
+        });
+    });
+
+    test("adds stable file identifiers next to the URL for the worker refresh", () => {
+        const taskData = {};
+
+        applyInputImageReference(
+            taskData,
+            {
+                azureUrl: "https://azure.example/media/a.png?stale=sas",
+                blobPath: "media/a.png",
+                hash: "hash-a",
+            },
+            0,
+            false,
+        );
+
+        expect(taskData).toEqual({
+            inputImageUrl: "https://azure.example/media/a.png?stale=sas",
+            inputImageBlobPath: "media/a.png",
+            inputImageHash: "hash-a",
+        });
+    });
+
+    test("uses numbered input fields for additional selected images", () => {
+        const taskData = {};
+
+        applyInputImageReference(
+            taskData,
+            {
+                gcsUrl: "gs://bucket/media/b.png",
+                azureUrl: "https://azure.example/media/b.png?stale=sas",
+                blobPath: "media/b.png",
+                hash: "hash-b",
+            },
+            1,
+            true,
+        );
+
+        expect(taskData).toEqual({
+            inputImageUrl2: "gs://bucket/media/b.png",
+            inputImageBlobPath2: "media/b.png",
+            inputImageHash2: "hash-b",
+        });
+    });
+
+    test("adds stable file identifiers next to the input video URL", () => {
+        const taskData = {};
+
+        applyInputVideoReference(
+            taskData,
+            {
+                azureUrl: "https://azure.example/media/a.mp4?stale=sas",
+                gcsUrl: "gs://bucket/media/a.mp4",
+                blobPath: "media/a.mp4",
+                hash: "hash-video-a",
+            },
+            0,
+            true,
+        );
+
+        expect(taskData).toEqual({
+            inputVideoUrl: "gs://bucket/media/a.mp4",
+            inputVideoBlobPath: "media/a.mp4",
+            inputVideoHash: "hash-video-a",
+        });
+    });
+
+    test("stores display input image references with numbered fields", () => {
+        const mediaItemData = {};
+
+        applyStoredInputImageReference(
+            mediaItemData,
+            {
+                url: "https://display.example/media/d.png",
+                azureUrl: "https://azure.example/media/d.png?stale=sas",
+                gcsUrl: "gs://bucket/media/d.png",
+            },
+            3,
+        );
+
+        expect(mediaItemData).toEqual({
+            inputImageUrl4: "https://display.example/media/d.png",
+        });
+    });
+
+    test("stores display input video references", () => {
+        const mediaItemData = {};
+
+        applyStoredInputVideoReference(
+            mediaItemData,
+            {
+                url: "https://display.example/media/d.mp4",
+                azureUrl: "https://azure.example/media/d.mp4?stale=sas",
+                gcsUrl: "gs://bucket/media/d.mp4",
+            },
+            0,
+            "extend",
+        );
+
+        expect(mediaItemData).toEqual({
+            inputVideoUrl: "https://display.example/media/d.mp4",
+            inputVideoRole: "extend",
+        });
+    });
+
+    test("stores display input audio references", () => {
+        const mediaItemData = {};
+
+        applyStoredInputAudioReference(mediaItemData, {
+            type: "audio",
+            url: "https://display.example/media/source.wav",
+            azureUrl: "https://azure.example/media/source.wav?stale=sas",
+            blobPath: "media/source.wav",
+            hash: "hash-source",
+        });
+
+        expect(mediaItemData).toEqual({
+            inputAudioUrl: "https://display.example/media/source.wav",
+            inputAudioBlobPath: "media/source.wav",
+            inputAudioHash: "hash-source",
+        });
+    });
+
+    test("stores numbered input image roles", () => {
+        const taskData = {};
+
+        applyInputImageRole(taskData, "end_frame", 1);
+
+        expect(taskData).toEqual({
+            inputImageRole2: "end_frame",
+        });
+    });
+});
+
+describe("useMediaGeneration settings snapshot", () => {
+    test("queues generation with the latest settings ref", async () => {
+        const runTask = {
+            mutateAsync: jest.fn().mockResolvedValue({ taskId: "task-1" }),
+        };
+        const createMediaItem = {
+            mutateAsync: jest.fn().mockResolvedValue({}),
+        };
+        const promptRef = { current: { focus: jest.fn() } };
+        const staleSettings = {
+            models: {
+                "google-lyria-3-music": {
+                    type: "audio",
+                    duration: 30,
+                    audioUseCase: "music",
+                    audioStyle: "cinematic",
+                    audioMood: "focused",
+                },
+            },
+        };
+        const latestSettings = {
+            models: {
+                "google-lyria-3-music": {
+                    type: "audio",
+                    duration: 30,
+                    audioUseCase: "music",
+                    audioStyle: "orchestral",
+                    audioMood: "focused",
+                },
+            },
+        };
+        const expectedSettings = {
+            models: {
+                "google-lyria-3-music": {
+                    type: "audio",
+                },
+            },
+        };
+
+        const view = renderHook(() =>
+            useMediaGeneration({
+                selectedModel: "google-lyria-3-music",
+                outputType: "audio",
+                settings: staleSettings,
+                settingsRef: { current: latestSettings },
+                runTask,
+                createMediaItem,
+                promptRef,
+                setLoading: jest.fn(),
+            }),
+        );
+
+        await act(async () => {
+            await view.result.current.generateMedia("turkish music");
+        });
+
+        expect(runTask.mutateAsync).toHaveBeenCalledWith(
+            expect.objectContaining({
+                settings: expectedSettings,
+            }),
+        );
+        expect(createMediaItem.mutateAsync).toHaveBeenCalledWith(
+            expect.objectContaining({
+                settings: expectedSettings,
+            }),
+        );
+        expect(createMediaItem.mutateAsync).toHaveBeenCalledWith(
+            expect.not.objectContaining({
+                audioStyle: expect.anything(),
+                audioMood: expect.anything(),
+                audioUseCase: expect.anything(),
+                duration: expect.anything(),
+            }),
+        );
+    });
+
+    test("queues generation into the selected media folder", async () => {
+        const runTask = {
+            mutateAsync: jest.fn().mockResolvedValue({ taskId: "task-folder" }),
+        };
+        const createMediaItem = {
+            mutateAsync: jest.fn().mockResolvedValue({}),
+        };
+        const promptRef = { current: { focus: jest.fn() } };
+
+        const view = renderHook(() =>
+            useMediaGeneration({
+                selectedModel: "gpt-image-2",
+                outputType: "image",
+                settings: {
+                    models: {
+                        "gpt-image-2": {
+                            type: "image",
+                        },
+                    },
+                },
+                outputFolder: "Article Demo",
+                runTask,
+                createMediaItem,
+                promptRef,
+                setLoading: jest.fn(),
+            }),
+        );
+
+        await act(async () => {
+            await view.result.current.generateMedia("article hero image");
+        });
+
+        expect(runTask.mutateAsync).toHaveBeenCalledWith(
+            expect.objectContaining({
+                outputFolder: "Article Demo",
+            }),
+        );
+        expect(createMediaItem.mutateAsync).toHaveBeenCalledWith(
+            expect.objectContaining({
+                outputFolder: "Article Demo",
+                status: "pending",
+            }),
+        );
+    });
+
+    test("uses per-generation music settings overrides", async () => {
+        const runTask = {
+            mutateAsync: jest.fn().mockResolvedValue({ taskId: "task-music" }),
+        };
+        const createMediaItem = {
+            mutateAsync: jest.fn().mockResolvedValue({}),
+        };
+        const promptRef = { current: { focus: jest.fn() } };
+        const settings = {
+            models: {
+                "replicate-minimax-music-26": {
+                    type: "audio",
+                    isInstrumental: true,
+                },
+            },
+        };
+        const generationSettings = {
+            models: {
+                "replicate-minimax-music-26": {
+                    type: "audio",
+                    audioFormat: "mp3",
+                    sampleRate: 44100,
+                    bitrate: 256000,
+                    isInstrumental: false,
+                    lyricsOptimizer: true,
+                    lyrics: "Sunrise over the desert",
+                },
+            },
+        };
+
+        const view = renderHook(() =>
+            useMediaGeneration({
+                selectedModel: "replicate-minimax-music-26",
+                outputType: "audio",
+                settings,
+                runTask,
+                createMediaItem,
+                promptRef,
+                setLoading: jest.fn(),
+            }),
+        );
+
+        await act(async () => {
+            await view.result.current.generateMedia(
+                "cinematic desert pop",
+                null,
+                null,
+                "",
+                generationSettings,
+            );
+        });
+
+        expect(runTask.mutateAsync).toHaveBeenCalledWith(
+            expect.objectContaining({
+                settings: generationSettings,
+            }),
+        );
+        expect(createMediaItem.mutateAsync).toHaveBeenCalledWith(
+            expect.objectContaining({
+                settings: generationSettings,
+            }),
+        );
+    });
+
+    test("queues MiniMax cover with selected audio input", async () => {
+        const runTask = {
+            mutateAsync: jest.fn().mockResolvedValue({ taskId: "task-cover" }),
+        };
+        const createMediaItem = {
+            mutateAsync: jest.fn().mockResolvedValue({}),
+        };
+        const promptRef = { current: { focus: jest.fn() } };
+        const inputAudio = {
+            type: "audio",
+            url: "https://display.example/source.wav",
+            azureUrl: "https://azure.example/source.wav?stale=sas",
+            blobPath: "media/source.wav",
+            hash: "hash-source",
+        };
+        const settings = {
+            models: {
+                "replicate-minimax-music-cover": {
+                    type: "audio",
+                    audioFormat: "wav",
+                    sampleRate: 44100,
+                    bitrate: 256000,
+                },
+            },
+        };
+        const expectedSettings = {
+            models: {
+                "replicate-minimax-music-cover": {
+                    type: "audio",
+                },
+            },
+        };
+
+        const view = renderHook(() =>
+            useMediaGeneration({
+                selectedModel: "replicate-minimax-music-cover",
+                outputType: "audio",
+                settings,
+                runTask,
+                createMediaItem,
+                promptRef,
+                setLoading: jest.fn(),
+            }),
+        );
+
+        await act(async () => {
+            await view.result.current.generateMedia(
+                "add cello layer",
+                null,
+                null,
+                "",
+                null,
+                inputAudio,
+            );
+        });
+
+        expect(runTask.mutateAsync).toHaveBeenCalledWith(
+            expect.objectContaining({
+                model: "replicate-minimax-music-cover",
+                inputAudioUrl: "https://azure.example/source.wav?stale=sas",
+                inputAudioBlobPath: "media/source.wav",
+                inputAudioHash: "hash-source",
+                settings: expectedSettings,
+            }),
+        );
+        expect(createMediaItem.mutateAsync).toHaveBeenCalledWith(
+            expect.objectContaining({
+                model: "replicate-minimax-music-cover",
+                inputAudioUrl: "https://display.example/source.wav",
+                inputAudioBlobPath: "media/source.wav",
+                inputAudioHash: "hash-source",
+                settings: expectedSettings,
+            }),
+        );
+    });
+
+    test("queues image-only Lyria generation with selected image context", async () => {
+        mockMediaModels = [
+            {
+                modelId: "google-lyria-3-music",
+                preferredUrlFormat: "gcs",
+                mediaDefaults: {
+                    inputImages: [0, 1],
+                },
+            },
+        ];
+        const runTask = {
+            mutateAsync: jest.fn().mockResolvedValue({ taskId: "task-lyria" }),
+        };
+        const createMediaItem = {
+            mutateAsync: jest.fn().mockResolvedValue({}),
+        };
+        const promptRef = { current: { focus: jest.fn() } };
+
+        const view = renderHook(() =>
+            useMediaGeneration({
+                selectedModel: "google-lyria-3-music",
+                outputType: "audio",
+                settings: {
+                    models: {
+                        "google-lyria-3-music": {
+                            type: "audio",
+                        },
+                    },
+                },
+                runTask,
+                createMediaItem,
+                promptRef,
+                setLoading: jest.fn(),
+            }),
+        );
+
+        await act(async () => {
+            await view.result.current.handleModifySelected({
+                prompt: "",
+                selectedImagesObjects: [
+                    {
+                        type: "image",
+                        url: "https://display.example/reference.png",
+                        azureUrl:
+                            "https://azure.example/reference.png?stale=sas",
+                        gcsUrl: "gs://bucket/reference.png",
+                        blobPath: "media/reference.png",
+                        hash: "hash-reference",
+                        tags: ["newsroom"],
+                    },
+                ],
+                outputType: "audio",
+                selectedModel: "google-lyria-3-music",
+                settings: {
+                    models: {
+                        "google-lyria-3-music": {
+                            type: "audio",
+                        },
+                    },
+                },
+                runTask,
+                createMediaItem,
+                promptRef,
+            });
+        });
+
+        expect(runTask.mutateAsync).toHaveBeenCalledWith(
+            expect.objectContaining({
+                prompt: "",
+                displayPrompt: "Image-only music generation",
+                outputType: "audio",
+                model: "google-lyria-3-music",
+                inputImageUrl: "gs://bucket/reference.png",
+                inputImageBlobPath: "media/reference.png",
+                inputImageHash: "hash-reference",
+                inputTags: ["newsroom"],
+            }),
+        );
+        expect(createMediaItem.mutateAsync).toHaveBeenCalledWith(
+            expect.objectContaining({
+                prompt: "Image-only music generation",
+                type: "audio",
+                model: "google-lyria-3-music",
+                inputImageUrl: "https://display.example/reference.png",
+                tags: ["newsroom"],
+            }),
+        );
+    });
+
+    test("queues a selected video with the extend role as an input video", async () => {
+        mockMediaModels = [
+            {
+                modelId: "veo-3.1-generate",
+                preferredUrlFormat: "gcs",
+                mediaDefaults: {
+                    inputImages: [0, 3],
+                    inputVideos: [0, 1],
+                },
+                videoInputModes: ["extend"],
+            },
+        ];
+        const runTask = {
+            mutateAsync: jest.fn().mockResolvedValue({ taskId: "task-extend" }),
+        };
+        const createMediaItem = {
+            mutateAsync: jest.fn().mockResolvedValue({}),
+        };
+        const promptRef = { current: { focus: jest.fn() } };
+        const selectedImagesObjects = [
+            {
+                cortexRequestId: "video-reference-1",
+                type: "video",
+                url: "https://display.example/reference.mp4",
+                azureUrl: "https://azure.example/reference.mp4?stale=sas",
+                gcsUrl: "gs://bucket/reference.mp4",
+                blobPath: "media/reference.mp4",
+                hash: "hash-reference-video",
+                tags: ["source"],
+            },
+        ];
+
+        const view = renderHook(() =>
+            useMediaGeneration({
+                selectedModel: "veo-3.1-generate",
+                outputType: "video",
+                settings: {
+                    models: {
+                        "veo-3.1-generate": {
+                            type: "video",
+                        },
+                    },
+                },
+                runTask,
+                createMediaItem,
+                promptRef,
+                setLoading: jest.fn(),
+            }),
+        );
+
+        await act(async () => {
+            await view.result.current.handleModifySelected({
+                prompt: "continue this shot",
+                selectedImagesObjects,
+                outputType: "video",
+                selectedModel: "veo-3.1-generate",
+                settings: {
+                    models: {
+                        "veo-3.1-generate": {
+                            type: "video",
+                        },
+                    },
+                },
+                runTask,
+                createMediaItem,
+                promptRef,
+                inputImageRolesById: {
+                    "video-reference-1": "extend",
+                },
+            });
+        });
+
+        expect(runTask.mutateAsync).toHaveBeenCalledWith(
+            expect.objectContaining({
+                inputVideoUrl: "gs://bucket/reference.mp4",
+                inputVideoBlobPath: "media/reference.mp4",
+                inputVideoHash: "hash-reference-video",
+                inputVideoRole: "extend",
+                inputImageUrl: "",
+                inputTags: ["source"],
+            }),
+        );
+        expect(createMediaItem.mutateAsync).toHaveBeenCalledWith(
+            expect.objectContaining({
+                inputVideoUrl: "https://display.example/reference.mp4",
+                inputVideoRole: "extend",
+                tags: ["source"],
+            }),
+        );
+    });
+
+    test("queues and persists all selected input image references up to model limit", async () => {
+        mockMediaModels = [
+            {
+                modelId: "gemini-3-pro-image-preview",
+                preferredUrlFormat: "gcs",
+                mediaDefaults: {
+                    inputImages: [2, 4],
+                },
+            },
+        ];
+        const runTask = {
+            mutateAsync: jest
+                .fn()
+                .mockResolvedValue({ taskId: "task-combine" }),
+        };
+        const createMediaItem = {
+            mutateAsync: jest.fn().mockResolvedValue({}),
+        };
+        const promptRef = { current: { focus: jest.fn() } };
+        const selectedImagesObjects = Array.from({ length: 4 }, (_, index) => ({
+            cortexRequestId: `reference-${index + 1}`,
+            type: "image",
+            url: `https://display.example/reference-${index + 1}.png`,
+            azureUrl: `https://azure.example/reference-${index + 1}.png?stale=sas`,
+            gcsUrl: `gs://bucket/reference-${index + 1}.png`,
+        }));
+
+        const view = renderHook(() =>
+            useMediaGeneration({
+                selectedModel: "gemini-3-pro-image-preview",
+                outputType: "image",
+                settings: {
+                    models: {
+                        "gemini-3-pro-image-preview": {
+                            type: "image",
+                        },
+                    },
+                },
+                runTask,
+                createMediaItem,
+                promptRef,
+                setLoading: jest.fn(),
+            }),
+        );
+
+        await act(async () => {
+            await view.result.current.handleCombineSelected({
+                prompt: "combine references",
+                selectedImagesObjects,
+                outputType: "image",
+                selectedModel: "gemini-3-pro-image-preview",
+                settings: {
+                    models: {
+                        "gemini-3-pro-image-preview": {
+                            type: "image",
+                        },
+                    },
+                },
+                runTask,
+                createMediaItem,
+                promptRef,
+                inputImageRolesById: {
+                    "reference-1": "start_frame",
+                    "reference-2": "end_frame",
+                    "reference-3": "reference",
+                    "reference-4": "reference",
+                },
+            });
+        });
+
+        expect(runTask.mutateAsync).toHaveBeenCalledWith(
+            expect.objectContaining({
+                inputImageUrl: "gs://bucket/reference-1.png",
+                inputImageUrl2: "gs://bucket/reference-2.png",
+                inputImageUrl3: "gs://bucket/reference-3.png",
+                inputImageUrl4: "gs://bucket/reference-4.png",
+                inputImageRole: "start_frame",
+                inputImageRole2: "end_frame",
+                inputImageRole3: "reference",
+                inputImageRole4: "reference",
+            }),
+        );
+        expect(createMediaItem.mutateAsync).toHaveBeenCalledWith(
+            expect.objectContaining({
+                inputImageUrl: "https://display.example/reference-1.png",
+                inputImageUrl2: "https://display.example/reference-2.png",
+                inputImageUrl3: "https://display.example/reference-3.png",
+                inputImageUrl4: "https://display.example/reference-4.png",
+                inputImageRole: "start_frame",
+                inputImageRole2: "end_frame",
+                inputImageRole3: "reference",
+                inputImageRole4: "reference",
+            }),
+        );
+    });
+
+    test("queues only the first allowed reference when selected references exceed the model limit", async () => {
+        mockMediaModels = [
+            {
+                modelId: "veo-3.1-lite-generate",
+                preferredUrlFormat: "gcs",
+                mediaDefaults: {
+                    inputImages: [0, 3],
+                },
+                referenceImageRoleLimits: {
+                    reference: [0, 1],
+                    start_frame: [0, 1],
+                    end_frame: [0, 1],
+                },
+            },
+        ];
+        const runTask = {
+            mutateAsync: jest
+                .fn()
+                .mockResolvedValue({ taskId: "task-combine" }),
+        };
+        const createMediaItem = {
+            mutateAsync: jest.fn().mockResolvedValue({}),
+        };
+        const promptRef = { current: { focus: jest.fn() } };
+        const selectedImagesObjects = Array.from({ length: 2 }, (_, index) => ({
+            cortexRequestId: `reference-${index + 1}`,
+            type: "image",
+            url: `https://display.example/reference-${index + 1}.png`,
+            azureUrl: `https://azure.example/reference-${index + 1}.png?stale=sas`,
+            gcsUrl: `gs://bucket/reference-${index + 1}.png`,
+        }));
+
+        const view = renderHook(() =>
+            useMediaGeneration({
+                selectedModel: "veo-3.1-lite-generate",
+                outputType: "video",
+                settings: {
+                    models: {
+                        "veo-3.1-lite-generate": {
+                            type: "video",
+                            inputImages: [0, 1],
+                        },
+                    },
+                },
+                runTask,
+                createMediaItem,
+                promptRef,
+                setLoading: jest.fn(),
+            }),
+        );
+
+        await act(async () => {
+            await view.result.current.handleCombineSelected({
+                prompt: "combine references",
+                selectedImagesObjects,
+                outputType: "video",
+                selectedModel: "veo-3.1-lite-generate",
+                settings: {
+                    models: {
+                        "veo-3.1-lite-generate": {
+                            type: "video",
+                            inputImages: [0, 1],
+                        },
+                    },
+                },
+                runTask,
+                createMediaItem,
+                promptRef,
+                inputImageRolesById: {
+                    "reference-1": "reference",
+                    "reference-2": "reference",
+                },
+            });
+        });
+
+        expect(runTask.mutateAsync).toHaveBeenCalledWith(
+            expect.objectContaining({
+                inputImageUrl: "gs://bucket/reference-1.png",
+                inputImageRole: "reference",
+            }),
+        );
+        expect(runTask.mutateAsync.mock.calls[0][0]).not.toHaveProperty(
+            "inputImageUrl2",
+        );
+        expect(createMediaItem.mutateAsync).toHaveBeenCalledWith(
+            expect.objectContaining({
+                inputImageUrl: "https://display.example/reference-1.png",
+                inputImageRole: "reference",
+            }),
+        );
+        expect(createMediaItem.mutateAsync.mock.calls[0][0]).not.toHaveProperty(
+            "inputImageUrl2",
+        );
+    });
+
+    test("allows start and end frame references beyond the generic image limit", async () => {
+        mockMediaModels = [
+            {
+                modelId: "veo-3.1-lite-generate",
+                preferredUrlFormat: "gcs",
+                mediaDefaults: {
+                    inputImages: [0, 3],
+                },
+                referenceImageRoleLimits: {
+                    reference: [0, 1],
+                    start_frame: [0, 1],
+                    end_frame: [0, 1],
+                },
+            },
+        ];
+        const runTask = {
+            mutateAsync: jest
+                .fn()
+                .mockResolvedValue({ taskId: "task-combine" }),
+        };
+        const createMediaItem = {
+            mutateAsync: jest.fn().mockResolvedValue({}),
+        };
+        const promptRef = { current: { focus: jest.fn() } };
+        const selectedImagesObjects = Array.from({ length: 2 }, (_, index) => ({
+            cortexRequestId: `reference-${index + 1}`,
+            type: "image",
+            url: `https://display.example/reference-${index + 1}.png`,
+            azureUrl: `https://azure.example/reference-${index + 1}.png?stale=sas`,
+            gcsUrl: `gs://bucket/reference-${index + 1}.png`,
+        }));
+
+        const view = renderHook(() =>
+            useMediaGeneration({
+                selectedModel: "veo-3.1-lite-generate",
+                outputType: "video",
+                settings: {
+                    models: {
+                        "veo-3.1-lite-generate": {
+                            type: "video",
+                            inputImages: [0, 1],
+                        },
+                    },
+                },
+                runTask,
+                createMediaItem,
+                promptRef,
+                setLoading: jest.fn(),
+            }),
+        );
+
+        await act(async () => {
+            await view.result.current.handleCombineSelected({
+                prompt: "animate between frames",
+                selectedImagesObjects,
+                outputType: "video",
+                selectedModel: "veo-3.1-lite-generate",
+                settings: {
+                    models: {
+                        "veo-3.1-lite-generate": {
+                            type: "video",
+                            inputImages: [0, 1],
+                        },
+                    },
+                },
+                runTask,
+                createMediaItem,
+                promptRef,
+                inputImageRolesById: {
+                    "reference-1": "start_frame",
+                    "reference-2": "end_frame",
+                },
+            });
+        });
+
+        expect(runTask.mutateAsync).toHaveBeenCalledWith(
+            expect.objectContaining({
+                inputImageRole: "start_frame",
+                inputImageRole2: "end_frame",
+            }),
+        );
+        expect(createMediaItem.mutateAsync).toHaveBeenCalled();
+    });
+});

--- a/src/components/images/hooks/useMediaGeneration.js
+++ b/src/components/images/hooks/useMediaGeneration.js
@@ -1,21 +1,231 @@
 import { useCallback } from "react";
+import { useMediaModels } from "../../../../app/queries/modelMetadata";
+import { sanitizeMediaSettings } from "../../../utils/mediaGenerationSettings";
+import {
+    getImageReferenceLimitConfig,
+    selectImageReferencesWithinLimits,
+    validateImageReferenceLimits,
+} from "../mediaReferenceLimits";
 
 const LOADING_STATE_DELAY_MS = 1000;
+const IMAGE_ONLY_AUDIO_PROMPT = "Image-only music generation";
+export const MAX_INPUT_IMAGE_REFERENCES = 14;
+export const MAX_INPUT_VIDEO_REFERENCES = 1;
+const VIDEO_EXTEND_REFERENCE_ROLE = "extend";
+
+function getInputImageFieldName(base, index) {
+    return index === 0 ? base : `${base}${index + 1}`;
+}
+
+function getInputVideoFieldName(base, index) {
+    return index === 0 ? base : `${base}${index + 1}`;
+}
+
+export function hasUsableInputImageUrl(image) {
+    return Boolean(image?.url || image?.azureUrl || image?.gcsUrl);
+}
+
+export function hasUsableInputVideoUrl(video) {
+    return Boolean(video?.url || video?.azureUrl || video?.gcsUrl);
+}
+
+export function hasUsableInputAudioUrl(media) {
+    return (
+        media?.type === "audio" &&
+        Boolean(media?.url || media?.azureUrl || media?.gcsUrl)
+    );
+}
+
+export function getInputImageUrl(image, preferGcs = false) {
+    if (!image) return "";
+    if (preferGcs) {
+        return image.gcsUrl || image.azureUrl || image.url || "";
+    }
+    return image.azureUrl || image.gcsUrl || image.url || "";
+}
+
+export function getStoredInputImageUrl(image) {
+    return image?.url || image?.azureUrl || image?.gcsUrl || "";
+}
+
+export function getInputVideoUrl(video, preferGcs = false) {
+    return getInputImageUrl(video, preferGcs);
+}
+
+export function getStoredInputVideoUrl(video) {
+    return getStoredInputImageUrl(video);
+}
+
+export function getInputAudioUrl(media) {
+    if (!media) return "";
+    return media.azureUrl || media.url || media.gcsUrl || "";
+}
+
+export function getStoredInputAudioUrl(media) {
+    return media?.url || media?.azureUrl || media?.gcsUrl || "";
+}
+
+export function applyInputImageReference(taskData, image, index, preferGcs) {
+    const url = getInputImageUrl(image, preferGcs);
+    if (!url) return;
+
+    taskData[getInputImageFieldName("inputImageUrl", index)] = url;
+    if (image?.blobPath) {
+        taskData[getInputImageFieldName("inputImageBlobPath", index)] =
+            image.blobPath;
+    }
+    if (image?.hash) {
+        taskData[getInputImageFieldName("inputImageHash", index)] = image.hash;
+    }
+}
+
+export function applyInputVideoReference(taskData, video, index, preferGcs) {
+    const url = getInputVideoUrl(video, preferGcs);
+    if (!url) return;
+
+    taskData[getInputVideoFieldName("inputVideoUrl", index)] = url;
+    if (video?.blobPath) {
+        taskData[getInputVideoFieldName("inputVideoBlobPath", index)] =
+            video.blobPath;
+    }
+    if (video?.hash) {
+        taskData[getInputVideoFieldName("inputVideoHash", index)] = video.hash;
+    }
+}
+
+export function applyInputAudioReference(taskData, media) {
+    const url = getInputAudioUrl(media);
+    if (!url) return;
+
+    taskData.inputAudioUrl = url;
+    if (media?.blobPath) {
+        taskData.inputAudioBlobPath = media.blobPath;
+    }
+    if (media?.hash) {
+        taskData.inputAudioHash = media.hash;
+    }
+}
+
+export function applyInputImageRole(target, role, index) {
+    if (!role) return;
+    target[getInputImageFieldName("inputImageRole", index)] = role;
+}
+
+export function applyInputVideoRole(target, role, index) {
+    if (!role) return;
+    target[getInputVideoFieldName("inputVideoRole", index)] = role;
+}
+
+export function applyStoredInputImageReference(
+    mediaItemData,
+    image,
+    index,
+    role,
+) {
+    const url = getStoredInputImageUrl(image);
+    if (!url) return;
+
+    mediaItemData[getInputImageFieldName("inputImageUrl", index)] = url;
+    applyInputImageRole(mediaItemData, role, index);
+}
+
+export function applyStoredInputVideoReference(
+    mediaItemData,
+    video,
+    index,
+    role,
+) {
+    const url = getStoredInputVideoUrl(video);
+    if (!url) return;
+
+    mediaItemData[getInputVideoFieldName("inputVideoUrl", index)] = url;
+    applyInputVideoRole(mediaItemData, role, index);
+}
+
+export function applyStoredInputAudioReference(mediaItemData, media) {
+    const url = getStoredInputAudioUrl(media);
+    if (!url) return;
+
+    mediaItemData.inputAudioUrl = url;
+    if (media?.blobPath) {
+        mediaItemData.inputAudioBlobPath = media.blobPath;
+    }
+    if (media?.hash) {
+        mediaItemData.inputAudioHash = media.hash;
+    }
+}
+
+function getDisplayPrompt(prompt, outputType, hasInputImage) {
+    if (prompt?.trim()) return prompt;
+    if (outputType === "audio" && hasInputImage) return IMAGE_ONLY_AUDIO_PROMPT;
+    return prompt || "";
+}
+
+function getInputImageRole(image, rolesById) {
+    const id =
+        image?.cortexRequestId ||
+        image?.taskId ||
+        image?._id ||
+        image?.url ||
+        image?.azureUrl ||
+        image?.gcsUrl;
+    return rolesById?.[id] || image?.inputImageRole || "";
+}
+
+function isVideoExtendReference(media, rolesById) {
+    return (
+        media?.type === "video" &&
+        getInputImageRole(media, rolesById) === VIDEO_EXTEND_REFERENCE_ROLE
+    );
+}
+
+function isUsableGenerationReference(media, rolesById) {
+    if (media?.type === "image") {
+        return hasUsableInputImageUrl(media);
+    }
+    if (isVideoExtendReference(media, rolesById)) {
+        return hasUsableInputVideoUrl(media);
+    }
+    return false;
+}
+
+function normalizeOutputFolder(value) {
+    return String(value || "")
+        .trim()
+        .replace(/\\/g, "/")
+        .replace(/^\/+|\/+$/g, "")
+        .replace(/\/+/g, "/");
+}
 
 export const useMediaGeneration = ({
     selectedModel,
     outputType,
     settings,
+    settingsRef,
+    outputFolder = "",
     runTask,
     createMediaItem,
     promptRef,
     setLoading,
 }) => {
+    const { data: mediaModels } = useMediaModels();
     const generateMedia = useCallback(
-        async (prompt, inputImageUrl = null, modelOverride = null) => {
+        async (
+            prompt,
+            inputImageUrl = null,
+            modelOverride = null,
+            inputImageRole = "",
+            generationSettings = null,
+            inputAudio = null,
+        ) => {
             // Determine which model to use
             const modelToUse = modelOverride || selectedModel;
             const modelName = modelToUse;
+            const effectiveSettings = sanitizeMediaSettings(
+                generationSettings || settingsRef?.current || settings,
+            );
+            const modelSettings = effectiveSettings?.models?.[modelName] || {};
+            const normalizedOutputFolder = normalizeOutputFolder(outputFolder);
 
             try {
                 const taskData = {
@@ -24,11 +234,16 @@ export const useMediaGeneration = ({
                     outputType,
                     model: modelName,
                     inputImageUrl: inputImageUrl || "",
+                    inputImageRole: inputImageUrl ? inputImageRole : "",
                     inputImageUrl2: "",
                     inputImageUrl3: "",
-                    settings,
+                    settings: effectiveSettings,
                     source: "media_page",
+                    ...(normalizedOutputFolder && {
+                        outputFolder: normalizedOutputFolder,
+                    }),
                 };
+                applyInputAudioReference(taskData, inputAudio);
 
                 const result = await runTask.mutateAsync(taskData);
 
@@ -46,13 +261,22 @@ export const useMediaGeneration = ({
                         type: outputType,
                         model: modelName,
                         status: "pending",
-                        settings: settings,
+                        settings: effectiveSettings,
+                        ...(normalizedOutputFolder && {
+                            outputFolder: normalizedOutputFolder,
+                        }),
+                        ...(modelSettings.duration && {
+                            duration: modelSettings.duration,
+                        }),
                     };
 
-                    // Only add inputImageUrl if it exists
                     if (inputImageUrl) {
                         mediaItemData.inputImageUrl = inputImageUrl;
+                        if (inputImageRole) {
+                            mediaItemData.inputImageRole = inputImageRole;
+                        }
                     }
+                    applyStoredInputAudioReference(mediaItemData, inputAudio);
 
                     await createMediaItem.mutateAsync(mediaItemData);
 
@@ -69,8 +293,10 @@ export const useMediaGeneration = ({
         },
         [
             outputType,
+            outputFolder,
             selectedModel,
             settings,
+            settingsRef,
             runTask,
             createMediaItem,
             promptRef,
@@ -88,48 +314,78 @@ export const useMediaGeneration = ({
             runTask,
             createMediaItem,
             promptRef,
+            inputImageRolesById = {},
+            outputFolder = "",
+            inputAudio = null,
         }) => {
-            if (!prompt.trim() || selectedImagesObjects.length === 0) return;
-
             // Use the selectedImagesObjects array directly
-            const selectedImageObjects = selectedImagesObjects.filter(
-                (img) => img.url && img.type === "image",
+            const selectedReferenceObjects = selectedImagesObjects.filter(
+                (item) =>
+                    isUsableGenerationReference(item, inputImageRolesById),
             );
+            if (
+                selectedReferenceObjects.length === 0 ||
+                (!prompt.trim() && outputType !== "audio")
+            )
+                return;
+            const effectiveSettings = sanitizeMediaSettings(settings);
+            const normalizedOutputFolder = normalizeOutputFolder(outputFolder);
 
-            for (const image of selectedImageObjects) {
+            for (const image of selectedReferenceObjects) {
                 try {
                     const combinedPrompt = prompt;
+                    const referenceRole = getInputImageRole(
+                        image,
+                        inputImageRolesById,
+                    );
+                    const isVideoExtend = isVideoExtendReference(
+                        image,
+                        inputImageRolesById,
+                    );
 
-                    // For Veo and Gemini models, use GCS URL; for others, use Azure URL
-                    const isVeoModel = selectedModel.includes("veo");
-                    const isGeminiModel = selectedModel.includes("gemini");
-                    const inputImageUrl =
-                        isVeoModel || isGeminiModel
-                            ? image.gcsUrl || image.azureUrl || image.url
-                            : image.azureUrl || image.gcsUrl || image.url;
-
+                    // Use metadata to determine URL format preference
+                    const modelMeta = mediaModels?.find(
+                        (m) => m.modelId === selectedModel,
+                    );
+                    const preferGcs = modelMeta?.preferredUrlFormat === "gcs";
                     // Collect tags from input image
                     const inputTags = image.tags || [];
 
                     const taskData = {
                         type: "media-generation",
                         prompt: combinedPrompt,
+                        displayPrompt: getDisplayPrompt(
+                            combinedPrompt,
+                            outputType,
+                            true,
+                        ),
                         outputType,
                         model: selectedModel,
-                        inputImageUrl: inputImageUrl,
+                        inputImageUrl: "",
                         inputImageUrl2: "",
                         inputImageUrl3: "",
-                        settings,
+                        settings: effectiveSettings,
                         source: "media_page",
+                        ...(normalizedOutputFolder && {
+                            outputFolder: normalizedOutputFolder,
+                        }),
                         // Pass tags from input image for inheritance
                         inputTags: inputTags,
                     };
+                    if (isVideoExtend) {
+                        applyInputVideoReference(taskData, image, 0, preferGcs);
+                        applyInputVideoRole(taskData, referenceRole, 0);
+                    } else {
+                        applyInputImageReference(taskData, image, 0, preferGcs);
+                        applyInputImageRole(taskData, referenceRole, 0);
+                    }
+                    applyInputAudioReference(taskData, inputAudio);
 
                     const result = await runTask.mutateAsync(taskData);
 
                     if (result.taskId) {
                         // Task is queued, set loading to false (only for first image in batch)
-                        if (image === selectedImageObjects[0]) {
+                        if (image === selectedReferenceObjects[0]) {
                             setLoading?.(false);
                         }
 
@@ -137,19 +393,41 @@ export const useMediaGeneration = ({
                         const mediaItemData = {
                             taskId: result.taskId,
                             cortexRequestId: result.taskId,
-                            prompt: combinedPrompt,
+                            prompt: getDisplayPrompt(
+                                combinedPrompt,
+                                outputType,
+                                true,
+                            ),
                             type: outputType,
                             model: selectedModel,
                             status: "pending",
-                            settings: settings,
+                            settings: effectiveSettings,
+                            ...(normalizedOutputFolder && {
+                                outputFolder: normalizedOutputFolder,
+                            }),
                             // Include inherited tags
                             tags: inputTags,
                         };
 
-                        // Only add inputImageUrl if it exists
-                        if (image.url) {
-                            mediaItemData.inputImageUrl = image.url;
+                        if (isVideoExtend) {
+                            applyStoredInputVideoReference(
+                                mediaItemData,
+                                image,
+                                0,
+                                referenceRole,
+                            );
+                        } else {
+                            applyStoredInputImageReference(
+                                mediaItemData,
+                                image,
+                                0,
+                                referenceRole,
+                            );
                         }
+                        applyStoredInputAudioReference(
+                            mediaItemData,
+                            inputAudio,
+                        );
 
                         await createMediaItem.mutateAsync(mediaItemData);
                     }
@@ -164,7 +442,7 @@ export const useMediaGeneration = ({
                 promptRef.current && promptRef.current.focus();
             }, 0);
         },
-        [setLoading],
+        [mediaModels, setLoading],
     );
 
     const handleCombineSelected = useCallback(
@@ -177,43 +455,86 @@ export const useMediaGeneration = ({
             runTask,
             createMediaItem,
             promptRef,
+            inputImageRolesById = {},
+            outputFolder = "",
+            inputAudio = null,
         }) => {
             // Use the selectedImagesObjects array directly
-            const selectedImageObjects = selectedImagesObjects.filter(
-                (img) => img.url && img.type === "image",
+            const selectedReferenceObjects = selectedImagesObjects.filter(
+                (item) =>
+                    isUsableGenerationReference(item, inputImageRolesById),
+            );
+            const selectedImageObjects = selectedReferenceObjects.filter(
+                (item) => item.type === "image",
+            );
+            const selectedVideoObjects = selectedReferenceObjects.filter(
+                (item) => isVideoExtendReference(item, inputImageRolesById),
             );
 
-            // Check if this is gemini-3-pro-image-preview which supports up to 14 images
-            const isGemini3Pro = selectedModel === "gemini-3-pro-image-preview";
-            const maxImages = isGemini3Pro ? 14 : 3;
-            const minImages = 2;
+            const effectiveSettings = sanitizeMediaSettings(settings);
+            const modelMeta = mediaModels?.find(
+                (m) => m.modelId === selectedModel,
+            );
+            const modelSettings = effectiveSettings?.models?.[selectedModel];
+            const { totalMax: maxImages } = getImageReferenceLimitConfig(
+                modelMeta,
+                modelSettings,
+            );
+            const maxVideos =
+                modelMeta?.mediaDefaults?.inputVideos?.[1] ??
+                modelSettings?.inputVideos?.[1] ??
+                0;
+            const minReferences = selectedVideoObjects.length > 0 ? 1 : 2;
+            const normalizedOutputFolder = normalizeOutputFolder(outputFolder);
+            const getReferenceRole = (image) =>
+                getInputImageRole(image, inputImageRolesById);
 
             if (
-                !prompt.trim() ||
-                selectedImageObjects.length < minImages ||
-                selectedImageObjects.length > maxImages
+                (!prompt.trim() && outputType !== "audio") ||
+                selectedReferenceObjects.length < minReferences ||
+                selectedVideoObjects.length > maxVideos
             )
                 return;
+
+            const selectedImageObjectsForTask =
+                selectImageReferencesWithinLimits(selectedImageObjects, {
+                    modelMeta,
+                    modelSettings,
+                    getRole: getReferenceRole,
+                }).slice(0, Math.min(maxImages, MAX_INPUT_IMAGE_REFERENCES));
+
+            if (
+                selectedImageObjects.length > 0 &&
+                selectedImageObjectsForTask.length === 0
+            ) {
+                return;
+            }
+
+            const selectedReferencesForTask = [
+                ...selectedImageObjectsForTask,
+                ...selectedVideoObjects.slice(
+                    0,
+                    Math.min(maxVideos, MAX_INPUT_VIDEO_REFERENCES),
+                ),
+            ];
+            const isWithinImageReferenceLimits = validateImageReferenceLimits(
+                selectedImageObjectsForTask,
+                {
+                    modelMeta,
+                    modelSettings,
+                    getRole: getReferenceRole,
+                },
+            );
+            if (!isWithinImageReferenceLimits) return;
 
             try {
                 const combinedPrompt = prompt;
 
-                // For Veo and Gemini models, use GCS URL; for others, use Azure URL
-                const isVeoModel = selectedModel.includes("veo");
-                const isGeminiModel = selectedModel.includes("gemini");
-                const useGcsUrl = isVeoModel || isGeminiModel;
-
-                // Helper function to get the appropriate URL
-                const getImageUrl = (image) => {
-                    if (useGcsUrl) {
-                        return image.gcsUrl || image.azureUrl || image.url;
-                    }
-                    return image.azureUrl || image.gcsUrl || image.url;
-                };
-
+                // Use metadata to determine URL format preference
+                const preferGcs = modelMeta?.preferredUrlFormat === "gcs";
                 // Collect tags from all input images
                 const allInputTags = new Set();
-                selectedImageObjects.forEach((image) => {
+                selectedReferencesForTask.forEach((image) => {
                     if (image.tags && Array.isArray(image.tags)) {
                         image.tags.forEach((tag) => allInputTags.add(tag));
                     }
@@ -223,88 +544,48 @@ export const useMediaGeneration = ({
                 const taskData = {
                     type: "media-generation",
                     prompt: combinedPrompt,
+                    displayPrompt: getDisplayPrompt(
+                        combinedPrompt,
+                        outputType,
+                        true,
+                    ),
                     outputType,
                     model: selectedModel,
-                    settings,
+                    settings: effectiveSettings,
                     source: "media_page",
+                    ...(normalizedOutputFolder && {
+                        outputFolder: normalizedOutputFolder,
+                    }),
                     // Pass tags from all input images for inheritance
                     inputTags: Array.from(allInputTags),
                 };
 
-                // Add input images (up to 14 for gemini-3-pro-image-preview)
-                if (selectedImageObjects[0]) {
-                    taskData.inputImageUrl = getImageUrl(
-                        selectedImageObjects[0],
+                // Add generic image references up to the model limit while
+                // preserving explicit start/end frame references.
+                selectedImageObjectsForTask.forEach((image, index) => {
+                    applyInputImageReference(taskData, image, index, preferGcs);
+                    applyInputImageRole(
+                        taskData,
+                        getReferenceRole(image),
+                        index,
                     );
-                }
-                if (selectedImageObjects[1]) {
-                    taskData.inputImageUrl2 = getImageUrl(
-                        selectedImageObjects[1],
-                    );
-                }
-                if (selectedImageObjects[2]) {
-                    taskData.inputImageUrl3 = getImageUrl(
-                        selectedImageObjects[2],
-                    );
-                }
-                // Only add additional images if this is gemini-3-pro-image-preview
-                if (isGemini3Pro) {
-                    if (selectedImageObjects[3]) {
-                        taskData.inputImageUrl4 = getImageUrl(
-                            selectedImageObjects[3],
+                });
+                selectedVideoObjects
+                    .slice(0, Math.min(maxVideos, MAX_INPUT_VIDEO_REFERENCES))
+                    .forEach((video, index) => {
+                        applyInputVideoReference(
+                            taskData,
+                            video,
+                            index,
+                            preferGcs,
                         );
-                    }
-                    if (selectedImageObjects[4]) {
-                        taskData.inputImageUrl5 = getImageUrl(
-                            selectedImageObjects[4],
+                        applyInputVideoRole(
+                            taskData,
+                            getReferenceRole(video),
+                            index,
                         );
-                    }
-                    if (selectedImageObjects[5]) {
-                        taskData.inputImageUrl6 = getImageUrl(
-                            selectedImageObjects[5],
-                        );
-                    }
-                    if (selectedImageObjects[6]) {
-                        taskData.inputImageUrl7 = getImageUrl(
-                            selectedImageObjects[6],
-                        );
-                    }
-                    if (selectedImageObjects[7]) {
-                        taskData.inputImageUrl8 = getImageUrl(
-                            selectedImageObjects[7],
-                        );
-                    }
-                    if (selectedImageObjects[8]) {
-                        taskData.inputImageUrl9 = getImageUrl(
-                            selectedImageObjects[8],
-                        );
-                    }
-                    if (selectedImageObjects[9]) {
-                        taskData.inputImageUrl10 = getImageUrl(
-                            selectedImageObjects[9],
-                        );
-                    }
-                    if (selectedImageObjects[10]) {
-                        taskData.inputImageUrl11 = getImageUrl(
-                            selectedImageObjects[10],
-                        );
-                    }
-                    if (selectedImageObjects[11]) {
-                        taskData.inputImageUrl12 = getImageUrl(
-                            selectedImageObjects[11],
-                        );
-                    }
-                    if (selectedImageObjects[12]) {
-                        taskData.inputImageUrl13 = getImageUrl(
-                            selectedImageObjects[12],
-                        );
-                    }
-                    if (selectedImageObjects[13]) {
-                        taskData.inputImageUrl14 = getImageUrl(
-                            selectedImageObjects[13],
-                        );
-                    }
-                }
+                    });
+                applyInputAudioReference(taskData, inputAudio);
 
                 const result = await runTask.mutateAsync(taskData);
 
@@ -316,28 +597,44 @@ export const useMediaGeneration = ({
                     const mediaItemData = {
                         taskId: result.taskId,
                         cortexRequestId: result.taskId,
-                        prompt: combinedPrompt,
+                        prompt: getDisplayPrompt(
+                            combinedPrompt,
+                            outputType,
+                            true,
+                        ),
                         type: outputType,
                         model: selectedModel,
                         status: "pending",
-                        settings: settings,
+                        settings: effectiveSettings,
+                        ...(normalizedOutputFolder && {
+                            outputFolder: normalizedOutputFolder,
+                        }),
                         // Include inherited tags
                         tags: Array.from(allInputTags),
                     };
 
-                    // Add input image URLs to media item data
-                    if (selectedImageObjects[0]?.url) {
-                        mediaItemData.inputImageUrl =
-                            selectedImageObjects[0].url;
-                    }
-                    if (selectedImageObjects[1]?.url) {
-                        mediaItemData.inputImageUrl2 =
-                            selectedImageObjects[1].url;
-                    }
-                    if (selectedImageObjects[2]?.url) {
-                        mediaItemData.inputImageUrl3 =
-                            selectedImageObjects[2].url;
-                    }
+                    selectedImageObjectsForTask.forEach((image, index) => {
+                        applyStoredInputImageReference(
+                            mediaItemData,
+                            image,
+                            index,
+                            getReferenceRole(image),
+                        );
+                    });
+                    selectedVideoObjects
+                        .slice(
+                            0,
+                            Math.min(maxVideos, MAX_INPUT_VIDEO_REFERENCES),
+                        )
+                        .forEach((video, index) => {
+                            applyStoredInputVideoReference(
+                                mediaItemData,
+                                video,
+                                index,
+                                getReferenceRole(video),
+                            );
+                        });
+                    applyStoredInputAudioReference(mediaItemData, inputAudio);
 
                     await createMediaItem.mutateAsync(mediaItemData);
 
@@ -353,7 +650,7 @@ export const useMediaGeneration = ({
                 setLoading?.(false);
             }
         },
-        [setLoading],
+        [mediaModels, setLoading],
     );
 
     return {

--- a/src/components/images/mediaReferenceLimits.js
+++ b/src/components/images/mediaReferenceLimits.js
@@ -1,0 +1,101 @@
+export function getRangeMax(range, fallback = Infinity) {
+    if (Array.isArray(range)) {
+        const max = Number(range[1] ?? range[0]);
+        return Number.isFinite(max) ? max : fallback;
+    }
+    const max = Number(range);
+    return Number.isFinite(max) ? max : fallback;
+}
+
+function getRoleLimitMax(roleLimits, role, fallback) {
+    if (!roleLimits || typeof roleLimits !== "object") return fallback;
+    const range = roleLimits[role] ?? roleLimits.default;
+    if (range === undefined) return fallback;
+    return getRangeMax(range, fallback);
+}
+
+export function getImageReferenceLimitConfig(modelMeta, modelSettings = {}) {
+    const mediaDefaults = modelMeta?.mediaDefaults || {};
+    return {
+        totalMax: getRangeMax(
+            mediaDefaults.inputImages ?? modelSettings?.inputImages,
+            3,
+        ),
+        roleLimits:
+            modelMeta?.referenceImageRoleLimits ||
+            modelMeta?.imageReferenceRoleLimits ||
+            modelMeta?.inputImageRoleLimits ||
+            null,
+    };
+}
+
+export function getReferenceRoleLimitMax(modelMeta, role, modelSettings = {}) {
+    const config = getImageReferenceLimitConfig(modelMeta, modelSettings);
+    return getRoleLimitMax(
+        config.roleLimits,
+        role || "reference",
+        config.totalMax,
+    );
+}
+
+export function getVideoFrameReferenceRoles(modelMeta) {
+    return new Set(modelMeta?.videoFrameReferenceRoles || []);
+}
+
+export function isVideoFrameReferenceRole(modelMeta, role) {
+    return getVideoFrameReferenceRoles(modelMeta).has(role);
+}
+
+export function validateImageReferenceLimits(
+    images,
+    { modelMeta, modelSettings, getRole } = {},
+) {
+    const imageItems = (images || []).filter((item) => item?.type === "image");
+    const config = getImageReferenceLimitConfig(modelMeta, modelSettings);
+    if (imageItems.length > config.totalMax) return false;
+
+    if (!config.roleLimits) return true;
+
+    const countsByRole = new Map();
+    for (const image of imageItems) {
+        const role = getRole?.(image) || "reference";
+        const nextCount = (countsByRole.get(role) || 0) + 1;
+        countsByRole.set(role, nextCount);
+        if (
+            nextCount >
+            getRoleLimitMax(config.roleLimits, role, config.totalMax)
+        ) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+export function selectImageReferencesWithinLimits(
+    images,
+    { modelMeta, modelSettings, getRole } = {},
+) {
+    const imageItems = (images || []).filter((item) => item?.type === "image");
+    const config = getImageReferenceLimitConfig(modelMeta, modelSettings);
+    const selected = [];
+    const countsByRole = new Map();
+
+    for (const image of imageItems) {
+        if (selected.length >= config.totalMax) break;
+
+        const role = getRole?.(image) || "reference";
+        const roleCount = countsByRole.get(role) || 0;
+        const roleMax = getRoleLimitMax(
+            config.roleLimits,
+            role,
+            config.totalMax,
+        );
+        if (roleCount >= roleMax) continue;
+
+        selected.push(image);
+        countsByRole.set(role, roleCount + 1);
+    }
+
+    return selected;
+}

--- a/src/graphql.js
+++ b/src/graphql.js
@@ -971,6 +971,147 @@ const VIDEO_SEEDANCE = gql`
     }
 `;
 
+const MEDIA_GENERATE = gql`
+    query MediaGenerate(
+        $model: String!
+        $text: String!
+        $async: Boolean
+        $inputImages: [String]
+        $inputImageRoles: [String]
+        $inputVideos: [String]
+        $aspectRatio: String
+        $duration: Int
+        $outputFormat: String
+        $outputQuality: Int
+        $quality: String
+        $negativePrompt: String
+        $numberResults: Int
+        $seed: Int
+        $optimizePrompt: Boolean
+        $generateAudio: Boolean
+        $forceInstrumental: Boolean
+        $resolution: String
+        $cameraFixed: Boolean
+        $enhancePrompt: Boolean
+        $imageSize: String
+        $width: Int
+        $height: Int
+        $size: String
+        $lyrics: String
+        $isInstrumental: Boolean
+        $lyricsOptimizer: Boolean
+        $audioUrl: String
+        $inputAudioUrl: String
+        $audioFormat: String
+        $sampleRate: Int
+        $bitrate: Int
+        $voiceName: String
+        $speaker1Name: String
+        $speaker1VoiceName: String
+        $speaker2Name: String
+        $speaker2VoiceName: String
+        $mode: String
+        $language: String
+        $speaker: String
+        $referenceText: String
+        $styleInstruction: String
+        $voiceDescription: String
+        $voice: String
+        $stability: Float
+        $similarityBoost: Float
+        $style: Float
+        $speed: Float
+        $previousText: String
+        $nextText: String
+        $languageCode: String
+        $voiceId: String
+        $customVoiceId: String
+        $volume: Float
+        $pitch: Int
+        $emotion: String
+        $channel: String
+        $languageBoost: String
+        $subtitleEnable: Boolean
+        $englishNormalization: Boolean
+        $contextId: String
+    ) {
+        media_generate(
+            model: $model
+            text: $text
+            async: $async
+            inputImages: $inputImages
+            inputImageRoles: $inputImageRoles
+            inputVideos: $inputVideos
+            aspectRatio: $aspectRatio
+            duration: $duration
+            outputFormat: $outputFormat
+            outputQuality: $outputQuality
+            quality: $quality
+            negativePrompt: $negativePrompt
+            numberResults: $numberResults
+            seed: $seed
+            optimizePrompt: $optimizePrompt
+            generateAudio: $generateAudio
+            forceInstrumental: $forceInstrumental
+            resolution: $resolution
+            cameraFixed: $cameraFixed
+            enhancePrompt: $enhancePrompt
+            imageSize: $imageSize
+            width: $width
+            height: $height
+            size: $size
+            lyrics: $lyrics
+            isInstrumental: $isInstrumental
+            lyricsOptimizer: $lyricsOptimizer
+            audioUrl: $audioUrl
+            inputAudioUrl: $inputAudioUrl
+            audioFormat: $audioFormat
+            sampleRate: $sampleRate
+            bitrate: $bitrate
+            voiceName: $voiceName
+            speaker1Name: $speaker1Name
+            speaker1VoiceName: $speaker1VoiceName
+            speaker2Name: $speaker2Name
+            speaker2VoiceName: $speaker2VoiceName
+            mode: $mode
+            language: $language
+            speaker: $speaker
+            referenceText: $referenceText
+            styleInstruction: $styleInstruction
+            voiceDescription: $voiceDescription
+            voice: $voice
+            stability: $stability
+            similarityBoost: $similarityBoost
+            style: $style
+            speed: $speed
+            previousText: $previousText
+            nextText: $nextText
+            languageCode: $languageCode
+            voiceId: $voiceId
+            customVoiceId: $customVoiceId
+            volume: $volume
+            pitch: $pitch
+            emotion: $emotion
+            channel: $channel
+            languageBoost: $languageBoost
+            subtitleEnable: $subtitleEnable
+            englishNormalization: $englishNormalization
+            contextId: $contextId
+        ) {
+            result
+            resultData
+        }
+    }
+`;
+
+const MEDIA_PROMPT_TAGS = gql`
+    query MediaPromptTags($text: String!) {
+        media_prompt_tags(text: $text) {
+            result
+        }
+    }
+`;
+
 const JIRA_STORY = gql`
     query JiraStory(
         $text: String!
@@ -1113,6 +1254,8 @@ const QUERIES = {
     IMAGE_FLUX,
     IMAGE_GEMINI_25,
     IMAGE_GEMINI_3,
+    MEDIA_GENERATE,
+    MEDIA_PROMPT_TAGS,
     VIDEO_VEO,
     VIDEO_SEEDANCE,
     SYS_READ_MEMORY,
@@ -1235,6 +1378,8 @@ export {
     IMAGE_GEMINI_3,
     IMAGE_QWEN,
     IMAGE_SEEDREAM4,
+    MEDIA_GENERATE,
+    MEDIA_PROMPT_TAGS,
     VIDEO_VEO,
     VIDEO_SEEDANCE,
     GRAMMAR,

--- a/src/utils/__tests__/mediaGenerationSettings.test.js
+++ b/src/utils/__tests__/mediaGenerationSettings.test.js
@@ -1,0 +1,93 @@
+import { sanitizeMediaSettings } from "../mediaGenerationSettings";
+
+describe("sanitizeMediaSettings", () => {
+    test("removes obsolete audio model prompt fragments", () => {
+        const settings = {
+            models: {
+                "google-lyria-3-music": {
+                    type: "audio",
+                    duration: 30,
+                    audioUseCase: "music",
+                    audioStyle: "cinematic",
+                    audioMood: "focused",
+                    negativePrompt: "vocals",
+                    negative_prompt: "drums",
+                },
+                "replicate-seedance-1-pro": {
+                    type: "video",
+                    duration: 5,
+                },
+            },
+        };
+
+        expect(sanitizeMediaSettings(settings)).toEqual({
+            models: {
+                "google-lyria-3-music": {
+                    type: "audio",
+                },
+                "replicate-seedance-1-pro": {
+                    type: "video",
+                    duration: 5,
+                },
+            },
+        });
+    });
+
+    test("removes obsolete legacy audio defaults", () => {
+        expect(
+            sanitizeMediaSettings({
+                audio: {
+                    defaultModel: "google-lyria-3-music",
+                    defaultDuration: 30,
+                    defaultUseCase: "music",
+                    defaultStyle: "cinematic",
+                    defaultMood: "focused",
+                },
+            }),
+        ).toEqual({
+            audio: {
+                defaultModel: "google-lyria-3-music",
+            },
+        });
+    });
+
+    test("removes obsolete Lyria model settings even without a saved type", () => {
+        expect(
+            sanitizeMediaSettings({
+                models: {
+                    "google-lyria-3-music": {
+                        duration: 30,
+                        audioUseCase: "music",
+                        audioStyle: "ambient",
+                        audioMood: "warm",
+                    },
+                },
+            }),
+        ).toEqual({
+            models: {
+                "google-lyria-3-music": {},
+            },
+        });
+    });
+
+    test("removes unsupported output controls from MiniMax Music Cover", () => {
+        expect(
+            sanitizeMediaSettings({
+                models: {
+                    "replicate-minimax-music-cover": {
+                        type: "audio",
+                        audioFormat: "wav",
+                        sampleRate: 44100,
+                        bitrate: 256000,
+                    },
+                },
+            }),
+        ).toEqual({
+            models: {
+                "replicate-minimax-music-cover": {
+                    type: "audio",
+                },
+            },
+        });
+    });
+});

--- a/src/utils/mediaGeneratedFilename.js
+++ b/src/utils/mediaGeneratedFilename.js
@@ -1,0 +1,55 @@
+export function getGeneratedMediaTaskSuffix(taskId) {
+    return String(taskId || "")
+        .toLowerCase()
+        .replace(/[^a-z0-9-]/g, "")
+        .slice(-12);
+}
+
+export function getGeneratedMediaFilenameStem(
+    prompt,
+    { index = 0, uniqueSuffix = "" } = {},
+) {
+    const suffix = index > 0 ? `-${index}` : "";
+    const normalizedUniqueSuffix = uniqueSuffix
+        ? `-${String(uniqueSuffix)
+              .toLowerCase()
+              .replace(/[^a-z0-9-]/g, "")
+              .slice(-12)}`
+        : "";
+
+    if (!prompt || typeof prompt !== "string") {
+        return `media${suffix}${normalizedUniqueSuffix}`;
+    }
+
+    let name = prompt
+        .toLowerCase()
+        .replace(/[_\s]+/g, "-")
+        .replace(/[^a-z0-9-]/g, "")
+        .replace(/-+/g, "-")
+        .replace(/^-|-$/g, "");
+
+    if (name.length > 60) {
+        name = name.substring(0, 60);
+        const lastHyphen = name.lastIndexOf("-");
+        if (lastHyphen > 20) name = name.substring(0, lastHyphen);
+    }
+
+    return `${name || "media"}${suffix}${normalizedUniqueSuffix}`;
+}
+
+export function getGeneratedMediaFilename(prompt, extension, options = {}) {
+    const ext = extension || "bin";
+    return `${getGeneratedMediaFilenameStem(prompt, options)}.${ext}`;
+}
+
+export function getExpectedGeneratedMediaFilenameStem(mediaItem) {
+    const taskSuffix = getGeneratedMediaTaskSuffix(
+        mediaItem?.taskId || mediaItem?.cortexRequestId,
+    );
+    if (!taskSuffix) return "";
+
+    return getGeneratedMediaFilenameStem(
+        mediaItem?.displayPrompt || mediaItem?.prompt,
+        { uniqueSuffix: taskSuffix },
+    );
+}

--- a/src/utils/mediaGenerationSettings.js
+++ b/src/utils/mediaGenerationSettings.js
@@ -1,0 +1,130 @@
+const OBSOLETE_AUDIO_PROMPT_SETTING_KEYS = [
+    "audioUseCase",
+    "audioStyle",
+    "audioMood",
+];
+
+const OBSOLETE_AUDIO_MODEL_SETTING_KEYS = [
+    "duration",
+    "negativePrompt",
+    "negative_prompt",
+];
+
+const AUDIO_MODELS_WITH_DURATION_CONTROL = new Set([
+    "replicate-elevenlabs-music",
+]);
+
+const UNSUPPORTED_MINIMAX_COVER_SETTING_KEYS = [
+    "audioFormat",
+    "audio_format",
+    "sampleRate",
+    "sample_rate",
+    "bitrate",
+];
+
+const OBSOLETE_AUDIO_DEFAULT_KEYS = [
+    "defaultDuration",
+    "defaultUseCase",
+    "defaultStyle",
+    "defaultMood",
+];
+
+function hasAnyKey(source, keys) {
+    return keys.some((key) => key in source);
+}
+
+function isAudioModelSettings(modelSettings, modelId = "") {
+    return (
+        modelSettings?.type === "audio" ||
+        /lyria|music/i.test(modelId) ||
+        hasAnyKey(modelSettings, OBSOLETE_AUDIO_PROMPT_SETTING_KEYS)
+    );
+}
+
+function isMiniMaxCoverModel(modelId = "") {
+    return modelId === "replicate-minimax-music-cover";
+}
+
+export function sanitizeMediaModelSettings(modelSettings = {}, modelId = "") {
+    if (!modelSettings || typeof modelSettings !== "object") {
+        return modelSettings;
+    }
+
+    const obsoleteKeys = [
+        ...OBSOLETE_AUDIO_PROMPT_SETTING_KEYS,
+        ...(isAudioModelSettings(modelSettings, modelId)
+            ? OBSOLETE_AUDIO_MODEL_SETTING_KEYS.filter(
+                  (key) =>
+                      key !== "duration" ||
+                      !AUDIO_MODELS_WITH_DURATION_CONTROL.has(modelId),
+              )
+            : []),
+        ...(isMiniMaxCoverModel(modelId)
+            ? UNSUPPORTED_MINIMAX_COVER_SETTING_KEYS
+            : []),
+    ];
+
+    if (!hasAnyKey(modelSettings, obsoleteKeys)) {
+        return modelSettings;
+    }
+
+    const sanitized = { ...modelSettings };
+    for (const key of obsoleteKeys) {
+        delete sanitized[key];
+    }
+    return sanitized;
+}
+
+export function sanitizeLegacyAudioDefaults(audioSettings = {}) {
+    if (!audioSettings || typeof audioSettings !== "object") {
+        return audioSettings;
+    }
+
+    if (!OBSOLETE_AUDIO_DEFAULT_KEYS.some((key) => key in audioSettings)) {
+        return audioSettings;
+    }
+
+    const sanitized = { ...audioSettings };
+    for (const key of OBSOLETE_AUDIO_DEFAULT_KEYS) {
+        delete sanitized[key];
+    }
+    return sanitized;
+}
+
+export function sanitizeMediaSettings(settings = {}) {
+    if (!settings || typeof settings !== "object") {
+        return settings;
+    }
+
+    let changed = false;
+    let models = settings.models;
+
+    if (settings.models) {
+        models = {};
+        for (const [modelId, modelSettings] of Object.entries(
+            settings.models,
+        )) {
+            const sanitized = sanitizeMediaModelSettings(
+                modelSettings,
+                modelId,
+            );
+            models[modelId] = sanitized;
+            changed = changed || sanitized !== modelSettings;
+        }
+    }
+
+    const audio = sanitizeLegacyAudioDefaults(settings.audio);
+    if (audio !== settings.audio) {
+        changed = true;
+    }
+
+    if (!changed) {
+        return settings;
+    }
+
+    return {
+        ...settings,
+        ...(settings.models ? { models } : {}),
+        ...(settings.audio ? { audio } : {}),
+    };
+}

--- a/src/utils/mediaPromptTags.js
+++ b/src/utils/mediaPromptTags.js
@@ -1,0 +1,60 @@
+export const MAX_AUTO_TAGS = 8;
+
+export function normalizeMediaTag(tag) {
+    return String(tag || "")
+        .trim()
+        .toLowerCase()
+        .replace(/\s+/g, " ")
+        .slice(0, 48);
+}
+
+export function mergeMediaTags(...tagLists) {
+    const merged = [];
+    const seen = new Set();
+
+    for (const tagList of tagLists) {
+        if (!Array.isArray(tagList)) continue;
+
+        for (const tag of tagList) {
+            const normalized = normalizeMediaTag(tag);
+            if (!normalized || seen.has(normalized)) continue;
+            seen.add(normalized);
+            merged.push(normalized);
+        }
+    }
+
+    return merged;
+}
+
+function extractJsonCandidate(value) {
+    if (typeof value !== "string") return value;
+
+    const trimmed = value.trim();
+    const fenceMatch = trimmed.match(/```(?:json)?\s*([\s\S]*?)```/i);
+    if (fenceMatch) return fenceMatch[1].trim();
+
+    return trimmed;
+}
+
+export function parseMediaPromptTagsResult(result) {
+    if (!result) return [];
+
+    let parsed = result;
+    if (typeof parsed === "string") {
+        try {
+            parsed = JSON.parse(extractJsonCandidate(parsed));
+        } catch {
+            return mergeMediaTags(
+                parsed
+                    .split(/[,\n]/)
+                    .map((tag) => tag.replace(/^[-*\d.\s]+/, "")),
+            ).slice(0, MAX_AUTO_TAGS);
+        }
+    }
+
+    const tags = Array.isArray(parsed)
+        ? parsed
+        : parsed?.tags || parsed?.mediaTags || parsed?.keywords || [];
+
+    return mergeMediaTags(tags).slice(0, MAX_AUTO_TAGS);
+}


### PR DESCRIPTION
## Summary
- route media generation through the generic Cortex media_generate contract with model metadata, prompt tagging, file naming, and refreshed storage URL handling
- extend media item records to preserve audio, video, image reference roles, generated file metadata, and output folders
- add reusable media settings/reference utilities plus structural tests for worker, GraphQL, and hook wiring

## Validation
- npm test -- jobs/__tests__/media-generate-quality-wiring.test.js src/components/images/hooks/__tests__/useMediaGeneration.test.js src/utils/__tests__/mediaGenerationSettings.test.js --runInBand --silent --openHandlesTimeout=1000
- npm test -- --runInBand --silent --openHandlesTimeout=1000
- npm run build
- git diff --cached --check
- staged forbidden brand/secret scan