### PR TITLE
Add automation schedule foundation

### DIFF
--- a/app/api/automations/utils.js
+++ b/app/api/automations/utils.js
@@ -1,0 +1,747 @@
+import mongoose from "mongoose";
+import sanitizeHtml from "sanitize-html";
+import Automation from "../models/automation.js";
+import {
+    deleteMediaFile,
+    hashBuffer,
+    listAutomationFiles,
+    readBlobContent,
+    uploadBufferToMediaService,
+} from "../utils/media-service-utils.js";
+import { createAutomationStorageTarget } from "../../../src/utils/storageTargets.js";
+
+export const AUTOMATION_MD = "AUTOMATION.md";
+export const AUTOMATION_TASK_TYPE = "automation-run";
+const ACTIVE_TASK_STATUSES = ["pending", "in_progress"];
+
+function stripJsonFence(value) {
+    return String(value || "")
+        .trim()
+        .replace(/^```(?:json)?\s*/i, "")
+        .replace(/\s*```$/i, "")
+        .trim();
+}
+
+function extractBalancedJsonObject(text) {
+    const start = text.indexOf("{");
+    if (start < 0) return "";
+
+    let depth = 0;
+    let inString = false;
+    let escaped = false;
+
+    for (let index = start; index < text.length; index += 1) {
+        const char = text[index];
+
+        if (escaped) {
+            escaped = false;
+            continue;
+        }
+        if (char === "\\") {
+            escaped = inString;
+            continue;
+        }
+        if (char === '"') {
+            inString = !inString;
+            continue;
+        }
+        if (inString) continue;
+
+        if (char === "{") {
+            depth += 1;
+        } else if (char === "}") {
+            depth -= 1;
+            if (depth === 0) {
+                return text.slice(start, index + 1);
+            }
+        }
+    }
+
+    return "";
+}
+
+function getJsonParseCandidates(text) {
+    const candidates = [stripJsonFence(text)];
+    const fencedJson = text.match(/```(?:json)?\s*([\s\S]*?)```/i)?.[1]?.trim();
+    if (fencedJson) {
+        candidates.push(fencedJson);
+    }
+    const balancedJson = extractBalancedJsonObject(text);
+    if (balancedJson) {
+        candidates.push(balancedJson);
+    }
+
+    return [...new Set(candidates.filter(Boolean))];
+}
+
+function coerceAutomationText(value) {
+    if (value === undefined || value === null || value === "") {
+        return "";
+    }
+    if (typeof value === "string") {
+        return value;
+    }
+    try {
+        return JSON.stringify(value, null, 2);
+    } catch {
+        return String(value);
+    }
+}
+
+export function parseAutomationResult(
+    rawResult,
+    producesHtml = false,
+    depth = 0,
+) {
+    if (depth > 4) {
+        return { summary: coerceAutomationText(rawResult), html: "" };
+    }
+
+    if (rawResult && typeof rawResult === "object") {
+        const html =
+            coerceAutomationText(
+                rawResult.html ||
+                    rawResult.htmlOutput ||
+                    rawResult.outputHtml ||
+                    rawResult.renderedHtml,
+            ) || "";
+        const nestedCandidate =
+            rawResult.result ||
+            rawResult.output ||
+            rawResult.payload ||
+            rawResult.content ||
+            "";
+        const nested = nestedCandidate
+            ? parseAutomationResult(nestedCandidate, producesHtml, depth + 1)
+            : { summary: "", html: "" };
+
+        return {
+            summary:
+                coerceAutomationText(rawResult.summary) ||
+                nested.summary ||
+                (!html ? coerceAutomationText(nestedCandidate) : ""),
+            html: html || nested.html,
+        };
+    }
+
+    const text = String(rawResult || "").trim();
+    if (!text) {
+        return { summary: "", html: "" };
+    }
+
+    for (const candidate of getJsonParseCandidates(text)) {
+        try {
+            const parsed = JSON.parse(candidate);
+            return parseAutomationResult(parsed, producesHtml, depth + 1);
+        } catch {
+            // Keep trying more specific candidates before falling back to text/HTML parsing.
+        }
+    }
+
+    if (!producesHtml) {
+        return { summary: text, html: "" };
+    }
+
+    const htmlMatch = text.match(/<!doctype html[\s\S]*|<html[\s\S]*/i);
+    const looksLikeHtml =
+        /<[a-z][\w:-]*(?:\s[^>]*)?>[\s\S]*<\/[a-z][\w:-]*>/i.test(text);
+    return {
+        summary: htmlMatch
+            ? text.slice(0, htmlMatch.index).trim()
+            : looksLikeHtml
+              ? "Automation completed."
+              : text,
+        html: htmlMatch ? htmlMatch[0].trim() : looksLikeHtml ? text : "",
+    };
+}
+
+export function parseAutomationTaskOutput(taskOrData) {
+    const data = taskOrData?.data || taskOrData || {};
+    const candidates = [
+        data?.html,
+        data?.summary,
+        data?.result,
+        data?.payload,
+        data?.output,
+        data?.content,
+        data,
+    ].filter((candidate) => candidate !== undefined && candidate !== null);
+    let summary = "";
+
+    for (const candidate of candidates) {
+        const parsed = parseAutomationResult(candidate, true);
+        if (!summary && parsed.summary) {
+            summary = parsed.summary;
+        }
+        if (parsed.html) {
+            return {
+                summary: parsed.summary || summary,
+                html: parsed.html,
+            };
+        }
+    }
+
+    return { summary, html: "" };
+}
+
+const BASE_ALLOWED_TAGS = sanitizeHtml.defaults.allowedTags.filter(
+    (tag) => !["script", "iframe", "object", "embed"].includes(tag),
+);
+const DOCUMENT_TAGS = [
+    "html",
+    "head",
+    "body",
+    "title",
+    "meta",
+    "link",
+    "style",
+];
+/** sanitize-html defaults allow figure/figcaption but not img — include img so hero images persist. */
+const AUTOMATION_EXTRA_TAGS = ["img"];
+const COMMON_ATTRIBUTES = {
+    ...sanitizeHtml.defaults.allowedAttributes,
+    "*": [
+        "class",
+        "id",
+        "title",
+        "style",
+        "role",
+        "aria-label",
+        "aria-hidden",
+        "data-theme",
+    ],
+    a: ["href", "name", "target", "rel"],
+    img: ["src", "srcset", "alt", "title", "width", "height", "loading"],
+    meta: ["charset", "name", "content", "http-equiv"],
+    link: ["rel", "href", "type", "media"],
+    html: ["lang", "dir", "data-theme"],
+};
+const COMMON_OPTIONS = {
+    allowedAttributes: COMMON_ATTRIBUTES,
+    allowedSchemes: ["http", "https", "mailto", "tel", "data"],
+    allowedSchemesByTag: { img: ["http", "https", "data"] },
+    allowProtocolRelative: false,
+    disallowedTagsMode: "discard",
+};
+const FRAGMENT_OPTIONS = {
+    ...COMMON_OPTIONS,
+    allowedTags: [...BASE_ALLOWED_TAGS, ...AUTOMATION_EXTRA_TAGS],
+};
+const DOCUMENT_OPTIONS = {
+    ...COMMON_OPTIONS,
+    allowedTags: [
+        ...BASE_ALLOWED_TAGS,
+        ...AUTOMATION_EXTRA_TAGS,
+        ...DOCUMENT_TAGS,
+    ],
+    allowVulnerableTags: true,
+};
+
+export function sanitizeGeneratedHtml(html) {
+    const input = String(html || "");
+    const isFullDocument = /<html[\s>]/i.test(input);
+
+    if (isFullDocument) {
+        return sanitizeHtml(input, DOCUMENT_OPTIONS);
+    }
+
+    const sanitized = sanitizeHtml(input, FRAGMENT_OPTIONS);
+
+    return `<!doctype html>
+<html data-theme="light">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <style>
+    :root { color-scheme: light; }
+    html[data-theme="dark"] { color-scheme: dark; }
+    body { font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; margin: 0; padding: 1rem; color: #111827; background: #ffffff; }
+    html[data-theme="dark"] body { color: #f3f4f6; background: #111827; }
+    @media (prefers-color-scheme: dark) {
+      html:not([data-theme="light"]) { color-scheme: dark; }
+      html:not([data-theme="light"]) body { color: #f3f4f6; background: #111827; }
+    }
+    img { max-width: 100%; height: auto; }
+  </style>
+</head>
+<body>
+${sanitized}
+</body>
+</html>`;
+}
+
+export function applyAutomationHtmlTheme(html, theme = "light") {
+    const safeTheme = theme === "dark" ? "dark" : "light";
+    const themeStyle = `<style id="concierge-automation-theme">
+:root { color-scheme: light; }
+html[data-theme="dark"] { color-scheme: dark; }
+html[data-theme="dark"] body { background: #0f172a !important; color: #e5e7eb !important; }
+html[data-theme="dark"] article,
+html[data-theme="dark"] section,
+html[data-theme="dark"] aside,
+html[data-theme="dark"] table,
+html[data-theme="dark"] pre,
+html[data-theme="dark"] code,
+html[data-theme="dark"] .card { background-color: #111827 !important; color: #e5e7eb !important; border-color: #374151 !important; }
+html[data-theme="dark"] h1,
+html[data-theme="dark"] h2,
+html[data-theme="dark"] h3,
+html[data-theme="dark"] h4,
+html[data-theme="dark"] h5,
+html[data-theme="dark"] h6 { color: #f9fafb; }
+html[data-theme="dark"] a { color: #7dd3fc; }
+html[data-theme="dark"] input,
+html[data-theme="dark"] textarea,
+html[data-theme="dark"] select,
+html[data-theme="dark"] button { background-color: #1f2937; color: #f9fafb; border-color: #4b5563; }
+@media (prefers-color-scheme: dark) {
+  html:not([data-theme="light"]) { color-scheme: dark; }
+  html:not([data-theme="light"]) body { background: #0f172a !important; color: #e5e7eb !important; }
+}
+</style>`;
+    let themedHtml = String(html || "");
+
+    if (/<html\b[^>]*>/i.test(themedHtml)) {
+        themedHtml = themedHtml.replace(/<html\b([^>]*)>/i, (_match, attrs) => {
+            const normalizedAttrs = String(attrs || "").replace(
+                /\sdata-theme=(["']).*?\1/i,
+                "",
+            );
+            return `<html${normalizedAttrs} data-theme="${safeTheme}">`;
+        });
+    }
+
+    if (/<\/head>/i.test(themedHtml)) {
+        themedHtml = themedHtml.replace(/<\/head>/i, `${themeStyle}</head>`);
+    } else if (/<html\b[^>]*>/i.test(themedHtml)) {
+        themedHtml = themedHtml.replace(
+            /<html\b[^>]*>/i,
+            (match) => `${match}<head>${themeStyle}</head>`,
+        );
+    }
+
+    return themedHtml;
+}
+
+export function buildHtmlPreview(html) {
+    return String(html || "")
+        .replace(/<style[\s\S]*?>[\s\S]*?<\/style>/gi, " ")
+        .replace(/<[^>]+>/g, " ")
+        .replace(/\s+/g, " ")
+        .trim()
+        .slice(0, 280);
+}
+
+export function normalizeAutomationSlug(value) {
+    const collapsed = String(value || "")
+        .trim()
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, "-")
+        .slice(0, 64);
+    let start = 0;
+    let end = collapsed.length;
+    while (start < end && collapsed.charCodeAt(start) === 45) start += 1;
+    while (end > start && collapsed.charCodeAt(end - 1) === 45) end -= 1;
+    return collapsed.slice(start, end);
+}
+
+export function validateAutomationSlug(slug) {
+    return /^[a-z0-9][a-z0-9-]*$/.test(slug) && slug.length <= 64;
+}
+
+export function sanitizeAutomationFilename(raw) {
+    const basename = raw?.split(/[/\\]/).pop();
+    if (!basename || basename === "." || basename === "..") return null;
+    return basename;
+}
+
+function isValidScheduleTime(value) {
+    return /^([01]\d|2[0-3]):[0-5]\d$/.test(value || "");
+}
+
+function normalizeScheduleTimes(input) {
+    const source = Array.isArray(input.times) ? input.times : [input.time];
+    const times = [
+        ...new Set(
+            source
+                .map((value) => String(value || "").trim())
+                .filter(isValidScheduleTime),
+        ),
+    ].sort();
+    return times.length > 0 ? times : ["09:00"];
+}
+
+function normalizeScheduleDays(input) {
+    const source = Array.isArray(input.daysOfWeek)
+        ? input.daysOfWeek
+        : [input.dayOfWeek];
+    const days = [
+        ...new Set(
+            source
+                .map((value) => Number.parseInt(value, 10))
+                .filter(
+                    (value) =>
+                        Number.isInteger(value) && value >= 0 && value <= 6,
+                ),
+        ),
+    ].sort((a, b) => a - b);
+    return days.length > 0 ? days : [1];
+}
+
+export function normalizeSchedule(input = {}) {
+    const frequency = ["manual", "hourly", "daily", "weekly"].includes(
+        input.frequency,
+    )
+        ? input.frequency
+        : "manual";
+
+    const interval = Math.max(1, Number.parseInt(input.interval, 10) || 1);
+    const times = normalizeScheduleTimes(input);
+    const daysOfWeek = normalizeScheduleDays(input);
+    const hourlyMode = input.hourlyMode === "clock" ? "clock" : "interval";
+    const parsedMinute = Number.parseInt(input.minute, 10);
+    const minute =
+        Number.isInteger(parsedMinute) &&
+        parsedMinute >= 0 &&
+        parsedMinute <= 59
+            ? parsedMinute
+            : 0;
+
+    return {
+        frequency,
+        interval,
+        time: times[0],
+        times,
+        dayOfWeek: daysOfWeek[0],
+        daysOfWeek,
+        hourlyMode,
+        minute,
+    };
+}
+
+/** Manual schedules are never polled; coerce off so APIs stay consistent */
+export function automationEffectiveEnabled(enabled, schedule) {
+    if (schedule?.frequency === "manual") {
+        return false;
+    }
+    return Boolean(enabled);
+}
+
+function getTimeZoneParts(date, timezone) {
+    const parts = new Intl.DateTimeFormat("en-US", {
+        timeZone: timezone || "UTC",
+        year: "numeric",
+        month: "2-digit",
+        day: "2-digit",
+        hour: "2-digit",
+        minute: "2-digit",
+        second: "2-digit",
+        hour12: false,
+    }).formatToParts(date);
+
+    return Object.fromEntries(
+        parts
+            .filter((part) => part.type !== "literal")
+            .map((part) => [part.type, Number(part.value)]),
+    );
+}
+
+function getTimeZoneOffsetMs(date, timezone) {
+    const parts = getTimeZoneParts(date, timezone);
+    const asUtc = Date.UTC(
+        parts.year,
+        parts.month - 1,
+        parts.day,
+        parts.hour,
+        parts.minute,
+        parts.second,
+    );
+    return asUtc - date.getTime();
+}
+
+function zonedDateTimeToUtc(
+    { year, month, day, hour = 0, minute = 0, second = 0 },
+    timezone,
+) {
+    const utcGuess = Date.UTC(year, month - 1, day, hour, minute, second);
+    const firstOffset = getTimeZoneOffsetMs(new Date(utcGuess), timezone);
+    let date = new Date(utcGuess - firstOffset);
+    const secondOffset = getTimeZoneOffsetMs(date, timezone);
+    if (secondOffset !== firstOffset) {
+        date = new Date(utcGuess - secondOffset);
+    }
+    return date;
+}
+
+function addDaysToParts(parts, days) {
+    const date = new Date(
+        Date.UTC(parts.year, parts.month - 1, parts.day + days, 12, 0, 0),
+    );
+    return {
+        year: date.getUTCFullYear(),
+        month: date.getUTCMonth() + 1,
+        day: date.getUTCDate(),
+    };
+}
+
+function addHoursToParts(parts, hours) {
+    const date = new Date(
+        Date.UTC(
+            parts.year,
+            parts.month - 1,
+            parts.day,
+            parts.hour + hours,
+            0,
+            0,
+        ),
+    );
+    return {
+        year: date.getUTCFullYear(),
+        month: date.getUTCMonth() + 1,
+        day: date.getUTCDate(),
+        hour: date.getUTCHours(),
+    };
+}
+
+function parseScheduleTime(time) {
+    const [hour, minute] = time.split(":").map(Number);
+    return { hour, minute };
+}
+
+function earliestFutureDate(candidates, fromDate) {
+    return candidates
+        .filter((candidate) => candidate > fromDate)
+        .sort((a, b) => a - b)[0];
+}
+
+export function calculateNextRunAt(
+    scheduleInput,
+    timezone = "UTC",
+    fromDate = new Date(),
+) {
+    const schedule = normalizeSchedule(scheduleInput);
+    if (schedule.frequency === "manual") return null;
+
+    if (schedule.frequency === "hourly") {
+        if (schedule.hourlyMode === "clock") {
+            const nowParts = getTimeZoneParts(fromDate, timezone);
+            for (
+                let hourOffset = 0;
+                hourOffset <= 24 * schedule.interval + 1;
+                hourOffset += 1
+            ) {
+                const parts = addHoursToParts(nowParts, hourOffset);
+                if (parts.hour % schedule.interval !== 0) {
+                    continue;
+                }
+                const candidate = zonedDateTimeToUtc(
+                    { ...parts, minute: schedule.minute, second: 0 },
+                    timezone,
+                );
+                if (candidate > fromDate) {
+                    return candidate;
+                }
+            }
+        }
+
+        return new Date(
+            fromDate.getTime() + schedule.interval * 60 * 60 * 1000,
+        );
+    }
+
+    const nowParts = getTimeZoneParts(fromDate, timezone);
+
+    if (schedule.frequency === "daily") {
+        for (
+            let dayOffset = 0;
+            dayOffset <= schedule.interval * 14;
+            dayOffset += schedule.interval
+        ) {
+            const dayParts =
+                dayOffset === 0
+                    ? nowParts
+                    : addDaysToParts(nowParts, dayOffset);
+            const candidates = schedule.times.map((time) => {
+                const { hour, minute } = parseScheduleTime(time);
+                return zonedDateTimeToUtc(
+                    { ...dayParts, hour, minute, second: 0 },
+                    timezone,
+                );
+            });
+            const next = earliestFutureDate(candidates, fromDate);
+            if (next) {
+                return next;
+            }
+        }
+        return null;
+    }
+
+    const localWeekday = new Date(
+        Date.UTC(nowParts.year, nowParts.month - 1, nowParts.day),
+    ).getUTCDay();
+    const maxDayOffset = 7 * schedule.interval + 6;
+    for (let dayOffset = 0; dayOffset <= maxDayOffset; dayOffset += 1) {
+        const weekIndex = Math.floor((localWeekday + dayOffset) / 7);
+        if (weekIndex % schedule.interval !== 0) {
+            continue;
+        }
+        const candidateWeekday = (localWeekday + dayOffset) % 7;
+        if (!schedule.daysOfWeek.includes(candidateWeekday)) {
+            continue;
+        }
+        const dayParts =
+            dayOffset === 0 ? nowParts : addDaysToParts(nowParts, dayOffset);
+        const candidates = schedule.times.map((time) => {
+            const { hour, minute } = parseScheduleTime(time);
+            return zonedDateTimeToUtc(
+                { ...dayParts, hour, minute, second: 0 },
+                timezone,
+            );
+        });
+        const next = earliestFutureDate(candidates, fromDate);
+        if (next) {
+            return next;
+        }
+    }
+
+    return null;
+}
+
+export async function readAutomationContent(userContextId, slug) {
+    const storageTarget = createAutomationStorageTarget(userContextId);
+    return (
+        (await readBlobContent(
+            `automations/${slug}/${AUTOMATION_MD}`,
+            storageTarget,
+        )) || ""
+    );
+}
+
+export async function writeAutomationContent(userContextId, slug, content) {
+    const buffer = Buffer.from(content || "", "utf-8");
+    const hash = await hashBuffer(buffer);
+    const storageTarget = createAutomationStorageTarget(userContextId);
+    return uploadBufferToMediaService(
+        buffer,
+        { filename: AUTOMATION_MD, mimeType: "text/markdown", hash },
+        { storageTarget, subPath: slug },
+    );
+}
+
+export async function writeAutomationOutputFile({
+    userContextId,
+    slug,
+    taskId,
+    filename,
+    content,
+    mimeType = "text/plain",
+}) {
+    const safeName = sanitizeAutomationFilename(filename);
+    if (!safeName) {
+        throw new Error("Invalid output filename");
+    }
+
+    const buffer = Buffer.from(content || "", "utf-8");
+    const hash = await hashBuffer(buffer);
+    const storageTarget = createAutomationStorageTarget(userContextId);
+    const subPath = `${slug}/outputs/${taskId}`;
+    const uploadResult = await uploadBufferToMediaService(
+        buffer,
+        { filename: safeName, mimeType, hash },
+        { storageTarget, subPath },
+    );
+
+    if (uploadResult.error) {
+        throw new Error("Failed to save automation output");
+    }
+
+    return `automations/${subPath}/${safeName}`;
+}
+
+export async function listAutomationSupportingFiles(userContextId, slug) {
+    const files = await listAutomationFiles(userContextId, slug);
+    return files.filter((file) => {
+        const name = file.name || file.filename || "";
+        return (
+            !name.endsWith(`/${AUTOMATION_MD}`) &&
+            file.filename !== AUTOMATION_MD
+        );
+    });
+}
+
+export async function deleteAutomationFolder(userContextId, slug) {
+    const storageTarget = createAutomationStorageTarget(userContextId);
+    const files = await listAutomationFiles(userContextId, slug);
+    await Promise.all(
+        files.map((file) =>
+            file.name
+                ? deleteMediaFile({ blobPath: file.name, storageTarget })
+                : Promise.resolve(),
+        ),
+    );
+}
+
+export async function findAutomationForUser(idOrSlug, ownerId) {
+    const query = mongoose.Types.ObjectId.isValid(idOrSlug)
+        ? { _id: idOrSlug, owner: ownerId }
+        : { slug: String(idOrSlug || "").toLowerCase(), owner: ownerId };
+    return Automation.findOne(query);
+}
+
+/**
+ * Best-effort: copy automation.automationId onto automationRefId so CSFLE-safe
+ * queries work (libmongocrypt analyze_query can fail on nested path filters).
+ */
+export function scheduleAutomationRefIdBackfill(docs) {
+    if (!Array.isArray(docs) || docs.length === 0) return;
+    void import("../models/task.mjs").then(({ default: Task }) => {
+        for (const d of docs) {
+            const nested = d?.automation?.automationId;
+            if (!nested || d.automationRefId) continue;
+            void Task.updateOne(
+                { _id: d._id },
+                { $set: { automationRefId: nested } },
+            ).catch(() => {});
+        }
+    });
+}
+
+export async function hasActiveAutomationRun(automationId, ownerId) {
+    const { default: Task } = await import("../models/task.mjs");
+    const idStr = String(automationId);
+    if (
+        await Task.exists({
+            owner: ownerId,
+            type: AUTOMATION_TASK_TYPE,
+            status: { $in: ACTIVE_TASK_STATUSES },
+            automationRefId: automationId,
+        })
+    ) {
+        return true;
+    }
+
+    const legacy = await Task.find({
+        owner: ownerId,
+        type: AUTOMATION_TASK_TYPE,
+        status: { $in: ACTIVE_TASK_STATUSES },
+    })
+        .sort({ createdAt: -1 })
+        .limit(200)
+        .lean();
+
+    scheduleAutomationRefIdBackfill(legacy);
+
+    return legacy.some(
+        (t) =>
+            String(t.automationRefId || t.automation?.automationId || "") ===
+            idStr,
+    );
+}
+
+export function serializeAutomation(automation, extra = {}) {
+    const obj =
+        typeof automation?.toObject === "function"
+            ? automation.toObject()
+            : automation;
+    return { ...obj, ...extra };
+}

--- a/app/api/automations/utils.test.js
+++ b/app/api/automations/utils.test.js
@@ -1,0 +1,197 @@
+/**
+ * @jest-environment node
+ */
+
+jest.mock("../models/automation.js", () => ({
+    __esModule: true,
+    default: {},
+}));
+
+jest.mock("../models/task.mjs", () => ({
+    __esModule: true,
+    default: {},
+}));
+
+jest.mock("../utils/media-service-utils.js", () => ({
+    deleteMediaFile: jest.fn(),
+    hashBuffer: jest.fn(),
+    listAutomationFiles: jest.fn(),
+    readBlobContent: jest.fn(),
+    uploadBufferToMediaService: jest.fn(),
+}));
+
+describe("automation utils", () => {
+    const {
+        automationEffectiveEnabled,
+        calculateNextRunAt,
+        normalizeAutomationSlug,
+        normalizeSchedule,
+        parseAutomationTaskOutput,
+        validateAutomationSlug,
+    } = require("./utils");
+
+    test("automationEffectiveEnabled rejects manual schedules", () => {
+        expect(automationEffectiveEnabled(true, { frequency: "manual" })).toBe(
+            false,
+        );
+        expect(automationEffectiveEnabled(true, { frequency: "daily" })).toBe(
+            true,
+        );
+        expect(automationEffectiveEnabled(false, { frequency: "daily" })).toBe(
+            false,
+        );
+    });
+
+    test("normalizes and validates slugs", () => {
+        expect(normalizeAutomationSlug(" Weekly Digest! ")).toBe(
+            "weekly-digest",
+        );
+        expect(validateAutomationSlug("weekly-digest")).toBe(true);
+        expect(validateAutomationSlug("-weekly")).toBe(false);
+    });
+
+    test("normalizes schedule input", () => {
+        expect(
+            normalizeSchedule({
+                frequency: "daily",
+                interval: "3",
+                time: "25:99",
+                dayOfWeek: 9,
+            }),
+        ).toEqual({
+            frequency: "daily",
+            interval: 3,
+            time: "09:00",
+            times: ["09:00"],
+            dayOfWeek: 1,
+            daysOfWeek: [1],
+            hourlyMode: "interval",
+            minute: 0,
+        });
+    });
+
+    test("normalizes multiple times and days", () => {
+        expect(
+            normalizeSchedule({
+                frequency: "weekly",
+                times: ["18:00", "bad", "06:00", "06:00"],
+                daysOfWeek: [5, "1", 12, 1],
+            }),
+        ).toEqual({
+            frequency: "weekly",
+            interval: 1,
+            time: "06:00",
+            times: ["06:00", "18:00"],
+            dayOfWeek: 1,
+            daysOfWeek: [1, 5],
+            hourlyMode: "interval",
+            minute: 0,
+        });
+    });
+
+    test("calculates next daily run in timezone", () => {
+        const next = calculateNextRunAt(
+            { frequency: "daily", time: "09:00" },
+            "UTC",
+            new Date("2026-04-28T08:00:00.000Z"),
+        );
+
+        expect(next.toISOString()).toBe("2026-04-28T09:00:00.000Z");
+    });
+
+    test("moves daily run to tomorrow after scheduled time", () => {
+        const next = calculateNextRunAt(
+            { frequency: "daily", time: "09:00" },
+            "UTC",
+            new Date("2026-04-28T10:00:00.000Z"),
+        );
+
+        expect(next.toISOString()).toBe("2026-04-29T09:00:00.000Z");
+    });
+
+    test("calculates next daily run with multiple times", () => {
+        const next = calculateNextRunAt(
+            { frequency: "daily", times: ["06:00", "18:00"] },
+            "UTC",
+            new Date("2026-04-28T07:00:00.000Z"),
+        );
+
+        expect(next.toISOString()).toBe("2026-04-28T18:00:00.000Z");
+    });
+
+    test("calculates next weekly run across multiple days", () => {
+        const next = calculateNextRunAt(
+            { frequency: "weekly", daysOfWeek: [1, 5], times: ["09:00"] },
+            "UTC",
+            new Date("2026-04-28T10:00:00.000Z"),
+        );
+
+        expect(next.toISOString()).toBe("2026-05-01T09:00:00.000Z");
+    });
+
+    test("calculates clock-aligned hourly runs", () => {
+        const next = calculateNextRunAt(
+            {
+                frequency: "hourly",
+                hourlyMode: "clock",
+                interval: 1,
+                minute: 0,
+            },
+            "UTC",
+            new Date("2026-04-28T10:14:00.000Z"),
+        );
+
+        expect(next.toISOString()).toBe("2026-04-28T11:00:00.000Z");
+    });
+
+    test("finds HTML output when summary and result fields differ", () => {
+        const parsed = parseAutomationTaskOutput({
+            data: {
+                summary: "Plain summary",
+                result: JSON.stringify({
+                    summary: "Generated HTML",
+                    html: "<!doctype html><html><body>Digest</body></html>",
+                }),
+            },
+        });
+
+        expect(parsed.summary).toBe("Generated HTML");
+        expect(parsed.html).toContain("<html>");
+    });
+
+    test("finds HTML output when the JSON object is stored in summary", () => {
+        const parsed = parseAutomationTaskOutput({
+            data: {
+                summary: {
+                    summary: "Generated HTML",
+                    html: "<!doctype html><html><body>Digest</body></html>",
+                },
+                result: "Plain summary",
+            },
+        });
+
+        expect(parsed.summary).toBe("Generated HTML");
+        expect(parsed.html).toContain("<html>");
+    });
+
+    test("parses fenced JSON automation output with surrounding text", () => {
+        const parsed = parseAutomationTaskOutput({
+            data: {
+                result: `Here is the output:
+
+\`\`\`json
+{
+  "summary": "Generated a front page",
+  "html": "<!doctype html>\\n<html lang=\\"en\\" data-theme=\\"light\\"><body><main>Front Page</main></body></html>"
+}
+\`\`\`
+`,
+            },
+        });
+
+        expect(parsed.summary).toBe("Generated a front page");
+        expect(parsed.html).toBe(
+            '<!doctype html>\n<html lang="en" data-theme="light"><body><main>Front Page</main></body></html>',
+        );
+    });
+});

--- a/app/api/models/automation.js
+++ b/app/api/models/automation.js
@@ -1,0 +1,160 @@
+import mongoose from "mongoose";
+
+const automationScheduleSchema = new mongoose.Schema(
+    {
+        frequency: {
+            type: String,
+            enum: ["manual", "hourly", "daily", "weekly"],
+            default: "manual",
+        },
+        interval: {
+            type: Number,
+            default: 1,
+            min: 1,
+        },
+        time: {
+            type: String,
+            default: "09:00",
+            match: /^([01]\d|2[0-3]):[0-5]\d$/,
+        },
+        times: {
+            type: [String],
+            default: undefined,
+            validate: {
+                validator: (values) =>
+                    !values ||
+                    values.every((value) =>
+                        /^([01]\d|2[0-3]):[0-5]\d$/.test(value),
+                    ),
+                message: "All schedule times must use HH:mm format",
+            },
+        },
+        dayOfWeek: {
+            type: Number,
+            min: 0,
+            max: 6,
+            default: 1,
+        },
+        daysOfWeek: {
+            type: [Number],
+            default: undefined,
+            validate: {
+                validator: (values) =>
+                    !values ||
+                    values.every(
+                        (value) =>
+                            Number.isInteger(value) && value >= 0 && value <= 6,
+                    ),
+                message: "All schedule days must be between 0 and 6",
+            },
+        },
+        hourlyMode: {
+            type: String,
+            enum: ["interval", "clock"],
+            default: "interval",
+        },
+        minute: {
+            type: Number,
+            min: 0,
+            max: 59,
+            default: 0,
+        },
+    },
+    { _id: false },
+);
+
+const automationSchema = new mongoose.Schema(
+    {
+        owner: {
+            type: mongoose.Schema.Types.ObjectId,
+            ref: "User",
+            required: true,
+            index: true,
+        },
+        slug: {
+            type: String,
+            required: true,
+            trim: true,
+            lowercase: true,
+            match: /^[a-z0-9][a-z0-9-]*$/,
+            maxlength: 64,
+        },
+        name: {
+            type: String,
+            required: true,
+            trim: true,
+            maxlength: 120,
+        },
+        description: {
+            type: String,
+            default: "",
+            maxlength: 500,
+        },
+        enabled: {
+            type: Boolean,
+            default: false,
+        },
+        schedule: {
+            type: automationScheduleSchema,
+            default: () => ({}),
+        },
+        timezone: {
+            type: String,
+            default: "UTC",
+        },
+        path: {
+            type: String,
+            required: true,
+        },
+        inputs: {
+            type: mongoose.Schema.Types.Mixed,
+            default: null,
+        },
+        producesHtml: {
+            type: Boolean,
+            default: false,
+        },
+        pinnedToSidebar: {
+            type: Boolean,
+            default: false,
+        },
+        lastRunAt: {
+            type: Date,
+            default: null,
+        },
+        nextRunAt: {
+            type: Date,
+            default: null,
+        },
+        latestRunTaskId: {
+            type: mongoose.Schema.Types.ObjectId,
+            ref: "Task",
+            default: null,
+        },
+        latestHtmlOutputPath: {
+            type: String,
+            default: null,
+        },
+        schedulerLockedAt: {
+            type: Date,
+            default: null,
+        },
+        lastEnqueuedAt: {
+            type: Date,
+            default: null,
+        },
+    },
+    {
+        timestamps: true,
+    },
+);
+
+automationSchema.index({ owner: 1, slug: 1 }, { unique: true });
+automationSchema.index({ enabled: 1, nextRunAt: 1 });
+automationSchema.index({ owner: 1, pinnedToSidebar: 1, producesHtml: 1 });
+
+const Automation =
+    mongoose.models?.Automation ||
+    mongoose.model("Automation", automationSchema);
+
+export default Automation;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-    "name": "labeeb",
+    "name": "concierge",
     "version": "3.6.4",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
-            "name": "labeeb",
+            "name": "concierge",
             "version": "3.6.4",
             "dependencies": {
                 "@aj-archipelago/subvibe": "^1.0.12",
@@ -95,6 +95,7 @@
                 "remark-directive": "^3.0.0",
                 "remark-gfm": "^4.0.0",
                 "remark-math": "^6.0.0",
+                "sanitize-html": "^2.17.4",
                 "sass-loader": "^13.2.0",
                 "sharp": "^0.34.5",
                 "stringcase": "^4.3.1",
@@ -16208,6 +16209,15 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/is-plain-object": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+            "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/is-potential-custom-element-name": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
@@ -18854,6 +18864,15 @@
             "dependencies": {
                 "picocolors": "^1.0.0",
                 "shell-quote": "^1.8.1"
+            }
+        },
+        "node_modules/launder": {
+            "version": "1.7.1",
+            "resolved": "https://registry.npmjs.org/launder/-/launder-1.7.1.tgz",
+            "integrity": "sha512-mU6WRz5EusL9ZZuiZ5SO4Y6C0P9PAUR9iwdb6bzj4KDihm28DiHFw+/yk9DBH4f+Pv1wuzQ4e2jV3oQ7mkIqvw==",
+            "license": "MIT",
+            "dependencies": {
+                "dayjs": "^1.11.7"
             }
         },
         "node_modules/layout-base": {
@@ -21585,6 +21604,12 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
+        },
+        "node_modules/parse-srcset": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
+            "integrity": "sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q==",
+            "license": "MIT"
         },
         "node_modules/parse5": {
             "version": "7.2.1",
@@ -26811,6 +26836,52 @@
             "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
             "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
             "license": "MIT"
+        },
+        "node_modules/sanitize-html": {
+            "version": "2.17.4",
+            "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.4.tgz",
+            "integrity": "sha512-2HW7v2ol/uAM7sX4hbD8Z59OGWmAPrvjL8E71UWlBcj6m+kcF6ilQBLny+cIgY214QJeJT5tQuxKKqX0SQqjGQ==",
+            "license": "MIT",
+            "dependencies": {
+                "deepmerge": "^4.2.2",
+                "escape-string-regexp": "^4.0.0",
+                "htmlparser2": "^10.1.0",
+                "is-plain-object": "^5.0.0",
+                "launder": "^1.7.1",
+                "parse-srcset": "^1.0.2",
+                "postcss": "^8.3.11"
+            }
+        },
+        "node_modules/sanitize-html/node_modules/entities": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+            "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=0.12"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
+            }
+        },
+        "node_modules/sanitize-html/node_modules/htmlparser2": {
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+            "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+            "funding": [
+                "https://github.com/fb55/htmlparser2?sponsor=1",
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fb55"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "domelementtype": "^2.3.0",
+                "domhandler": "^5.0.3",
+                "domutils": "^3.2.2",
+                "entities": "^7.0.1"
+            }
         },
         "node_modules/sanitize.css": {
             "version": "13.0.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "labeeb",
+    "name": "concierge",
     "version": "3.6.4",
     "private": true,
     "type": "module",
@@ -91,6 +91,7 @@
         "remark-directive": "^3.0.0",
         "remark-gfm": "^4.0.0",
         "remark-math": "^6.0.0",
+        "sanitize-html": "^2.17.4",
         "sass-loader": "^13.2.0",
         "sharp": "^0.34.5",
         "stringcase": "^4.3.1",


### PR DESCRIPTION
## Summary
- add the generic Automation model and schedule/output utility foundation for future automation APIs and worker execution
- add focused tests for slug normalization, schedule calculation, enabled semantics, and HTML output parsing
- add sanitize-html for safe automation HTML output handling
- sanitize package metadata from Labeeb to Concierge while touching package files

## Validation
- npm test -- app/api/automations/utils.test.js --runInBand --silent --openHandlesTimeout=1000
- git diff --check
- forbidden branding/secret scan over modified and staged files