### PR TITLE
Add automation CRUD API routes

### DIFF
--- a/app/api/automations/[id]/files/route.js
+++ b/app/api/automations/[id]/files/route.js
@@ -1,0 +1,141 @@
+import { NextResponse } from "next/server";
+import { getCurrentUser, handleError } from "../../../utils/auth";
+import { parseStreamingMultipart } from "../../../utils/upload-utils";
+import {
+    deleteMediaFile,
+    listAutomationFiles,
+    uploadBufferToMediaService,
+} from "../../../utils/media-service-utils";
+import { createAutomationStorageTarget } from "../../../../../src/utils/storageTargets";
+import {
+    AUTOMATION_MD,
+    findAutomationForUser,
+    sanitizeAutomationFilename,
+} from "../../utils";
+
+export async function GET(request, { params }) {
+    try {
+        const user = await getCurrentUser();
+        const automation = await findAutomationForUser(params.id, user._id);
+
+        if (!automation) {
+            return NextResponse.json(
+                { error: "Automation not found" },
+                { status: 404 },
+            );
+        }
+
+        const files = await listAutomationFiles(
+            user.contextId,
+            automation.slug,
+        );
+        return NextResponse.json({ files });
+    } catch (error) {
+        return handleError(error);
+    }
+}
+
+export async function POST(request, { params }) {
+    try {
+        const user = await getCurrentUser();
+        const automation = await findAutomationForUser(params.id, user._id);
+
+        if (!automation) {
+            return NextResponse.json(
+                { error: "Automation not found" },
+                { status: 404 },
+            );
+        }
+
+        const result = await parseStreamingMultipart(request, user);
+        if (result.error) {
+            return result.error;
+        }
+
+        const { fileBuffer, metadata } = result.data;
+        const safeName = sanitizeAutomationFilename(metadata.filename);
+        if (!safeName) {
+            return NextResponse.json(
+                { error: "Invalid filename" },
+                { status: 400 },
+            );
+        }
+        if (safeName.toLowerCase() === AUTOMATION_MD.toLowerCase()) {
+            return NextResponse.json(
+                {
+                    error: `Cannot upload a file named ${AUTOMATION_MD}. Use the automation editor instead.`,
+                },
+                { status: 400 },
+            );
+        }
+
+        metadata.filename = safeName;
+        const storageTarget = createAutomationStorageTarget(user.contextId);
+        const uploadResult = await uploadBufferToMediaService(
+            fileBuffer,
+            metadata,
+            { storageTarget, subPath: automation.slug },
+        );
+
+        if (uploadResult.error) {
+            return uploadResult.error;
+        }
+
+        const files = await listAutomationFiles(
+            user.contextId,
+            automation.slug,
+        );
+        return NextResponse.json({ success: true, files });
+    } catch (error) {
+        return handleError(error);
+    }
+}
+
+export async function DELETE(request, { params }) {
+    try {
+        const user = await getCurrentUser();
+        const automation = await findAutomationForUser(params.id, user._id);
+
+        if (!automation) {
+            return NextResponse.json(
+                { error: "Automation not found" },
+                { status: 404 },
+            );
+        }
+
+        const { searchParams } = new URL(request.url);
+        const safeName = sanitizeAutomationFilename(
+            searchParams.get("filename"),
+        );
+        if (!safeName) {
+            return NextResponse.json(
+                { error: "Filename is required" },
+                { status: 400 },
+            );
+        }
+        if (safeName.toLowerCase() === AUTOMATION_MD.toLowerCase()) {
+            return NextResponse.json(
+                {
+                    error: `Cannot delete ${AUTOMATION_MD}. Delete the automation instead.`,
+                },
+                { status: 400 },
+            );
+        }
+
+        const storageTarget = createAutomationStorageTarget(user.contextId);
+        await deleteMediaFile({
+            blobPath: `automations/${automation.slug}/${safeName}`,
+            storageTarget,
+        });
+
+        const files = await listAutomationFiles(
+            user.contextId,
+            automation.slug,
+        );
+        return NextResponse.json({ success: true, files });
+    } catch (error) {
+        return handleError(error);
+    }
+}
+
+export const dynamic = "force-dynamic";

