### PR TITLE
Refresh open source README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,352 +1,385 @@
 # Concierge
 
-Concierge is an open-source web application that provides AI applications to enterprise customers for internal use. Concierge encapsulates functions like document translation, copy editing, summarization, headline generation, tagging, and entity extraction into easy-to-use task-specific interfaces rather than just making the functionality available through a chat-style prompting interface. Concierge is built on top of [Cortex](https://github.com/aj-archipelago/cortex), an open-source GraphQL middle tier for AI.
+[![License: MIT](https://img.shields.io/badge/license-MIT-2f855a.svg)](LICENSE)
+[![Built on Cortex](https://img.shields.io/badge/built%20on-Cortex-2563eb.svg)](https://github.com/aj-archipelago/cortex)
+[![Next.js](https://img.shields.io/badge/Next.js-app-111827.svg)](package.json)
 
-## Environment setup
+Concierge is an open-source AI agent interaction portal: a direct interface to intelligent autonomous agents that can converse, use tools, generate media, run scheduled work, build interactive HTML, and host custom AI micro-applications.
 
-### Envrionment variables
+It is the user-facing companion to [Cortex](https://github.com/aj-archipelago/cortex), the open-source AI backend that handles model routing, entity agents, tools, memory, media, and containerized workspaces. Concierge turns that runtime into a continuous product experience: chat when you need a conversation, applets when you need interactive software, automations when work should happen on a schedule, and built-in AI functions when a task deserves a dedicated interface.
 
-The following environment variables are required to configure Concierge to connect to Cortex and the Media Helper app:
+![Concierge architecture: users work in the Concierge web app, which stores product state in MongoDB, runs background jobs through Redis workers, and delegates agent execution, models, tools, media, and workspaces to Cortex.](docs/assets/concierge-architecture.svg)
 
-- `CORTEX_GRAPHQL_API_URL`: the full GraphQL URL of the Cortex deployment, e.g. `https://<site>.azure-api.net/graphql?subscription-key=<key>`
-- `CORTEX_MEDIA_API_URL`: the full URL of the Cortex media helper app, e.g. `https://<site>.azure-api.net/media-helper?subscription-key=<key>`
+## What You Get
 
-The following environment variable is optional and used for blue/green deployment scenarios:
+- **A direct portal to autonomous agents.** Persistent chat, streaming tool progress, file attachments, model selection, reasoning controls, canvas previews, and workspace-aware execution give users one place to interact with capable AI agents.
+- **Scheduling through automations.** Turn natural-language instructions into scheduled agent workflows with supporting files, run history, queue-backed execution, rendered HTML outputs, and pinned results.
+- **Interactive HTML as a first-class medium.** Agents can create and update rich HTML outputs that users can preview, revise, publish, and keep working with instead of leaving results trapped in chat transcripts.
+- **Custom AI micro-application development.** Generate, edit, version, publish, and debug applets with the injected `ConciergeSDK`, applet-scoped files, private data, shared data, locale helpers, service tokens, and model/agent calls.
+- **A full-featured media generation studio.** Use Cortex-backed image, video, audio, transcription, translation, media-library sync, file proxying, preview, tagging, and storage workflows from a dedicated product surface.
+- **Built-in AI functions for real workflows.** Video transcription, language translation, writing tools, style-guide checks, document-aware chat, media generation, and other focused features sit beside the open-ended agent interface.
+- **Infinite expansion points.** Add connectors, MCP servers, skills, applets, automations, task handlers, API routes, media tools, admin screens, and product-specific workflows without changing the core architecture.
+- **Operational controls.** Manage users, queues, feedback, usage reports, style guides, SDK examples, secure workspace secrets, and debug views from the built-in admin and personalization surfaces.
 
-- `CORTEX_GRAPHQL_API_BLUE_URL`: When you want to test your application against a pre-production ("blue") environment while using the same build that will run in production, set this to the Cortex "blue" URL. This variable must be set both at build-time and at runtime in the blue environment only. This is particularly useful for testing new features or changes in a pre-production environment before deploying to production.
+## Why Concierge Exists
 
-The following environment variables control xAI transcription availability:
+Most AI applications start as a chat box. Real agent products quickly need more: scheduling, files, OAuth connectors, media generation, custom instructions, interactive outputs, app publishing, workspace secrets, admin views, and product-specific tools.
 
-- `ENABLE_XAI_TRANSCRIBE`: set to `true` to show and accept the xAI transcription models in Concierge.
-- `ENABLE_XAI_TRANSCRIBE_DEFAULT`: set to `true` with `ENABLE_XAI_TRANSCRIBE=true` to make regular non-YouTube media default to `xAI + Gemini`.
-- `TRANSCRIBE_DEFAULT_MODEL_OPTION`: optional primary model for regular non-YouTube media. Supported values: `Whisper`, `Gemini`, `NeuralSpace`, `xAI`, `xAI + Gemini`.
-- `TRANSCRIBE_ALTERNATE_MODEL_OPTION`: optional model used by "Transcribe again using an alternate model" for regular non-YouTube media. Supported values match `TRANSCRIBE_DEFAULT_MODEL_OPTION`.
+Concierge puts those pieces in one open Next.js application and keeps them connected. A chat can create a file. A file can become an applet. An applet can call the agent. An automation can produce an HTML report. A connector can give the agent permissioned external context. A secret can follow the user's entity into a private workspace. The result is not a pile of AI widgets; it is a portal for continuous interaction with intelligent agents.
 
-The following environment variable is needed to deliver user feedback to Slack:
+The goal is not to hide the complexity. It is to make the seams explicit enough that a team can own them:
 
-- `SLACK_WEBHOOK_URL` - the is the URL of the Slack webhook you've configured to deliver the message to whichever channel you want to deliver it to.
+- The UI is regular React and Next.js.
+- Agent execution lives in Cortex.
+- User state, applets, automations, skills, and connector metadata live in MongoDB.
+- Long-running work goes through Redis-backed BullMQ workers.
+- Secure user secrets stay in Cortex entity configuration and are injected into workspaces by the backend.
+- Product-specific surfaces can be removed, replaced, or white-labeled without rewriting the core app.
 
-## Available Scripts
+## Start Here
 
-In the project directory, you can run:
+If you are new to Concierge, pick the lane closest to what you are trying to do:
 
-### `npm start`
+| If you want to...           | Start with...                                         | Why                                                                         |
+| --------------------------- | ----------------------------------------------------- | --------------------------------------------------------------------------- |
+| Run the app locally         | [Local Development](#local-development)               | Starts the Next app and worker against local MongoDB, Redis, and Cortex.    |
+| Connect Concierge to agents | [Cortex Backend](#cortex-backend)                     | Concierge delegates models, agents, tools, media, and workspaces to Cortex. |
+| Build AI micro-applications | [Applets](#applets)                                   | Applets package interactive agent-powered tools inside Concierge.           |
+| Add scheduled agent work    | [Automations](#automations)                           | Automations run saved agent instructions on a schedule through the queue.   |
+| Add external tools          | [Connectors And MCP](#connectors-and-mcp)             | OAuth and MCP let the assistant use services outside Concierge.             |
+| Operate a deployment        | [Configuration](#configuration) and [Docker](#docker) | These sections cover the important runtime settings and containers.         |
 
-Runs the app in the development mode.\
-Open [http://localhost:3000](http://localhost:3000) to view it in your browser.
-
-The page will reload when you make changes.\
-You may also see any lint errors in the console.
-
-### `npm test`
-
-Launches the test runner in the interactive watch mode.\
-See the section about [running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.
-
-### `npm run build`
-
-Builds the app for production to the `build` folder.\
-It correctly bundles React in production mode and optimizes the build for the best performance.
-
-The build is minified and the filenames include the hashes.\
-Your app is ready to be deployed!
-
-See the section about [deployment](https://facebook.github.io/create-react-app/docs/deployment) for more information.
-
-# Offline Tasks in Concierge
-
-The Concierge system includes a robust background task processing system that allows you to run time-consuming operations asynchronously. Here's how the offline task system works and how to define a new task.
-
-## How Offline Tasks Work
-
-Concierge uses a queuing system based on BullMQ to handle background tasks. Here's the general flow:
-
-1. **Task Creation**: When a task is initiated, a record is created in the database with a "pending" status
-2. **Task Queueing**: The task is added to a Redis-backed queue for processing
-3. **Task Execution**: A worker picks up the task and executes it
-4. **Task Completion**: Upon completion, the task status is updated in the database
-5. **Client-Side Handling**: React components can monitor task status and respond to completion
-
-Tasks support both synchronous and asynchronous execution modes, with progress tracking, error handling, and configurable timeouts.
-
-## Defining a New Task
-
-To create a new task type in Concierge, follow these steps:
-
-### 1. Create a Task Handler
-
-Create a new file in the `jobs/tasks/` directory. Each task handler should extend the `BaseTask` class:
-
-```javascript:jobs/tasks/new-task-name.mjs
-import { BaseTask } from './base-task.mjs';
-
-class NewTaskHandler extends BaseTask {
-    constructor() {
-        super();
-    }
-
-    // Required: Provide a human-readable name for the task
-    get displayName() {
-        return "New Task Type";
-    }
-
-    // Required: Implement the task execution logic
-    async startRequest(job) {
-        const { taskId, userId, metadata } = job.data;
-
-        try {
-            // Update task to in_progress
-            await this.updateTaskStatus(taskId, "in_progress");
-
-            // Your task implementation goes here
-            // ...
-
-            // Update progress as needed
-            await this.updateTaskProgress(taskId, 50, "Processing data...");
-
-            // Final result
-            const result = { /* your result data */ };
-
-            // Mark as completed
-            await this.updateTaskStatus(taskId, "completed", result);
-            return result;
-        } catch (error) {
-            // Handle errors
-            console.error("Task failed:", error);
-            await this.updateTaskStatus(taskId, "failed", null, error.message);
-            throw error;
-        }
-    }
-
-    // Optional: Custom completion handler
-    async handleCompletion(taskId, dataObject, infoObject, metadata, client) {
-        // Custom logic after task completes
-        // For example, update other data, send notifications, etc.
-        return dataObject;
-    }
-}
-
-export default new NewTaskHandler();
-```
-
-### 2. Register Client-Side Completion Handler
-
-If your task needs to trigger client-side actions when completed, add a handler to the `clientSideCompletionHandlers` object in `queries/notifications.js`:
-
-```javascript:app/queries/notifications.js
-// ... existing code ...
-const clientSideCompletionHandlers = {
-    // ... existing handlers ...
-    "new-task-name": async ({ task, queryClient, refetchUserState }) => {
-        // Perform client-side actions after completion
-        // For example:
-        queryClient.invalidateQueries({ queryKey: ["some-related-data"] });
-        refetchUserState();
-    },
-};
-// ... existing code ...
-```
-
-### 3. Use the Existing Task Hook
-
-Concierge provides a built-in hook called `useRunTask()` for initiating background tasks. Use this hook in your components:
-
-```jsx
-import { useRunTask } from "../../app/queries/notifications";
-import { useNotificationsContext } from "../../src/contexts/NotificationContext";
-
-function YourComponent() {
-    const runTask = useRunTask();
-    const { openNotifications } = useNotificationsContext();
-
-    const handleStartTask = async () => {
-        try {
-            // The type property identifies which task handler to use
-            const result = await runTask.mutateAsync({
-                type: "new-task-name",
-                // Your task parameters
-                parameter1: "value1",
-                parameter2: "value2",
-                // Optional: specify the source for tracking
-                source: "your_component",
-            });
-
-            // Optional: open notifications panel to show task progress
-            openNotifications();
-
-            return result;
-        } catch (error) {
-            console.error("Task failed:", error);
-        }
-    };
-
-    return (
-        <div>
-            <button onClick={handleStartTask} disabled={runTask.isPending}>
-                {runTask.isPending ? "Starting..." : "Start Task"}
-            </button>
-        </div>
-    );
-}
-```
-
-### 4. Monitor Task Status
-
-You can monitor the status of a task using the `useTask` hook:
-
-```jsx
-import { useRunTask, useTask } from "../../app/queries/notifications";
-
-function YourComponent() {
-    const runTask = useRunTask();
-    const [taskId, setTaskId] = useState(null);
-    const { data: taskStatus } = useTask(taskId);
-
-    const handleStartTask = async () => {
-        const result = await runTask.mutateAsync({
-            type: "new-task-name",
-            // Task parameters...
-        });
-
-        setTaskId(result.taskId);
-    };
-
-    return (
-        <div>
-            <button onClick={handleStartTask}>Start Task</button>
-
-            {taskStatus && (
-                <div>
-                    Status: {taskStatus.status}
-                    {taskStatus.statusText && <p>{taskStatus.statusText}</p>}
-                    {taskStatus.progress > 0 && (
-                        <progress value={taskStatus.progress} max="100" />
-                    )}
-                </div>
-            )}
-        </div>
-    );
-}
-```
-
-## Best Practices
-
-1. **Keep Tasks Focused**: Each task should do one thing well
-2. **Handle Errors Gracefully**: Always update task status on errors
-3. **Provide Progress Updates**: When possible, update progress periodically
-4. **Timeout Handling**: Set appropriate timeouts for long-running tasks
-5. **Clean Up Resources**: Release any resources in the completion handler
-
-The task system in Concierge provides a flexible way to handle background processing while maintaining a responsive user experience.
-
-## Development Setup
+## Local Development
 
 ### Prerequisites
 
-- Node.js (version specified in package.json)
-- npm
-- Redis (required for BullMQ task processing)
+- Node.js and npm. The Docker images use Node.js 22.
+- MongoDB.
+- Redis.
+- A running Cortex server, typically at `http://localhost:4000/graphql`.
+- Optional: a Cortex media helper URL for media generation, transcription, and file-helper flows.
 
-### Installation
+Install dependencies:
 
-1. Clone the repository
-2. Install dependencies:
-
-```bash
+```sh
 npm install
 ```
 
-### Development Scripts
+Create `.env.local`:
 
-The project includes several npm scripts for development:
+```sh
+MONGO_URI=mongodb://127.0.0.1:27017/concierge
+REDIS_CONNECTION_STRING=redis://127.0.0.1:6379
+CORTEX_GRAPHQL_API_URL=http://127.0.0.1:4000/graphql
+CORTEX_MEDIA_API_URL=http://127.0.0.1:5000
+NEXT_PUBLIC_APP_URL=http://localhost:3000
+```
 
-- `npm run dev`: Runs both the Next.js development server and the worker process concurrently
-- `npm run next:dev`: Runs only the Next.js development server
-- `npm run worker:dev`: Runs only the worker process with hot reloading using nodemon
-- `npm run lint`: Runs ESLint and Prettier checks
-- `npm run format`: Formats code using Prettier
-- `npm test`: Runs Jest tests
+Start the web app and worker together:
 
-### Running the Application
-
-1. Start the development servers:
-
-```bash
+```sh
 npm run dev
 ```
 
-This will start:
+The Next.js app runs at `http://localhost:3000`. The worker process runs in the same terminal group and processes background jobs from Redis.
 
-- Next.js dev server at http://localhost:3000
-- Worker process for background task processing
+For narrower development:
 
-2. For development of specific components:
-    - Web app only: `npm run next:dev`
-    - Worker only: `npm run worker:dev`
+```sh
+npm run next:dev     # web app only
+npm run worker:dev   # worker only
+```
 
-# Admin Section
+## Cortex Backend
 
-The Concierge application includes a comprehensive admin section that provides administrative tools and monitoring capabilities. This section is only accessible to users with the admin role.
+Concierge is designed to run with Cortex. The important contract is:
 
-## Access Control
+- `CORTEX_GRAPHQL_API_URL` points at the Cortex GraphQL endpoint.
+- `CORTEX_MEDIA_API_URL` points at the Cortex media helper endpoint when media/file-helper features are enabled.
+- Each Concierge user gets a Cortex context id and can be provisioned a personal Cortex entity.
+- The app sends chat, tool, model, workspace, media, and entity calls through Cortex GraphQL or media-helper routes.
 
-The admin section is protected by role-based access control:
+For a minimal local Cortex run, see the Cortex README. A common local setup is:
 
-- Only users with the `admin` role can access the admin section
-- Unauthorized users are automatically redirected to the home page
-- Admin users cannot modify their own role to prevent accidental self-demotion
+```sh
+cd ../cortex
+npm install
+npm start
+```
 
-## Available Features
+Then run Concierge with:
 
-### 1. User Management
+```sh
+CORTEX_GRAPHQL_API_URL=http://127.0.0.1:4000/graphql npm run dev
+```
 
-The user management interface allows administrators to:
+## Configuration
 
-- View all users in the system
-- Search users by name or username
-- Modify user roles (between 'user' and 'admin')
-- Paginate through user listings
-- View user details including:
-    - Name
-    - Username
-    - Current role
-    - Account status
+Concierge reads runtime configuration from environment variables and `config/default/config/index.js`.
 
-### 2. Queue Monitoring
+### Core
 
-The queue monitoring dashboard provides real-time insights into the background task processing system:
+| Variable                        | Required          | Purpose                                                                                                                   |
+| ------------------------------- | ----------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `MONGO_URI`                     | Yes               | MongoDB connection string for users, chats, workspaces, applets, automations, skills, connector metadata, and admin data. |
+| `REDIS_CONNECTION_STRING`       | Yes for workers   | Redis connection string for BullMQ queues and background task processing. Defaults to local Redis in worker utilities.    |
+| `CORTEX_GRAPHQL_API_URL`        | Yes               | Cortex GraphQL endpoint used by the app, worker, and server routes.                                                       |
+| `CORTEX_MEDIA_API_URL`          | Feature-dependent | Cortex media helper URL for media generation, transcription, file-helper, and media proxy flows.                          |
+| `NEXT_PUBLIC_APP_URL`           | Recommended       | Public app origin used to build OAuth redirect URIs and feedback links.                                                   |
+| `NEXT_PUBLIC_BASE_PATH`         | Optional          | Base path when Concierge is hosted below a subpath.                                                                       |
+| `NEXT_PUBLIC_AMPLITUDE_API_KEY` | Optional          | Enables browser analytics.                                                                                                |
+| `MAX_FILE_SIZE`                 | Optional          | Upload validation limit in bytes.                                                                                         |
 
-- View statistics for different queues
-- Monitor active jobs with progress tracking
-- View failed jobs with error details
-- Perform queue management actions
-- Real-time updates (refreshes every 5 seconds)
+### Auth
 
-Key metrics displayed:
+Concierge supports Entra-backed production auth and a local development auth cookie.
 
-- Active jobs count
-- Failed jobs count
-- Job progress
-- Error messages
-- Timestamps
+| Variable                      | Required              | Purpose                                                                    |
+| ----------------------------- | --------------------- | -------------------------------------------------------------------------- |
+| `ENTRA_AUTHORIZED_TENANT_IDS` | Production with Entra | Comma-separated tenant ids allowed through middleware and user resolution. |
 
-## Development
+In development, local auth can create a test user without Entra headers. In production, missing or unauthorized Entra tenant information is rejected.
 
-### Adding New Admin Features
+### Connectors
 
-To add new admin features:
+| Variable                                                 | Purpose                                                                                                                     |
+| -------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `SLACK_CLIENT_ID` / `SLACK_CLIENT_SECRET`                | Slack OAuth connector.                                                                                                      |
+| `SLACK_WEBHOOK_URL`                                      | Sends product feedback and queue alerts to Slack.                                                                           |
+| `NEXT_PUBLIC_ATLASSIAN_CLIENT_ID` / `JIRA_CLIENT_SECRET` | Atlassian/Jira OAuth connector and applet service-token flows.                                                              |
+| `GITHUB_CLIENT_ID` / `GITHUB_CLIENT_SECRET`              | GitHub OAuth/MCP connector.                                                                                                 |
+| `MCP_ALLOW_PRIVATE_URLS`                                 | Allows private-network MCP server URLs outside production. Keep disabled in production unless you understand the SSRF risk. |
 
-1. Create new components in the `app/admin` directory
-2. Add new routes in the `app/api` directory with proper admin role checks
-3. Update the `AdminNav` component to include new navigation items
-4. Implement proper access control using the `getCurrentUser` utility
+### Media And Transcription
 
-### Security Considerations
+| Variable                            | Purpose                                                                             |
+| ----------------------------------- | ----------------------------------------------------------------------------------- |
+| `ENABLE_XAI_TRANSCRIBE`             | Shows and accepts xAI transcription model options.                                  |
+| `ENABLE_XAI_TRANSCRIBE_DEFAULT`     | Uses `xAI + Gemini` as the regular-media default when xAI transcription is enabled. |
+| `TRANSCRIBE_DEFAULT_MODEL_OPTION`   | Overrides the default transcription model option.                                   |
+| `TRANSCRIBE_ALTERNATE_MODEL_OPTION` | Overrides the alternate transcription model option.                                 |
+| `ENABLE_NEURALSPACE`                | Enables NeuralSpace-related UI metadata.                                            |
 
-When developing admin features:
+### Secure Secrets And CSFLE
 
-- Always verify admin role using `getCurrentUser()`
-- Implement proper error handling
-- Use appropriate HTTP status codes for unauthorized access
-- Validate all user inputs
-- Log important administrative actions
+Concierge includes a generic secure secrets UI in the personalization portal. Users can store named secrets on their personal Cortex entity; Cortex can then inject those values into the user's agent workspace as environment variables. Existing secret values are not revealed back to the browser.
+
+MongoDB client-side encryption support uses the Mongo crypt shared library when available:
+
+| Variable          | Purpose                                                                                                |
+| ----------------- | ------------------------------------------------------------------------------------------------------ |
+| `MONGOCRYPT_PATH` | Path to `mongo_crypt_v1.so`; the Docker images install it at `/app/mongo_crypt_lib/mongo_crypt_v1.so`. |
+
+## Docker
+
+The repository includes app and worker images plus a development `docker-compose.yml`.
+
+```sh
+docker compose up --build
+```
+
+The compose file expects MongoDB, Redis, and Cortex to be reachable from the host machine through `host.docker.internal`:
+
+- MongoDB: `mongodb://host.docker.internal:27017/concierge`
+- Cortex: `http://host.docker.internal:4000/graphql`
+- Redis: `redis://host.docker.internal:6379`
+
+It also reads `.env.local` at runtime. The compose setup is useful when you want the Concierge processes in containers but still run infrastructure services on your host.
+
+Production images:
+
+- `Dockerfile` builds the Next.js standalone app image and runs `node server.js`.
+- `Dockerfile.worker` builds the worker image and runs `npm run worker`.
+
+Both images install the MongoDB crypt shared library used by encrypted MongoDB flows.
+
+## Applets
+
+Applets are custom AI micro-applications stored and hosted by Concierge. Users can ask an agent to build one, inspect and edit the source, save immutable versions, publish direct links, and keep the applet live in the canvas while the conversation continues.
+
+Applet runtime capabilities include:
+
+- Auto-injected `ConciergeSDK`.
+- Agent calls through `ConciergeSDK.agent.chat`.
+- Direct model calls through `ConciergeSDK.models.generate`.
+- OAuth service tokens through `ConciergeSDK.services.getAccessToken`.
+- Applet-scoped file upload/list/delete helpers.
+- Per-user private applet data through `ConciergeSDK.data`.
+- Shared applet state with revision protection through `ConciergeSDK.sharedData`.
+- Locale and direction helpers for English/Arabic UI.
+- Query-parameter helpers for published or embedded applets.
+
+The admin SDK playground is available under `app/admin/sdk-playground`.
+
+## Automations
+
+Automations let autonomous agents keep working after the chat window closes. A user describes recurring work in natural language, Concierge turns it into saved instructions and schedule metadata, and the worker queue runs it on time.
+
+Each automation has:
+
+- `AUTOMATION.md` instructions.
+- Optional supporting files.
+- A schedule preset or custom schedule.
+- Output type, including rendered HTML output.
+- Run history and pinned outputs.
+
+The main worker entry point is `jobs/worker.js`. Automation execution lives in `jobs/tasks/automation-run.mjs`, and scheduler logic lives in `jobs/automation-scheduler.js`.
+
+Useful routes and surfaces:
+
+- `/automations`
+- `/automations/[id]`
+- `app/api/automations`
+- `app/api/automations/[id]/run`
+- `app/api/automations/[id]/runs`
+- `src/components/automations`
+
+## Connectors And MCP
+
+Concierge can connect the assistant and applets to external systems.
+
+Built-in connector surfaces include:
+
+- Slack OAuth and bot-message sending.
+- Atlassian/Jira OAuth, issue/project APIs, and applet service-token access.
+- GitHub OAuth/MCP initialization.
+- Custom MCP servers with bearer-token or OAuth connection flows.
+
+The MCP configuration dialog lets users add custom servers. Server-side validation blocks unsafe MCP URLs by default, especially in production.
+
+## Skills
+
+Skills are reusable instructions and supporting files that the assistant can load when they match a request. Concierge includes built-in applet/article skills and lets users create custom skills from the personalization portal.
+
+Skill APIs live under:
+
+- `app/api/skills`
+- `app/api/skills/[name]`
+- `app/api/skills/[name]/files`
+
+Client-side skill definitions and built-in instruction text live in `src/utils/skills.js`.
+
+## Files, Media, And Workspaces
+
+Concierge treats files and media as part of the agent interaction loop, not as side attachments. A generated image can stay in the media studio, become chat context, move into a workspace, or be referenced by an applet. HTML outputs can be previewed, published, edited, and reused.
+
+Related surfaces include:
+
+- Chat attachments and generated files.
+- Workspace files and published workspaces.
+- Applet files and published applet assets.
+- Media library items, tags, preview URLs, and storage sync.
+- Text, image, and media proxy routes.
+
+Important directories:
+
+- `src/components/common/UnifiedFileManager`
+- `src/components/images`
+- `app/api/files`
+- `app/api/media-items`
+- `app/api/workspaces`
+- `app/workspaces`
+- `jobs/tasks/media-generation.mjs`
+
+## Help And Release Notes
+
+The in-app help system is built from Markdown content:
+
+- `src/content/help-guides/*.md`
+- `src/content/help-guides/*.ar.md`
+- `src/content/help-guides.js`
+- `src/components/help`
+- `app/help`
+
+The release-notes UI is present and ready for project-specific entries. Open-source Concierge does not ship the downstream product's private release history. Add public release notes under `src/content/release-notes/` and register them in `src/content/release-notes/index.js`.
+
+## Admin
+
+The admin area includes:
+
+- User management.
+- Queue monitoring.
+- Feedback review.
+- Usage reporting and API-key mappings.
+- Style-guide management.
+- SDK playground.
+- Debug pages.
+
+Admin APIs should always call `getCurrentUser()` and enforce `role === "admin"` before returning sensitive data or allowing mutation.
+
+## Project Map
+
+| Path              | Purpose                                                                         |
+| ----------------- | ------------------------------------------------------------------------------- |
+| `app/`            | Next.js App Router pages, layouts, and API routes.                              |
+| `src/components/` | React component library used by pages and client surfaces.                      |
+| `src/content/`    | Help guides, release-note loader, SDK docs, and Markdown content.               |
+| `src/utils/`      | Client utilities, tool definitions, skill text, theme helpers, storage helpers. |
+| `src/graphql.js`  | Cortex GraphQL queries and mutations used by the client and server.             |
+| `app/api/utils/`  | Server utility layer for auth, queues, MCP, media, files, and validation.       |
+| `jobs/`           | Worker process, scheduler, queue jobs, and long-running task handlers.          |
+| `config/default/` | Product configuration, locale files, taxonomy data, and global content.         |
+| `playwright/`     | End-to-end test fixtures and flows.                                             |
+| `docs/`           | Contributor-facing operational docs.                                            |
+
+## Scripts
+
+| Command                  | Purpose                                                                     |
+| ------------------------ | --------------------------------------------------------------------------- |
+| `npm run dev`            | Runs Next.js and the worker together.                                       |
+| `npm run next:dev`       | Runs only the Next.js development server.                                   |
+| `npm run worker:dev`     | Runs only the worker with nodemon.                                          |
+| `npm run build`          | Builds the Next.js app.                                                     |
+| `npm start`              | Starts the built Next.js app with `next start`.                             |
+| `npm run worker`         | Starts the production worker process.                                       |
+| `npm test`               | Runs Jest tests.                                                            |
+| `npm run test:e2e`       | Runs Playwright tests.                                                      |
+| `npm run lint`           | Runs Next lint and Prettier checks.                                         |
+| `npm run format`         | Formats the repo with Prettier.                                             |
+| `npm run precommit`      | Runs lint, format, and Jest tests.                                          |
+| `npm run upstream:audit` | Runs the downstream/upstream audit helper used for open-source parity work. |
+
+## Testing
+
+Focused unit tests:
+
+```sh
+npm test -- --runInBand path/to/test.js
+```
+
+Full Jest suite:
+
+```sh
+npm test -- --runInBand
+```
+
+Build:
+
+```sh
+npm run build
+```
+
+Playwright:
+
+```sh
+npm run test:e2e
+```
+
+Set `PLAYWRIGHT_BASE_URL` or `BASE_URL` when running Playwright against an already-running deployment.
+
+## What Concierge Is Not
+
+Concierge is not a hosted SaaS by itself, a model provider, or a replacement for Cortex. It is the open product layer you put in front of Cortex when you want a fully-functioned AI agent interaction portal instead of a single chat route.
+
+You should expect to configure your own:
+
+- Cortex deployment and model credentials.
+- MongoDB and Redis.
+- Auth boundary.
+- OAuth apps for connectors.
+- Storage/media-helper deployment.
+- Branding, help content, and release notes.
+
+## License
+
+Concierge is released under the [MIT License](LICENSE).

--- a/docs/assets/concierge-architecture.svg
+++ b/docs/assets/concierge-architecture.svg
@@ -1,0 +1,245 @@
+<svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="1120"
+    height="520"
+    viewBox="0 0 1120 520"
+    role="img"
+    aria-labelledby="title desc"
+>
+    <title id="title">Concierge architecture</title>
+    <desc id="desc">
+        Users work in Concierge. Concierge stores product state in MongoDB, runs
+        background jobs through Redis workers, and delegates AI execution to
+        Cortex.
+    </desc>
+    <defs>
+        <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+            <stop offset="0" stop-color="#f8fafc" />
+            <stop offset="1" stop-color="#eef2ff" />
+        </linearGradient>
+        <linearGradient id="concierge" x1="0" y1="0" x2="1" y2="1">
+            <stop offset="0" stop-color="#2563eb" />
+            <stop offset="1" stop-color="#0891b2" />
+        </linearGradient>
+        <linearGradient id="cortex" x1="0" y1="0" x2="1" y2="1">
+            <stop offset="0" stop-color="#111827" />
+            <stop offset="1" stop-color="#334155" />
+        </linearGradient>
+        <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+            <feDropShadow
+                dx="0"
+                dy="14"
+                stdDeviation="12"
+                flood-color="#0f172a"
+                flood-opacity="0.14"
+            />
+        </filter>
+        <marker
+            id="arrow"
+            markerWidth="10"
+            markerHeight="10"
+            refX="8"
+            refY="5"
+            orient="auto"
+        >
+            <path d="M 0 0 L 10 5 L 0 10 z" fill="#64748b" />
+        </marker>
+        <style>
+            .label {
+                font:
+                    700 20px Inter,
+                    ui-sans-serif,
+                    system-ui,
+                    -apple-system,
+                    BlinkMacSystemFont,
+                    "Segoe UI",
+                    sans-serif;
+                fill: #0f172a;
+            }
+            .small {
+                font:
+                    500 14px Inter,
+                    ui-sans-serif,
+                    system-ui,
+                    -apple-system,
+                    BlinkMacSystemFont,
+                    "Segoe UI",
+                    sans-serif;
+                fill: #475569;
+            }
+            .tiny {
+                font:
+                    600 12px Inter,
+                    ui-sans-serif,
+                    system-ui,
+                    -apple-system,
+                    BlinkMacSystemFont,
+                    "Segoe UI",
+                    sans-serif;
+                fill: #64748b;
+                letter-spacing: 0.04em;
+            }
+            .whiteLabel {
+                font:
+                    700 20px Inter,
+                    ui-sans-serif,
+                    system-ui,
+                    -apple-system,
+                    BlinkMacSystemFont,
+                    "Segoe UI",
+                    sans-serif;
+                fill: #fff;
+            }
+            .whiteSmall {
+                font:
+                    500 14px Inter,
+                    ui-sans-serif,
+                    system-ui,
+                    -apple-system,
+                    BlinkMacSystemFont,
+                    "Segoe UI",
+                    sans-serif;
+                fill: #dbeafe;
+            }
+            .line {
+                stroke: #64748b;
+                stroke-width: 2.5;
+                fill: none;
+                marker-end: url(#arrow);
+            }
+            .softLine {
+                stroke: #94a3b8;
+                stroke-width: 2;
+                fill: none;
+                marker-end: url(#arrow);
+                stroke-dasharray: 6 7;
+            }
+        </style>
+    </defs>
+
+    <rect width="1120" height="520" rx="28" fill="url(#bg)" />
+
+    <rect
+        x="40"
+        y="44"
+        width="1040"
+        height="432"
+        rx="24"
+        fill="#ffffff"
+        stroke="#dbe4f0"
+    />
+    <text x="80" y="92" class="tiny">OPEN-SOURCE AI WORKBENCH</text>
+    <text x="80" y="124" class="label">
+        Concierge turns Cortex into a complete team product surface.
+    </text>
+
+    <g filter="url(#shadow)">
+        <rect
+            x="80"
+            y="190"
+            width="210"
+            height="150"
+            rx="18"
+            fill="#ffffff"
+            stroke="#d7e0ea"
+        />
+        <text x="112" y="235" class="label">Users</text>
+        <text x="112" y="264" class="small">Chat</text>
+        <text x="112" y="286" class="small">Files</text>
+        <text x="112" y="308" class="small">Applets</text>
+        <text x="112" y="330" class="small">Automations</text>
+    </g>
+
+    <g filter="url(#shadow)">
+        <rect
+            x="410"
+            y="160"
+            width="300"
+            height="210"
+            rx="22"
+            fill="url(#concierge)"
+        />
+        <text x="448" y="214" class="whiteLabel">Concierge</text>
+        <text x="448" y="244" class="whiteSmall">
+            Next.js web app and API routes
+        </text>
+        <text x="448" y="278" class="whiteSmall">
+            Personalization, connectors, skills
+        </text>
+        <text x="448" y="302" class="whiteSmall">
+            Help, admin, media, workspace UI
+        </text>
+        <text x="448" y="326" class="whiteSmall">
+            Secure user secret controls
+        </text>
+    </g>
+
+    <g filter="url(#shadow)">
+        <rect
+            x="830"
+            y="160"
+            width="210"
+            height="210"
+            rx="22"
+            fill="url(#cortex)"
+        />
+        <text x="868" y="214" class="whiteLabel">Cortex</text>
+        <text x="868" y="244" class="whiteSmall">Agents</text>
+        <text x="868" y="268" class="whiteSmall">Model routing</text>
+        <text x="868" y="292" class="whiteSmall">Tools and MCP</text>
+        <text x="868" y="316" class="whiteSmall">Workspaces</text>
+    </g>
+
+    <path d="M 292 265 L 394 265" class="line" />
+    <path d="M 712 265 L 814 265" class="line" />
+
+    <g>
+        <rect
+            x="380"
+            y="410"
+            width="142"
+            height="44"
+            rx="12"
+            fill="#ecfeff"
+            stroke="#a5f3fc"
+        />
+        <text x="407" y="438" class="small">MongoDB</text>
+        <rect
+            x="542"
+            y="410"
+            width="142"
+            height="44"
+            rx="12"
+            fill="#f0fdf4"
+            stroke="#bbf7d0"
+        />
+        <text x="582" y="438" class="small">Redis</text>
+        <path d="M 500 372 C 492 392 475 400 454 410" class="softLine" />
+        <path d="M 620 372 C 628 392 637 400 636 410" class="softLine" />
+    </g>
+
+    <g>
+        <rect
+            x="760"
+            y="410"
+            width="120"
+            height="44"
+            rx="12"
+            fill="#fff7ed"
+            stroke="#fed7aa"
+        />
+        <text x="786" y="438" class="small">Models</text>
+        <rect
+            x="900"
+            y="410"
+            width="120"
+            height="44"
+            rx="12"
+            fill="#f5f3ff"
+            stroke="#ddd6fe"
+        />
+        <text x="923" y="438" class="small">Storage</text>
+        <path d="M 895 372 C 860 392 840 400 820 410" class="softLine" />
+        <path d="M 972 372 C 968 392 966 400 960 410" class="softLine" />
+    </g>
+</svg>


### PR DESCRIPTION
## Summary
- rewrite README around the current open-source Concierge product surface
- document local setup, Cortex dependency, env vars, Docker, applets, automations, connectors, skills, files/media/workspaces, help/release notes, admin, scripts, and testing
- add a README architecture diagram matching the Cortex project style

## Validation
- `npx prettier --check README.md`
- `npx prettier --parser html --check docs/assets/concierge-architecture.svg`
- `git diff --check`
- scanned README/SVG for stale private/downstream terms