### PR TITLE
Add missing notification locale key

### DIFF
--- a/config/default/locales/ar.json
+++ b/config/default/locales/ar.json
@@ -776,6 +776,7 @@
     "Available Apps": "التطبيقات المتاحة",
     "Built-in Apps": "التطبيقات المدمجة",
     "User-Created Apps": "التطبيقات المنشأة من قبل المستخدمين",
+    "Created ": "أُنشئ ",
     "Loading...": "جار التحميل...",
     "Unknown App": "تطبيق غير معروف",
     "No applet created yet": "لم يتم إنشاء تطبيق صغير بعد",

--- a/config/default/locales/en.json
+++ b/config/default/locales/en.json
@@ -127,6 +127,7 @@
     "Available Apps": "Available Apps",
     "Built-in Apps": "Built-in Apps",
     "User-Created Apps": "User-Created Apps",
+    "Created ": "Created ",
     "Remove": "Remove",
     "Add": "Add",
     "Loading...": "Loading...",


### PR DESCRIPTION
## Summary
- add the missing `Created ` locale key used by notification timestamps in English and Arabic

## Validation
- parsed updated locale JSON files
- verified config/default and generated src locale copies remain equivalent
- ran `git diff --check`
- reran normalized Labeeb/Concierge comparison and confirmed the remaining source-only locale keys are branding/private or unused in this tree