--- a/app/api/automations/[id]/route.js
+++ b/app/api/automations/[id]/route.js
@@ -1,0 +1,240 @@
+import { NextResponse } from "next/server";
+import { getCurrentUser, handleError } from "../../utils/auth";
+import Automation from "../../models/automation";
+import Digest from "../../models/digest.mjs";
+import {
+    automationEffectiveEnabled,
+    calculateNextRunAt,
+    deleteAutomationFolder,
+    findAutomationForUser,
+    listAutomationSupportingFiles,
+    normalizeSchedule,
+    readAutomationContent,
+    serializeAutomation,
+    writeAutomationContent,
+} from "../utils";
+
+async function findHomeWidget(ownerId, automationId) {
+    const digest = await Digest.findOne({ owner: ownerId });
+    if (!digest) return { digest: null, block: null };
+    const block = digest.blocks.find(
+        (b) => String(b.automationId || "") === String(automationId),
+    );
+    return { digest, block: block || null };
+}
+
+async function setHomeWidget(ownerId, automation, pinned) {
+    // CSFLE rejects $push on the encrypted blocks array, so we always
+    // replace the full array via $set with a freshly-built list.
+    const existing = (await Digest.findOne({ owner: ownerId }).lean()) || {
+        owner: ownerId,
+        blocks: [],
+    };
+    const automationKey = String(automation._id);
+    const hasBlock = (existing.blocks || []).some(
+        (b) => String(b.automationId || "") === automationKey,
+    );
+
+    if (pinned && hasBlock) return;
+    if (!pinned && !hasBlock) return;
+
+    let nextBlocks;
+    if (pinned) {
+        nextBlocks = [
+            ...(existing.blocks || []),
+            {
+                title: automation.name || "Automation",
+                automationId: automation._id,
+            },
+        ];
+    } else {
+        nextBlocks = (existing.blocks || []).filter(
+            (b) => String(b.automationId || "") !== automationKey,
+        );
+    }
+
+    await Digest.findOneAndUpdate(
+        { owner: ownerId },
+        { $set: { owner: ownerId, blocks: nextBlocks } },
+        { upsert: true, new: true },
+    );
+}
+
+export async function GET(request, { params }) {
+    try {
+        const user = await getCurrentUser();
+        const automation = await findAutomationForUser(params.id, user._id);
+
+        if (!automation) {
+            return NextResponse.json(
+                { error: "Automation not found" },
+                { status: 404 },
+            );
+        }
+
+        const [content, files, homeWidget] = await Promise.all([
+            readAutomationContent(user.contextId, automation.slug),
+            listAutomationSupportingFiles(user.contextId, automation.slug),
+            findHomeWidget(user._id, automation._id),
+        ]);
+
+        return NextResponse.json(
+            serializeAutomation(automation, {
+                content,
+                files,
+                pinnedToHome: Boolean(homeWidget.block),
+            }),
+        );
+    } catch (error) {
+        return handleError(error);
+    }
+}
+
+export async function PUT(request, { params }) {
+    try {
+        const user = await getCurrentUser();
+        const automation = await findAutomationForUser(params.id, user._id);
+
+        if (!automation) {
+            return NextResponse.json(
+                { error: "Automation not found" },
+                { status: 404 },
+            );
+        }
+
+        const body = await request.json();
+
+        if (body.name !== undefined) {
+            automation.name = String(body.name || "").trim();
+        }
+        if (body.description !== undefined) {
+            automation.set(
+                "description",
+                String(body.description || "").trim(),
+            );
+        }
+        if (body.schedule !== undefined) {
+            automation.schedule = normalizeSchedule(body.schedule);
+        }
+        if (body.timezone !== undefined) {
+            automation.timezone = body.timezone || "UTC";
+        }
+        if (body.enabled !== undefined) {
+            automation.enabled = Boolean(body.enabled);
+        }
+        if (body.inputs !== undefined) {
+            automation.inputs = body.inputs || null;
+        }
+        if (body.producesHtml !== undefined) {
+            automation.producesHtml = Boolean(body.producesHtml);
+            if (!automation.producesHtml) {
+                automation.pinnedToSidebar = false;
+            }
+        }
+        if (body.pinnedToSidebar !== undefined) {
+            automation.pinnedToSidebar =
+                automation.producesHtml && Boolean(body.pinnedToSidebar);
+        }
+
+        automation.enabled = automationEffectiveEnabled(
+            automation.enabled,
+            automation.schedule,
+        );
+
+        automation.nextRunAt = automation.enabled
+            ? calculateNextRunAt(automation.schedule, automation.timezone)
+            : null;
+
+        if (!automation.name) {
+            return NextResponse.json(
+                { error: "Automation name is required" },
+                { status: 400 },
+            );
+        }
+
+        let savedContent;
+        if (body.content !== undefined) {
+            savedContent = String(body.content || "");
+            const uploadResult = await writeAutomationContent(
+                user.contextId,
+                automation.slug,
+                savedContent,
+            );
+            if (uploadResult.error) {
+                return NextResponse.json(
+                    { error: "Failed to update automation content" },
+                    { status: 500 },
+                );
+            }
+        }
+
+        await automation.save();
+
+        if (body.pinnedToHome !== undefined) {
+            await setHomeWidget(
+                user._id,
+                automation,
+                Boolean(body.pinnedToHome),
+            );
+        }
+
+        const { block: homeBlock } = await findHomeWidget(
+            user._id,
+            automation._id,
+        );
+
+        return NextResponse.json(
+            serializeAutomation(automation, {
+                ...(savedContent !== undefined
+                    ? { content: savedContent }
+                    : {}),
+                pinnedToHome: Boolean(homeBlock),
+            }),
+        );
+    } catch (error) {
+        return handleError(error);
+    }
+}
+
+export async function DELETE(request, { params }) {
+    try {
+        const user = await getCurrentUser();
+        const existing = await findAutomationForUser(params.id, user._id);
+
+        if (!existing) {
+            return NextResponse.json(
+                { error: "Automation not found" },
+                { status: 404 },
+            );
+        }
+
+        await Automation.findOneAndDelete({
+            _id: existing._id,
+            owner: user._id,
+        });
+
+        // Drop any home widget that pointed at the now-deleted automation.
+        // Use $set with the full array; CSFLE blocks $push/$pull on the
+        // encrypted blocks array.
+        const digest = await Digest.findOne({ owner: user._id }).lean();
+        if (digest) {
+            const next = (digest.blocks || []).filter(
+                (b) => String(b.automationId || "") !== String(existing._id),
+            );
+            if (next.length !== (digest.blocks || []).length) {
+                await Digest.findOneAndUpdate(
+                    { owner: user._id },
+                    { $set: { blocks: next } },
+                );
+            }
+        }
+
+        await deleteAutomationFolder(user.contextId, existing.slug);
+
+        return NextResponse.json({ success: true });
+    } catch (error) {
+        return handleError(error);
+    }
+}
+
+export const dynamic = "force-dynamic";

--- a/app/api/automations/route.js
+++ b/app/api/automations/route.js
@@ -1,0 +1,116 @@
+import { NextResponse } from "next/server";
+import { getCurrentUser, handleError } from "../utils/auth";
+import Automation from "../models/automation";
+import {
+    AUTOMATION_MD,
+    calculateNextRunAt,
+    automationEffectiveEnabled,
+    normalizeAutomationSlug,
+    normalizeSchedule,
+    serializeAutomation,
+    validateAutomationSlug,
+    writeAutomationContent,
+} from "./utils";
+
+const DEFAULT_AUTOMATION_CONTENT = `# Automation
+
+Describe what Concierge should do when this automation runs.
+
+## Instructions
+
+- Be specific about the output you want.
+- Mention any supporting files the automation should use.
+`;
+
+export async function GET() {
+    try {
+        const user = await getCurrentUser();
+        const automations = await Automation.find({ owner: user._id }).lean();
+        automations.sort(
+            (a, b) => new Date(b.updatedAt || 0) - new Date(a.updatedAt || 0),
+        );
+
+        return NextResponse.json({ automations });
+    } catch (error) {
+        return handleError(error);
+    }
+}
+
+export async function POST(request) {
+    try {
+        const user = await getCurrentUser();
+        const body = await request.json();
+        const name = String(body.name || "").trim();
+        const slug = normalizeAutomationSlug(body.slug || name);
+        const schedule = normalizeSchedule(body.schedule);
+        const timezone = body.timezone || "UTC";
+        const enabled = automationEffectiveEnabled(
+            Boolean(body.enabled),
+            schedule,
+        );
+        const producesHtml = Boolean(body.producesHtml);
+        const description = String(body.description || "").trim();
+
+        if (!name) {
+            return NextResponse.json(
+                { error: "Automation name is required" },
+                { status: 400 },
+            );
+        }
+
+        if (!validateAutomationSlug(slug)) {
+            return NextResponse.json(
+                {
+                    error: "Slug must be lowercase alphanumeric with hyphens, max 64 characters",
+                },
+                { status: 400 },
+            );
+        }
+
+        const path = `automations/${slug}`;
+        const nextRunAt = enabled
+            ? calculateNextRunAt(schedule, timezone)
+            : null;
+
+        const automation = await Automation.create({
+            owner: user._id,
+            slug,
+            name,
+            description,
+            enabled,
+            schedule,
+            timezone,
+            path,
+            inputs: body.inputs || null,
+            producesHtml,
+            pinnedToSidebar: producesHtml && Boolean(body.pinnedToSidebar),
+            nextRunAt,
+        });
+
+        const content =
+            typeof body.content === "string"
+                ? body.content
+                : DEFAULT_AUTOMATION_CONTENT;
+        const uploadResult = await writeAutomationContent(
+            user.contextId,
+            slug,
+            content,
+        );
+
+        if (uploadResult.error) {
+            await Automation.deleteOne({ _id: automation._id }).catch(() => {});
+            return NextResponse.json(
+                { error: `Failed to save ${AUTOMATION_MD}` },
+                { status: 500 },
+            );
+        }
+
+        return NextResponse.json(serializeAutomation(automation, { content }), {
+            status: 201,
+        });
+    } catch (error) {
+        return handleError(error);
+    }
+}
+
+export const dynamic = "force-dynamic";


### PR DESCRIPTION
## Summary
- add authenticated automation list/create/detail/update/delete API routes
- add supporting-file upload/list/delete route scoped to automation storage
- keep execution and scheduled run endpoints for a later worker-backed slice
- sanitize default automation content for Concierge

## Validation
- npm test -- app/api/automations/utils.test.js --runInBand --silent --openHandlesTimeout=1000
- npm run build
- git diff --check
- forbidden branding/secret scan over modified and staged files